### PR TITLE
NI: Update Breath of Fire V (USA) patch

### DIFF
--- a/cheats_ni/588CC41B.pnach
+++ b/cheats_ni/588CC41B.pnach
@@ -1,4 +1,2 @@
-patch=1,EE,2020D9F0,extended,03E00008
-patch=1,EE,2020D9F4,extended,00000000
 patch=1,EE,20102104,extended,00000000
-patch=1,EE,2010236C,extended,00000000
+patch=1,EE,2010236c,extended,00000000


### PR DESCRIPTION
Original patch also nopped a function that applied a film grain/noise effect to the game. This is correctly emulated and doesn't need to be removed.