### PR TITLE
Update Sly No-Interlacing patches (& Kinetica)

### DIFF
--- a/cheats_ni/07652DD9.pnach
+++ b/cheats_ni/07652DD9.pnach
@@ -1,2 +1,8 @@
+gametitle=Sly 2 - Band of Thieves (NTSC-U) [SCUS-97316]
+comment=No Interlacing & No Motion Blur
+
+// No Interlacing by asasega
 patch=1,EE,20240B4C,word,00000000
-patch=1,EE,2016F5FC,word,34020001
+
+// No Motion Blur by Meos
+patch=1,EE,20160FA0,extended,00000000

--- a/cheats_ni/8BC95883.pnach
+++ b/cheats_ni/8BC95883.pnach
@@ -1,2 +1,8 @@
+gametitle=Sly 3 - Honor Among Thieves (NTSC-U) [SCUS-97464]
+comment=No Interlacing & No Motion Blur
+
+// No Interlacing by asasega
 patch=1,EE,20195D40,word,00000000
-patch=1,EE,20183190,word,AC60DC98
+
+// No Motion Blur by Meos
+patch=1,EE,201837E8,extended,00000000

--- a/cheats_ni/C77AF2CA.pnach
+++ b/cheats_ni/C77AF2CA.pnach
@@ -1,2 +1,13 @@
+gametitle=Sly Cooper and the Thievius Raccoonus (NTSC-U) [SCUS-97198]
+comment=No Interlacing & No Motion Blur
+
+// No Interlacing by asasega
 patch=1,EE,20202104,word,00000000
 patch=1,EE,2015F4F0,word,00009025
+
+// No Motion Blur by Meos
+patch=1,EE,2015EE64,extended,08057B9D
+patch=1,EE,2018F6D0,extended,08063DB8
+patch=1,EE,201E9C60,extended,0807A71B
+patch=1,EE,2012B838,extended,0804AE17
+patch=1,EE,2015F47C,extended,24060000

--- a/cheats_ni/D39C08F5.pnach
+++ b/cheats_ni/D39C08F5.pnach
@@ -1,0 +1,4 @@
+gametitle=Kinetica (NTSC-U)
+comment=No Interlacing
+
+patch=1,EE,201ABB34,word,00000000


### PR DESCRIPTION
Updates Sly Cooper No-Interlacing patches to fix a screen shaking issue, and combines the no-blur patches into one, giving a much more clearer look to the games. Also adds no-interlacing patch for Kinetica from PCSX2 forums.