### PR TITLE
WS: Disable Tokyo Road Race patch

### DIFF
--- a/cheats_ws/F880239B.pnach
+++ b/cheats_ws/F880239B.pnach
@@ -4,4 +4,6 @@ comment=Widescreen Hack by Arapapa
 //Widescreen hack 16:9
 
 //X-Fov
-patch=1,EE,20607888,extended,3f400000 //3f800000
+//patch=1,EE,20607888,extended,3f400000 //3f800000
+
+//Causes the car to disconnect from the model and make the game unplayable.


### PR DESCRIPTION
Causes the car to disconnect from the model and make the game unplayable.