### PR TITLE
Add Pac-Man World 2 & Dead to Rights No-Interlacing patches

### DIFF
--- a/cheats_ni/047D8AA6.pnach
+++ b/cheats_ni/047D8AA6.pnach
@@ -1,0 +1,9 @@
+gametitle=Pac-Man World 2 (U)(SLUS-20224)
+comment=No Interlacing
+
+//480p
+patch=1,EE,0033D2C8,extended,00000002
+patch=1,EE,0033D2D0,extended,00001038
+
+//No interlaced FMVs
+patch=1,EE,002C874C,extended,64420000

--- a/cheats_ni/049BF05D.pnach
+++ b/cheats_ni/049BF05D.pnach
@@ -1,6 +1,9 @@
-patch=1,EE,20347808,extended,00000001
-patch=1,EE,20347810,extended,00001038
-patch=1,EE,20347E88,extended,00000001
-patch=1,EE,20347E90,extended,000014A0
-patch=1,EE,20347EB0,extended,00000001
-patch=1,EE,20347EB8,extended,000014A0
+gametitle=Pac-Man World 2 (J)(SLPS-25141)
+comment=No Interlacing
+
+//480p
+patch=1,EE,00347808,extended,00000002
+patch=1,EE,00347810,extended,00001038
+
+//No interlaced FMVs
+patch=1,EE,002CF02C,extended,64420000

--- a/cheats_ni/5EA6B8BE.pnach
+++ b/cheats_ni/5EA6B8BE.pnach
@@ -1,2 +1,9 @@
-//Dead to Rights (USA)
+gametitle=Dead to Rights (U)(SLUS-20220)
+comment=No Interlacing
+
+//480p
+patch=1,EE,00250B48,extended,00000002
+patch=1,EE,00250B50,extended,00001038
+
+//No interlaced FMVs
 patch=1,EE,00218264,extended,00000000

--- a/cheats_ni/916B1D2E.pnach
+++ b/cheats_ni/916B1D2E.pnach
@@ -1,0 +1,9 @@
+gametitle=Dead to Rights (J)(SLPS-25268)
+comment=No Interlacing
+
+//480p
+patch=1,EE,0026EBC8,extended,00000002
+patch=1,EE,0026EBD0,extended,00001038
+
+//No interlaced FMVs
+patch=1,EE,0021EC5C,extended,00000000

--- a/cheats_ni/E7EA3288.pnach
+++ b/cheats_ni/E7EA3288.pnach
@@ -1,0 +1,9 @@
+gametitle=Pac-Man World 2 (U)(SLUS-20224) (Greatest Hits)
+comment=No Interlacing
+
+//480p
+patch=1,EE,0032F988,extended,00000002
+patch=1,EE,0032F990,extended,00001038
+
+//No interlaced FMVs
+patch=1,EE,002B95BC,extended,64420000


### PR DESCRIPTION
Adds no-interlacing patches for the NTSC (USA and Japan) versions of Pac-Man World 2 and Dead to Rights.