### PR TITLE
Patches: Fix Tag Team Racing WS and tidy up formatting

### DIFF
--- a/patches/SLUS-21191_AA525269.pnach
+++ b/patches/SLUS-21191_AA525269.pnach
@@ -2,19 +2,16 @@ gametitle=Crash Tag Team Racing (U)(SLUS-21191)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen 16:9
-
-//X-Fov
-patch=1,EE,00399f58,word,3c013fab //3c013f80
-
-//Render fix
-patch=1,EE,002d91c0,word,3c013fe0 //3c013f80
+author=Arapapa
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio.
+//X-FOV
+patch=1,EE,002D919C,word,3C013FAB //3c013f80
+//Render Fix
+patch=1,EE,002D91C0,word,3C013FAB //3c013f80
 
 
-//60 FPS by asasega
+[60 FPS]
 //02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 C1 03 00 00 01 00 00 00 01 00 00 00 30 95 57 00
-//patch=1,EE,207A9E5C,extended,00000001 //00000002
-
-
+author=asasega
+description=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,207A9E5C,extended,00000001 //00000002


### PR DESCRIPTION
This PR Fixes the broken WS patch as was shown on #60.
Also properly fixes the formatting in accordance to the new syntax format.
~~Putting as draft for now, while waiting for a member to test the patch in few hours.~~

The patches now shows up properly on the patch tab:
![image](https://github.com/PCSX2/pcsx2_patches/assets/14798312/ea2c90dd-d3a8-45aa-a30f-d162eaf1e19b)

