### PR TITLE
WS: Fix for Onimusha Dawn of Dreams Pal version pnach

### DIFF
--- a/cheats_ws/812C5A96.pnach
+++ b/cheats_ws/812C5A96.pnach
@@ -12,8 +12,8 @@ patch=1,EE,0012fb64,word,3c033f19
 patch=1,EE,0012fb6c,word,334639999
 
 //val3
-patch=1,EE,0012f960,word,3c023f19
-patch=1,EE,0012f968,word,34439999
+patch=1,EE,0012f9d8,word,3c023f19
+patch=1,EE,0012f9dc,word,34439999
 
 //rfix1
 patch=1,EE,0012fbe4,word,3c02c3d6


### PR DESCRIPTION
This is a fix for Onimusha Dawn of Dreams 812C5A96.pnach

The old one was broken and it only showed 2d elements, no 3d graphics.