### PR TITLE
WS: Add Gran Turismo 4 (NTSC-U) (PAL) patches

### DIFF
--- a/cheats_ws/32A1C752.pnach
+++ b/cheats_ws/32A1C752.pnach
@@ -1,0 +1,6 @@
+gametitle=Gran Turismo 4 Online Public Beta [SCUS-97436] (U)
+comment=Widescreen Text
+author=Aero_
+// Corrects Text Aspect Ratio for Widescreen 
+patch=1,EE,2033D7DC,extended,08125570 // lui at, 0x3F40
+patch=1,EE,2033D7E0,extended,34210000 // ori at, 0x0000

--- a/cheats_ws/44A61C8F.pnach
+++ b/cheats_ws/44A61C8F.pnach
@@ -1,0 +1,16 @@
+gametitle=Gran Turismo 4 [SCES-51719] (E)
+comment=Widescreen Text
+author=Aero_
+// Corrects Text Aspect Ratio for Widescreen
+patch=1,EE,20492E08,extended,08125666 // j 00495998
+patch=1,EE,20495998,extended,3C090061 // lui t1,0x0061 : Widescreen Mode 1st-Half of Memory Address
+patch=1,EE,2049599C,extended,352984F0 // ori t1,0x84F0 : Widescreen Mode 2nd-Half of Memory Address
+patch=1,EE,204959A0,extended,812A0000 // lb t2,(t1)
+patch=1,EE,204959A4,extended,C65A0024 // lwc1 f26,0x24(s2)
+patch=1,EE,204959A8,extended,11400004 // beqz t2,0x004959BC : Jumps if Widescreen Mode is Disabled
+patch=1,EE,204959AC,extended,3C013F40 // lui at,0x3F40 : Text Width 1st-Half of Float Value
+patch=1,EE,204959B0,extended,34210000 // ori at,0x0000 : Text Width 2nd-Half of Float Value
+patch=1,EE,204959B4,extended,4481A000 // mtc1 at,f20
+patch=1,EE,204959B8,extended,4614D682 // mul.s f26, f26, f20
+patch=1,EE,204959BC,extended,08124B83 // j 00492E0C
+patch=1,EE,2044DF60,extended,00000000 // nop

--- a/cheats_ws/77E61C8A.pnach
+++ b/cheats_ws/77E61C8A.pnach
@@ -1,0 +1,16 @@
+gametitle=Gran Turismo 4 [SCUS-97328] (U)
+comment=Widescreen Text
+author=Aero_
+// Corrects Text Aspect Ratio for Widescreen 
+patch=1,EE,20492A30,extended,08125570 // j 004955C0
+patch=1,EE,204955C0,extended,3C090061 // lui t1,0x0061 : Widescreen Mode 1st-Half of Memory Address
+patch=1,EE,204955C4,extended,352984F0 // ori t1,0x84F0 : Widescreen Mode 2nd-Half of Memory Address
+patch=1,EE,204955C8,extended,812A0000 // lb t2,(t1)
+patch=1,EE,204955CC,extended,C65A0024 // lwc1 f26,0x24(s2)
+patch=1,EE,204955D0,extended,11400004 // beqz t2,0x004955E4 : Jumps if Widescreen Mode is Disabled
+patch=1,EE,204955D4,extended,3C013F40 // lui at,0x3F40 : Text Width 1st-Half of Float Value
+patch=1,EE,204955D8,extended,34210000 // ori at,0x0000 : Text Width 2nd-Half of Float Value
+patch=1,EE,204955DC,extended,4481A000 // mtc1 at,f20
+patch=1,EE,204955E0,extended,4614D682 // mul.s f26, f26, f20
+patch=1,EE,204955E4,extended,08124A8D // j 00492A34
+patch=1,EE,2044DBD8,extended,00000000 // nop


### PR DESCRIPTION
Fixes the text aspect ratio of Gran Turismo 4 for widescreen. This feature was originally exclusive to _Gran Turismo 4 Online Public Beta_, but has been ported to the retail version of the game.

![Preview](https://i.imgur.com/YAuBDbI.gif)

- Gran Turismo 4 [SCUS-97328] (U)
- Gran Turismo 4 [SCES-51719] (E)
- Gran Turismo 4 Online Public Beta [SCUS-97436] (U)
