### PR TITLE
Add more Blitz 16:9 patches

### DIFF
--- a/cheats_ws/1A7A27E6.pnach
+++ b/cheats_ws/1A7A27E6.pnach
@@ -1,0 +1,14 @@
+gametitle=SpongeBob SquarePants - Creature from the Krusty Krab (J)(SLPM-66694)
+comment=Widescreen hack by Arapapa & ICUP321
+ 
+//Widescreen hack 16:9
+
+//X-Fov
+//000000000000000083ad004600000000
+patch=1,EE,0043cf1c,word,3c013f40
+patch=1,EE,0043cf20,word,4481f000
+patch=1,EE,0043cf28,word,461eb582
+
+//Render fix
+//003f013c 00a08144 98000cc6 (1st)
+patch=1,EE,0041e828,word,3c013f20 //3c013f00

--- a/cheats_ws/72A924F1.pnach
+++ b/cheats_ws/72A924F1.pnach
@@ -1,0 +1,14 @@
+gametitle=Pac-Man World 3 (PAL-M5)(SLES-53959)
+comment=Widescreen Hack by ICUP321
+
+//Widescreen hack 16:9 (Set "Normal" in Picture Options)
+
+//X-Fov
+//000000000000000083ad004600000000
+patch=1,EE,003f30c4,word,3c013f40
+patch=1,EE,003f30c8,word,4481f000
+patch=1,EE,003f30d0,word,461eb582
+
+//Render fix
+//003f013c 00a88144 2db80002
+patch=1,EE,00439184,word,3c013f2b //3c013f00

--- a/cheats_ws/82C46B7A.pnach
+++ b/cheats_ws/82C46B7A.pnach
@@ -1,0 +1,14 @@
+gametitle=SpongeBob SquarePants - Creature from the Krusty Krab (U)(SLUS-21391)
+comment=Widescreen hack by Arapapa & ICUP321
+ 
+//Widescreen hack 16:9
+
+//X-Fov
+//000000000000000083ad004600000000
+patch=1,EE,00438b6c,word,3c013f40
+patch=1,EE,00438b70,word,4481f000
+patch=1,EE,00438b78,word,461eb582
+
+//Render fix
+//003f013c 00a08144 98000cc6 (1st)
+patch=1,EE,0041a458,word,3c013f20 //3c013f00

--- a/cheats_ws/91ECC411.pnach
+++ b/cheats_ws/91ECC411.pnach
@@ -1,0 +1,14 @@
+gametitle=Pac-Man World 3 (U)(SLUS-21219)
+comment=Widescreen Hack by ICUP321
+
+//Widescreen hack 16:9 (Set "Normal" in Picture Options)
+
+//X-Fov
+//000000000000000083ad004600000000
+patch=1,EE,003efdc4,word,3c013f40
+patch=1,EE,003efdc8,word,4481f000
+patch=1,EE,003efdd0,word,461eb582
+
+//Render fix
+//003f013c 00a88144 2db80002
+patch=1,EE,00435bac,word,3c013f2b //3c013f00

--- a/cheats_ws/B1F87437.pnach
+++ b/cheats_ws/B1F87437.pnach
@@ -1,0 +1,14 @@
+gametitle=SpongeBob SquarePants - Creature from the Krusty Krab (E)(SLES-54400)
+comment=Widescreen hack by Arapapa & ICUP321
+ 
+//Widescreen hack 16:9
+
+//X-Fov
+//000000000000000083ad004600000000
+patch=1,EE,0043d92c,word,3c013f40
+patch=1,EE,0043d930,word,4481f000
+patch=1,EE,0043d938,word,461eb582
+
+//Render fix
+//003f013c 00a08144 98000cc6 (1st)
+patch=1,EE,0041f1f0,word,3c013f20 //3c013f00

--- a/cheats_ws/CC8451F9.pnach
+++ b/cheats_ws/CC8451F9.pnach
@@ -1,26 +1,15 @@
 gametitle=SpongeBob SquarePants - Creature from the Krusty Krab (K)(SCKA-20098)
-comment=Widescreen hack by Arapapa
+comment=Widescreen hack by Arapapa & ICUP321
  
 //Widescreen 16:9
 
 //X-Fov
-00000000 00000000 83ad0046 00000000
-403f013c 00f08144 83ad0046 82b51e46
+//00000000 00000000 83ad0046 00000000
+//403f013c 00f08144 83ad0046 82b51e46
 patch=1,EE,0043cb1c,word,3c013f40
 patch=1,EE,0043cb20,word,4481f000
 patch=1,EE,0043cb28,word,461eb582
 
-
-////////////////////////////////////////////////
-
-//Zoom
-//patch=1,EE,0043caf0,word,3c013f20 //3c013f00
-
-//X-Fov
-//patch=1,EE,0043caf8,word,080800b0
-
-//patch=1,EE,002002c0,word,c60c0098
-//patch=1,EE,002002c4,word,3c013f90
-//patch=1,EE,002002c8,word,4481f000
-//patch=1,EE,002002cc,word,461e6302
-//patch=1,EE,002002d0,word,0810f2bf
+//Render fix by ICUP321
+//003f013c 00a08144 98000cc6 (1st)
+patch=1,EE,0041e428,word,3c013f20 //3c013f00

--- a/cheats_ws/E7EA3288.pnach
+++ b/cheats_ws/E7EA3288.pnach
@@ -1,0 +1,5 @@
+gametitle=Pac-Man World 2 (U)(SLUS-20224) (Greatest Hits)
+comment=Widescreen hack
+
+//Official Widescreen auto-enable (vertical screen skewed)
+patch=1,EE,205A68C0,extended,00000001 // change value to 0 for 4:3


### PR DESCRIPTION
Adds SpongeBob CFTKK 16:9 patches, Pac-Man World 3 and one Pac-Man World 2 patch that enables the unused official widescreen mode in the NTSC-U Greatest Hits version not implemented in the options menu until the later PAL and NTSC-J releases.