### PR TITLE
WS: Disable patches for Mobile Suit Gundam Federation vs. Zeon

### DIFF
--- a/cheats_ws/59319476.pnach
+++ b/cheats_ws/59319476.pnach
@@ -1,6 +1,6 @@
 gametitle=Mobile Suit Gundam - Gundam vs. Zeta Gundam SLUS_208.21
 comment=Widescreen Hack
-patch=1,EE,00267604,word,3c023f40
-patch=1,EE,207a11b0,extended,44bff400
-patch=1,EE,207a1370,extended,443FE7FF
-patch=1,EE,207a1530,extended,443FE7FF
+//patch=1,EE,00267604,word,3c023f40
+//patch=1,EE,207a11b0,extended,44bff400
+//patch=1,EE,207a1370,extended,443FE7FF
+//patch=1,EE,207a1530,extended,443FE7FF


### PR DESCRIPTION
Patch breaks radar rendering causing it to be offset.

Issue link:
https://forums.pcsx2.net/Thread-Mobile-Suit-Gundam-Federation-vs-Zeon-Radar-and-Lock-On-Issues-on-nightly-build