### PR TITLE
WS: Disable Prisoner of War patches.

### DIFF
--- a/cheats_ws/BAFCDA66.pnach
+++ b/cheats_ws/BAFCDA66.pnach
@@ -1,16 +1,19 @@
 gametitle=Prisoner of War (PAL-M5) (SLES-50397)
 comment=Widescreen hack by ElHecht
 
+// The patches cause the game/emulator to crash to desktop
+// comment all of them as commenting only one results in the game locking up instead.
+
 // 16:9
-patch=1,EE,0039c3dc,word,0c1127e8 // 3c013f80
-patch=1,EE,0039c3e0,word,00000000 // 4481a000
-patch=1,EE,00449fa0,word,3c013f40 // 00000000 hor fov
-patch=1,EE,00449fa8,word,4481a000 // 00000000
-patch=1,EE,00449fac,word,46146b42 // 00000000
-patch=1,EE,00449fb0,word,4614a503 // 00000000
-patch=1,EE,00449fb4,word,03e00008 // 00000000
-patch=1,EE,0013e6fc,word,3c0140c0 // 3c013f99 renderfix
-patch=1,EE,001a6b60,word,3c013f2b // 3c013f00 renderfix
+//patch=1,EE,0039c3dc,word,0c1127e8 // 3c013f80
+//patch=1,EE,0039c3e0,word,00000000 // 4481a000
+//patch=1,EE,00449fa0,word,3c013f40 // 00000000 hor fov
+//patch=1,EE,00449fa8,word,4481a000 // 00000000
+//patch=1,EE,00449fac,word,46146b42 // 00000000
+//patch=1,EE,00449fb0,word,4614a503 // 00000000
+//patch=1,EE,00449fb4,word,03e00008 // 00000000
+//patch=1,EE,0013e6fc,word,3c0140c0 // 3c013f99 renderfix
+//patch=1,EE,001a6b60,word,3c013f2b // 3c013f00 renderfix
 
 //16:10
 //patch=1,EE,0039c3dc,word,0c1127e8 // 3c013f80


### PR DESCRIPTION
Caused the emulator to crash on boot up.