### PR TITLE
Patches: Add 60 FPS to Crash Bandicoot games and Pac-Man World Rally

### DIFF
--- a/patches/SLUS-21328_99BD2C0C.pnach
+++ b/patches/SLUS-21328_99BD2C0C.pnach
@@ -1,0 +1,8 @@
+gametitle=Pac-Man World Rally (NTSC-U)
+
+[60 FPS]
+author=asasega
+description=Patches the game to run at 60 FPS.
+
+patch=1,EE,2059BF10,extended,3F800000 // FPS
+patch=1,EE,2055B000,extended,3F000000 // Speed

--- a/patches/SLUS-21583_C6E85EF0.pnach
+++ b/patches/SLUS-21583_C6E85EF0.pnach
@@ -1,0 +1,6 @@
+gametitle=Crash of the Titans (NTSC-U)
+
+[60 FPS]
+author=asasega
+description=Patches the game to run at 60 FPS (Might need 130% EE Overclock to be stable).
+patch=1,EE,20490340,extended,24020000

--- a/patches/SLUS-21661_8FCCB5D9.pnach
+++ b/patches/SLUS-21661_8FCCB5D9.pnach
@@ -2,7 +2,8 @@ gametitle=Ben 10 - Protector of Earth SLUS_216.61
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack
+author=asasega
+description=Patches the game to run at Widescreen 16:9 aspect ratio.
 patch=1,EE,0011940C,word,3C013F4d
 patch=1,EE,00119410,word,3421b6e0
 

--- a/patches/SLUS-21728_6A8448BA.pnach
+++ b/patches/SLUS-21728_6A8448BA.pnach
@@ -1,0 +1,6 @@
+gametitle=Crash - Mind Over Mutant (NTSC-U)
+
+[60 FPS]
+author=asasega
+description=Patches the game to run at 60 FPS.
+patch=1,EE,205823A0,extended,24020000

--- a/patches/SLUS-21815_DB2DE310.pnach
+++ b/patches/SLUS-21815_DB2DE310.pnach
@@ -2,7 +2,8 @@ gametitle=Ben 10: Alien Force [NTSC-U] (SLUS_218.15)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Sergx12
+author=Sergx12
+description=Patches the game to run at Widescreen 16:9 aspect ratio.
 
 //Gameplay 16:9
 patch=1,EE,002A2430,word,3C013F1C //3C013F00 Zoom

--- a/patches/SLUS-21921_8A1D18EE.pnach
+++ b/patches/SLUS-21921_8A1D18EE.pnach
@@ -2,7 +2,8 @@ gametitle=Ben 10 - Alien Force - Vilgax Attacks (U)(SLUS-21921)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by El_Patas (NTSC-U by Arapapa)
+author=El_Patas (NTSC-U by Arapapa)
+description=Patches the game to run at Widescreen 16:9 aspect ratio.
 
 //Gameplay 16:9
 patch=1,EE,20741A54,extended,3FE38E38 //3FAAAAAB (Increases hor. axis)


### PR DESCRIPTION
This PR adds 60 FPS patches to several  games namely:

- Crash of The Titans (SLUS-21583)
- Crash - Mind Over Mutant (SLUS-21728)
- Pac-Man World Rally (SLUS-21328)

These are tested personally by me, from beginning to end game with no game breaking glitches in sight.

Also fixed the formatting for some games.