### PR TITLE
WS: Colin McRae Rally 3 (SLUS-20502)

### DIFF
--- a/cheats_ws/AA294EDC.pnach
+++ b/cheats_ws/AA294EDC.pnach
@@ -1,0 +1,7 @@
+gametitle=Colin McRae Rally 3 [SLUS 20502] (U)
+comment=Widescreen patch
+author=Silent
+
+// Enable a native Widescreen option from the PAL version
+patch=0,EE,20134C78,extended,3C040001
+patch=0,EE,20134C80,extended,00000000


### PR DESCRIPTION
This patch force-enables native widescreen in the NTSC version of Colin McRae Rally 3. The PAL version had it available in Graphics options, it's later been removed in the NTSC release for performance reasons (due to higher FOV).

![image](https://user-images.githubusercontent.com/7947461/213883509-d76d3231-6d83-47fd-b8bb-7c1a30a81792.png)

Also posted here: https://forums.pcsx2.net/Thread-PCSX2-Widescreen-Game-Patches?pid=631400#pid631400