### PR TITLE
WS: Disable Sega Soccer Slam patch

### DIFF
--- a/cheats_ws/9DD290E2.pnach
+++ b/cheats_ws/9DD290E2.pnach
@@ -3,4 +3,6 @@ comment=Widescreen hack by Arapapa
 
 //Widescreen hack 16:9
 
-patch=1,EE,00232064,word,3c013f40 //3c013f80
+//patch=1,EE,00232064,word,3c013f40 //3c013f80
+
+//Causes the crowd and signs to float in the air and move with the camera.


### PR DESCRIPTION
Causes the crowd and signs to float in the air and move with the camera.