### PR TITLE
WS: Harry Potter Chambers of Secrets  and Sonic Riders Zero Gravity

### DIFF
--- a/cheats_ws/C5473413.pnach
+++ b/cheats_ws/C5473413.pnach
@@ -4,25 +4,27 @@ comment=Widescreen Hack by Arapapa
 //Widescreen hack 16:9
 
 //Zoom
-patch=1,EE,004ca798,word,3c013f24 //3c013f49
-patch=1,EE,004ca79c,word,34210000 //34210fda
+//patch=1,EE,004ca798,word,3c013f24 //3c013f49
+//patch=1,EE,004ca79c,word,34210000 //34210fda
 
 //Y-Fov
-patch=1,EE,004e8eb0,word,3c013fe3 //3c013faa
-patch=1,EE,004e8eb4,word,34218e2a //3421aaab
+//patch=1,EE,004e8eb0,word,3c013fe3 //3c013faa
+//patch=1,EE,004e8eb4,word,34218e2a //3421aaab
 
 //Button fix
-patch=1,EE,0031cb24,word,3c013fd0 //3c013f9c
-patch=1,EE,0031cb28,word,342197af //342171c7
+//patch=1,EE,0031cb24,word,3c013fd0 //3c013f9c
+//patch=1,EE,0031cb28,word,342197af //342171c7
 
 //Font Y-Fov
-patch=1,EE,20541894,extended,3B0882F1 //3acccccd
+//patch=1,EE,20541894,extended,3B0882F1 //3acccccd
 
 //Font Y-Position
-patch=1,EE,205418b4,extended,bf000000 //bec00000
+//patch=1,EE,205418b4,extended,bf000000 //bec00000
 
 //Font Zoom
-patch=1,EE,205418bc,extended,3faaaaab //3f800000
+//patch=1,EE,205418bc,extended,3faaaaab //3f800000
 
 //Widen HUD to hide icons
-patch=1,EE,205E9F30,extended,3F95C28F
+//patch=1,EE,205E9F30,extended,3F95C28F
+
+// Commented out as it broke loading screen font and other stuff.

--- a/cheats_ws/CBDF678C.pnach
+++ b/cheats_ws/CBDF678C.pnach
@@ -3,4 +3,4 @@ comment=Widescreen hack by jordenlb/ElHecht
 
 // 16:9
 patch=1,EE,005fe9a0,word,43700000 // 43a00000 hor fov
-patch=1,EE,00149964,word,3c023fab // 3c023f80 renderfix
+// patch=1,EE,00149964,word,3c023fab // 3c023f80 renderfix (causes SPS in several locations ex. start of the race when you run 1 second and after)


### PR DESCRIPTION
WS Harry Potter see: 
https://github.com/PCSX2/pcsx2/pull/7988#issuecomment-1407520072

But basically the WS patch quality destroyed font in loading/saving screen and zoomed instead of proper widescreen patch.

WS Sonic Riders Zero Gravity:
![image](https://user-images.githubusercontent.com/24227051/215297976-3d5f3586-4107-49ff-a98a-6be7510dfc8d.png)
It made SPS