### PR TITLE
Update A32F7CD0.pnach

### DIFF
--- a/cheats_ws/A32F7CD0.pnach
+++ b/cheats_ws/A32F7CD0.pnach
@@ -1,5 +1,5 @@
 gametitle=Ace Combat 04: Shattered Skies (SLUS-20152)
-comment=Widescreen fix by nemesis2000 (pnach by nemesis2000)
+comment=Widescreen fix by Puggsy
 
-//widescreen fix
-patch=1,EE,0040DACC,word,441CF7AE
+//Widescreen 
+patch=1,EE,0010c9f4,word,3c014455 //3c014420


### PR DESCRIPTION
The Widescreen Hack for Ace Combat 04: Shattered Skies (and possibly all the other versions) doesn't work

CRC - A32F7CD0

Here is the current Hack

//widescreen fix
patch=1,EE,0040DACC,word,441CF7AE

The Game looks the same with or without the hack
![STRECHED](https://user-images.githubusercontent.com/55870574/221801592-bc336ec4-09b2-403a-96f2-bd0ddbdd3037.png)


Here is my new Hack

//WideScreen
patch=1,EE,0010c9f4,word,3c014455 //3c014420

and this is how the game looks
![WIDESCREEN](https://user-images.githubusercontent.com/55870574/221801543-df5eb09e-7896-4043-a786-d361fc1b5347.png)

