### PR TITLE
Remove ZWNBSP and align gametitle lines

### DIFF
--- a/patches/664D4EAE.pnach
+++ b/patches/664D4EAE.pnach
@@ -1,6 +1,7 @@
+gametitle=Jyuouki - Project Altered Beast [NTSC-J]
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Jyuouki - Project Altered Beast [NTSC-J]
 comment=Widescreen Hack by Little Giant
 
 patch=1,EE,00156be0,word,3c033fe3 //3c033faa

--- a/patches/SCPS-11003_B01A4C95.pnach
+++ b/patches/SCPS-11003_B01A4C95.pnach
@@ -1,6 +1,7 @@
+gametitle=ICO [NTSC-J] (SCPS-11003)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=ICO [NTSC-J] (SCPS-11003)
 comment=Widescreen hack by nemesis2000 (pnach by Little Giant)
 
 //widescreen

--- a/patches/SCPS-11006_9000252A.pnach
+++ b/patches/SCPS-11006_9000252A.pnach
@@ -1,6 +1,7 @@
+gametitle=SkyGunner [NTSC-J] (SCPS-11006)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=SkyGunner [NTSC-J] (SCPS-11006)
 comment=Widescreen Hack
 patch=1,EE,00126724,word,3c013f40
 patch=1,EE,00126728,word,44810000

--- a/patches/SCPS-15020_EC38E681.pnach
+++ b/patches/SCPS-15020_EC38E681.pnach
@@ -1,6 +1,7 @@
+gametitle=Legaia: Duel Saga  [NTSC-J] (SCPS-15020)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Legaia: Duel Saga  [NTSC-J] (SCPS-15020)
 comment=Widescreen Hack by Little Gaint
 
 patch=1,EE,00220050,word,3c013f40 //3c013f80 gameplay hor fov

--- a/patches/SCPS-15024_EB4A4786.pnach
+++ b/patches/SCPS-15024_EB4A4786.pnach
@@ -1,6 +1,7 @@
+gametitle=Wild Arms Advanced 3rd  [NTSC-J] (SCPS-15024)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Wild Arms Advanced 3rd  [NTSC-J] (SCPS-15024)
 comment=Widescreen hack by nemesis2000 (pnach by Little Ginat)
 
 //widescreen

--- a/patches/SCPS-15025_FE0A6AB6.pnach
+++ b/patches/SCPS-15025_FE0A6AB6.pnach
@@ -1,6 +1,7 @@
+gametitle=Saru! Get You! 2 [NTSC-J] (SCPS-15025)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Saru! Get You! 2 [NTSC-J] (SCPS-15025)
 comment=Widescreen hack
 
 patch=1,EE,D03D5788,extended,0000CD3A

--- a/patches/SCPS-15053_FDDE7528.pnach
+++ b/patches/SCPS-15053_FDDE7528.pnach
@@ -1,6 +1,7 @@
+gametitle=Siren [NTSC-J] (SCPS-15053)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Siren [NTSC-J] (SCPS-15053)
 comment=Widescreen hack
 //gameplay by sergx12
 patch=1,EE,001fb3b8,word,3c023f40

--- a/patches/SCPS-15095_B4776FC1.pnach
+++ b/patches/SCPS-15095_B4776FC1.pnach
@@ -1,6 +1,7 @@
+gametitle=Genji [NTSC-J] (SCPS-15095)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Genji [NTSC-J] (SCPS-15095)
 comment=Widescreen Hack by okuha8748p, Arapapa
 
 patch=1,EE,002e4ba0,word,3C013FC5

--- a/patches/SCPS-15096_1D9C3331.pnach
+++ b/patches/SCPS-15096_1D9C3331.pnach
@@ -1,6 +1,7 @@
+gametitle=Saru Get You 3 [NTSC-J] （SCPS-15096)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Saru Get You 3 [NTSC-J] （SCPS-15096)
 comment=Widescreen hack
 
 patch=1,EE,20762BB0,extended,3F100000

--- a/patches/SCPS-15111_488B2543.pnach
+++ b/patches/SCPS-15111_488B2543.pnach
@@ -1,6 +1,7 @@
+gametitle=Brave Story - Wataru no Bouken [NTSC-J] (SCPS-15111)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Brave Story - Wataru no Bouken [NTSC-J] (SCPS-15111)
 comment=Widescreen hack by Little Giant
 
 //gameplay 16:9

--- a/patches/SCPS-15112_4D8D6989.pnach
+++ b/patches/SCPS-15112_4D8D6989.pnach
@@ -1,6 +1,7 @@
+gametitle=Blood+ Souyoku no Battle Rondo [NTSC-J] (SCPS-15112)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Blood+ Souyoku no Battle Rondo [NTSC-J] (SCPS-15112)
 comment=Widescreen Hack
 patch=1,EE,00269E60,word,BFAAAAAA
 

--- a/patches/SCPS-15115_8EFDBAEB.pnach
+++ b/patches/SCPS-15115_8EFDBAEB.pnach
@@ -1,6 +1,7 @@
+gametitle=Saru Get You - Million Monkeys [NTSC-J] (SCPS-15115)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Saru Get You - Million Monkeys [NTSC-J] (SCPS-15115)
 comment=Widescreen hack
 patch=1,EE,2070D214,word,3F947ADF
 

--- a/patches/SLES-50031_E81BE74B.pnach
+++ b/patches/SLES-50031_E81BE74B.pnach
@@ -1,6 +1,7 @@
+gametitle=X-Squad (E)(SLES-50031)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=X-Squad (E)(SLES-50031)
 comment=Widescreen Hack (PAL by Arapapa)
 
 //803f013c 00008144 00000000 000040e4

--- a/patches/SLES-51244_200BC0E6.pnach
+++ b/patches/SLES-51244_200BC0E6.pnach
@@ -1,6 +1,7 @@
+gametitle=XIII (SLES-51244)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=XIII (SLES-51244)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 patch=1,EE,001d76cc,word,14400005

--- a/patches/SLES-51244_9C0F01BD.pnach
+++ b/patches/SLES-51244_9C0F01BD.pnach
@@ -1,6 +1,7 @@
+gametitle=XIII (PAL-M5) (SLES-51244)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=XIII (PAL-M5) (SLES-51244)
 comment=Widescreen hack by nemesis2000 (pnach by ElHecht)
 
 // 16:9

--- a/patches/SLES-53492_4C380F8B.pnach
+++ b/patches/SLES-53492_4C380F8B.pnach
@@ -1,6 +1,7 @@
+gametitle=Total Overdose (E)(SLES-53492)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Total Overdose (E)(SLES-53492)
 comment=Widescreen Hack
 
 //00 00 80 3F 83 F9 22 3F DB 0F C9 3F 00 00 00 BF

--- a/patches/SLES-54162_37891D3A.pnach
+++ b/patches/SLES-54162_37891D3A.pnach
@@ -1,6 +1,7 @@
+gametitle=Saint Seiya - The Hades SLES_541.62
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Saint Seiya - The Hades SLES_541.62
 comment=Widescreen Hack
 patch=1,EE,00161e68,word,3c033f40
 

--- a/patches/SLKA-25100_BFCCF369.pnach
+++ b/patches/SLKA-25100_BFCCF369.pnach
@@ -1,6 +1,7 @@
+gametitle=Breath of Fire: Dragon Quarter (K) (SLKA-25100)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Breath of Fire: Dragon Quarter (K) (SLKA-25100)
 comment=Widescreen hack by nemesis2000 (NTSC-K by Arapapa)
 
 patch=1,EE,0012dc1c,word,3c024306 //hor val

--- a/patches/SLKA-25299_CA2073B3.pnach
+++ b/patches/SLKA-25299_CA2073B3.pnach
@@ -1,6 +1,7 @@
+gametitle=One Piece - Grand Battle! Combat Rush (K)(SLKA-25299)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=One Piece - Grand Battle! Combat Rush (K)(SLKA-25299)
 comment=Widescreen Hack (NTSC-K by Arapapa)
 patch=1,EE,204241C8,extended,3F400000
 

--- a/patches/SLKA-25361_42EE9611.pnach
+++ b/patches/SLKA-25361_42EE9611.pnach
@@ -1,6 +1,7 @@
+gametitle=Keroro Gunsou - MeroMero Battle Royale Z (K)(SLKA-25361)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Keroro Gunsou - MeroMero Battle Royale Z (K)(SLKA-25361)
 comment=Widescreen hack by Little Giant (NTSC-K by Arapapa)
 
 //16:9

--- a/patches/SLPM-25401_EB925207.pnach
+++ b/patches/SLPM-25401_EB925207.pnach
@@ -1,6 +1,7 @@
+gametitle=Magna Carta [NTSC-J] (SLPM-25401)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Magna Carta [NTSC-J] (SLPM-25401)
 comment=Widescreen hack by Little Giant
 
 patch=1,EE,002bd898,word,3c023f40 //3c023f80

--- a/patches/SLPM-55005_D6E90E33.pnach
+++ b/patches/SLPM-55005_D6E90E33.pnach
@@ -1,6 +1,7 @@
+gametitle=Mana Khemia 2: Fall of Alchemy [NTSC-J](SLPM-55005)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Mana Khemia 2: Fall of Alchemy [NTSC-J](SLPM-55005)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 //3D scenes

--- a/patches/SLPM-62227_5BC8C9E8.pnach
+++ b/patches/SLPM-62227_5BC8C9E8.pnach
@@ -1,6 +1,7 @@
+gametitle=Marvel vs. Capcom 2: New Age of Heroes [NTSC-J] (SLPM-62227)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Marvel vs. Capcom 2: New Age of Heroes [NTSC-J] (SLPM-62227)
 comment=Widescreen patch by nemesis2000 (pnach by nemesis2000)
 
 patch=1,EE,00414174,word,3C023FAA

--- a/patches/SLPM-62264_C6B97484.pnach
+++ b/patches/SLPM-62264_C6B97484.pnach
@@ -1,6 +1,7 @@
+gametitle=Shin Contra [NTSC-J] (SLPM-62264)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Shin Contra [NTSC-J] (SLPM-62264)
 comment=Widescreen hack
 patch=1,EE,005dc404,word,3c013f40 // hor fov
 patch=1,EE,005dc408,word,44810000

--- a/patches/SLPM-62391_91EC035D.pnach
+++ b/patches/SLPM-62391_91EC035D.pnach
@@ -1,6 +1,7 @@
+gametitle=Ichigeki Sacchuu!! HoiHoi-San [NTSC-J] (SLPM-62391)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Ichigeki Sacchuu!! HoiHoi-San [NTSC-J] (SLPM-62391)
 comment=Widescreen Hack by Little Giant
 
 //16:9

--- a/patches/SLPM-62422_09398F2B.pnach
+++ b/patches/SLPM-62422_09398F2B.pnach
@@ -1,6 +1,7 @@
+gametitle=Hudson Selection Vol. 4 - Takahashi Meijin no Bouken Jima [NTSC-J] (SLPM-62422)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Hudson Selection Vol. 4 - Takahashi Meijin no Bouken Jima [NTSC-J] (SLPM-62422)
 comment=Widescreen hack by Little Giant
 
 patch=1,EE,206F1C60,extended,3F4F5C2A //3F8A3D71

--- a/patches/SLPM-62623_B99379B7.pnach
+++ b/patches/SLPM-62623_B99379B7.pnach
@@ -1,6 +1,7 @@
+gametitle=Erementar Gerad [NTSC-J] (SLPM-62623)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Erementar Gerad [NTSC-J] (SLPM-62623)
 comment=Widescreen Hack
 
 //story

--- a/patches/SLPM-65014_E94C216C.pnach
+++ b/patches/SLPM-65014_E94C216C.pnach
@@ -1,6 +1,7 @@
+gametitle=Bouken Jidai Katsugeki - Goemon [NTSC-J] (SLPM-65014)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Bouken Jidai Katsugeki - Goemon [NTSC-J] (SLPM-65014)
 comment=Widescreen hack by Little Giant and Arapapa
 
 //Widescreen hack 16:9

--- a/patches/SLPM-65022_D0CF2395.pnach
+++ b/patches/SLPM-65022_D0CF2395.pnach
@@ -1,6 +1,7 @@
+gametitle=Biohazard Code Veronica Kanzenban (SLPM_650.22)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Biohazard Code Veronica Kanzenban (SLPM_650.22)
 comment=NTSC-J Widescreen Hack by synce
 patch=1,EE,21136200,extended,3F400000
 

--- a/patches/SLPM-65047_B54C0319.pnach
+++ b/patches/SLPM-65047_B54C0319.pnach
@@ -1,6 +1,7 @@
+gametitle=Capcom vs. SNK 2: Mark of the Millennium 2001  [NTSC-J] (SLPM-65047)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Capcom vs. SNK 2: Mark of the Millennium 2001  [NTSC-J] (SLPM-65047)
 comment=Widescreen patch by nemesis2000 (pnach by nemesis2000)
 
 patch=1,EE,00142fb0,word,3C023FAA

--- a/patches/SLPM-65073_5AF8016F.pnach
+++ b/patches/SLPM-65073_5AF8016F.pnach
@@ -1,6 +1,7 @@
+gametitle=幻想水滸伝 III (SLPM-65073)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=幻想水滸伝 III (SLPM-65073)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000 )
 
 patch=1,EE,016c1b04,word,460d6d42

--- a/patches/SLPM-65101_224B2933.pnach
+++ b/patches/SLPM-65101_224B2933.pnach
@@ -1,6 +1,7 @@
+gametitle=Onimusha 2 [NTSC-J] (SLPM-65101])
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Onimusha 2 [NTSC-J] (SLPM-65101])
 comment=Widescreen correction by nemesis2000 (pnach by Little Giant)
 //gameplay
 patch=1,EE,0010285c,word,3c013f40

--- a/patches/SLPM-65124_5980E116.pnach
+++ b/patches/SLPM-65124_5980E116.pnach
@@ -1,6 +1,7 @@
+gametitle=Auto Modellista [NTSC-J] (SLPM-65124)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Auto Modellista [NTSC-J] (SLPM-65124)
 comment=Widescreen hack by nemesis2000 and Arapapa
 
 //gameplay

--- a/patches/SLPM-65153_C3B568F8.pnach
+++ b/patches/SLPM-65153_C3B568F8.pnach
@@ -1,6 +1,7 @@
+gametitle=Gungrave [NTSC-J] (SLPM-65153)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Gungrave [NTSC-J] (SLPM-65153)
 comment=Widescreen Hack
 
 patch=1,EE,001bee9c,word,3c013f40
@@ -11,6 +12,6 @@ patch=1,EE,001beea8,word,4600c602
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-﻿patch=1,EE,201AF9C4,word,00000000 // nop interleaced
+patch=1,EE,201AF9C4,word,00000000 // nop interleaced
 
 

--- a/patches/SLPM-65246_0AD22FB5.pnach
+++ b/patches/SLPM-65246_0AD22FB5.pnach
@@ -1,6 +1,7 @@
+gametitle=Drift Racer - Kaido Battle [NTSC-J] (SLPM-65246)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Drift Racer - Kaido Battle [NTSC-J] (SLPM-65246)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 patch=1,EE,0013bd80,word,3c023f40

--- a/patches/SLPM-65249_5E191B9C.pnach
+++ b/patches/SLPM-65249_5E191B9C.pnach
@@ -1,6 +1,7 @@
+gametitle=Chaos Legion [NTSC-J] (SLPM-65249)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Chaos Legion [NTSC-J] (SLPM-65249)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 patch=1,EE,00242a1c,word,3c013f40
 patch=1,EE,00242a2c,word,4481d800

--- a/patches/SLPM-65308_DD70E38F.pnach
+++ b/patches/SLPM-65308_DD70E38F.pnach
@@ -1,6 +1,7 @@
+gametitle=Shutokou Battle 01 [NTSC-J] (SLPM-65308)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Shutokou Battle 01 [NTSC-J] (SLPM-65308)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 patch=1,EE,001411f8,word,3c043f53

--- a/patches/SLPM-65331_E46BD847.pnach
+++ b/patches/SLPM-65331_E46BD847.pnach
@@ -1,6 +1,7 @@
+gametitle=RockMan X7 [NTSC-J] (SLPM-65331)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=RockMan X7 [NTSC-J] (SLPM-65331)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 patch=1,EE,0014cbc4,word,3c0244a8

--- a/patches/SLPM-65380_8E79F84B.pnach
+++ b/patches/SLPM-65380_8E79F84B.pnach
@@ -1,6 +1,7 @@
+gametitle=Samurai Dou 2 - Way of the Samurai 2 NTSC-J] (SLPM-65380)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Samurai Dou 2 - Way of the Samurai 2 NTSC-J] (SLPM-65380)
 comment=Widescreen Hack
 
 patch=1,EE,202EFCA0,extended,3F400000

--- a/patches/SLPM-65413_71320CA8.pnach
+++ b/patches/SLPM-65413_71320CA8.pnach
@@ -1,6 +1,7 @@
+gametitle=Onimusha 3 [NTSC-J] (SLPM-65413])
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Onimusha 3 [NTSC-J] (SLPM-65413])
 comment=Widescreen correction by nemesis2000 (pnach by nemesis2000 )
 
 //gameplay

--- a/patches/SLPM-65428_03C8F393.pnach
+++ b/patches/SLPM-65428_03C8F393.pnach
@@ -1,6 +1,7 @@
+gametitle=BioHazard Outbreak [NTSC-J] (SLPM-65428)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=BioHazard Outbreak [NTSC-J] (SLPM-65428)
 comment=FMV's fix will cause abnormal collection interface
 
 //gameplay by synce

--- a/patches/SLPM-65428_198EFDC1.pnach
+++ b/patches/SLPM-65428_198EFDC1.pnach
@@ -1,6 +1,7 @@
+gametitle=BioHazard Outbreak [NTSC-J] (SLPM-65428) (ENGLISH PATCHED)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=BioHazard Outbreak [NTSC-J] (SLPM-65428) (ENGLISH PATCHED)
 comment=FMV's fix will cause abnormal collection interface
 
 //gameplay by synce

--- a/patches/SLPM-65428_32088394.pnach
+++ b/patches/SLPM-65428_32088394.pnach
@@ -1,6 +1,7 @@
+gametitle=BioHazard Outbreak [NTSC-J] (SLPM-65428) (ENGLISH PATCHED)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=BioHazard Outbreak [NTSC-J] (SLPM-65428) (ENGLISH PATCHED)
 comment=FMV's fix will cause abnormal collection interface
 
 //gameplay by synce

--- a/patches/SLPM-65444_A36CFF6C.pnach
+++ b/patches/SLPM-65444_A36CFF6C.pnach
@@ -1,6 +1,7 @@
+gametitle=Castlevania: Lament of Innocence [NTSC-J] (SLPM-65444)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Castlevania: Lament of Innocence [NTSC-J] (SLPM-65444)
 comment==Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 //gameplay

--- a/patches/SLPM-65514_C37C1B76.pnach
+++ b/patches/SLPM-65514_C37C1B76.pnach
@@ -1,6 +1,7 @@
+gametitle=Kaido Battle 2 - Chain Reaction [NTSC-J] (SLPM-65514)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Kaido Battle 2 - Chain Reaction [NTSC-J] (SLPM-65514)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 patch=1,EE,00149200,word,3c023f40

--- a/patches/SLPM-65526_9E2ADF9C.pnach
+++ b/patches/SLPM-65526_9E2ADF9C.pnach
@@ -1,6 +1,7 @@
+gametitle=Dororo [NTSC-J] (SLPM-65526)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Dororo [NTSC-J] (SLPM-65526)
 comment=Widescreen Hack by Little Giant
 patch=1,EE,001b8cbc,word,3c023f06 //3c023f33
 patch=1,EE,001b8cc4,word,34426666 //34423333

--- a/patches/SLPM-65580_84AAB204.pnach
+++ b/patches/SLPM-65580_84AAB204.pnach
@@ -1,6 +1,7 @@
+gametitle=Crash Bandicoot Bakusou! Nitro Kart [NTSC-J] (SLPM-65580)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Crash Bandicoot Bakusou! Nitro Kart [NTSC-J] (SLPM-65580)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 patch=1,EE,005854a8,word,3c023f17
 

--- a/patches/SLPM-65635_FA861ED2.pnach
+++ b/patches/SLPM-65635_FA861ED2.pnach
@@ -1,6 +1,7 @@
+gametitle=Bakuen Kakusei - Neverland Senki Zero [NTSC-J] (SLPM-65635)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Bakuen Kakusei - Neverland Senki Zero [NTSC-J] (SLPM-65635)
 comment=Widescreen hack by Little Giant
 
 //16:9

--- a/patches/SLPM-65643_2AF40F67.pnach
+++ b/patches/SLPM-65643_2AF40F67.pnach
@@ -1,6 +1,7 @@
+gametitle=RockMan X Command Mission [NTSC-J] (SLPM-65643)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=RockMan X Command Mission [NTSC-J] (SLPM-65643)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 patch=1,EE,0010ea24,word,3c013f40 //hor value

--- a/patches/SLPM-65718_DBD2230B.pnach
+++ b/patches/SLPM-65718_DBD2230B.pnach
@@ -1,6 +1,7 @@
+gametitle=Sengoku Musou: Moushouden [NTSC-J] (SLPM-65718)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Sengoku Musou: Moushouden [NTSC-J] (SLPM-65718)
 comment=Widescreen Hack by ElHecht (Pnach by Little Giant)
 
 // 16:9

--- a/patches/SLPM-65730_4FF01A82.pnach
+++ b/patches/SLPM-65730_4FF01A82.pnach
@@ -1,6 +1,7 @@
+gametitle=RockMan X8 [NTSC-J] (SLPM-65730)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=RockMan X8 [NTSC-J] (SLPM-65730)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 patch=1,EE,0010f10c,word,3c013f40 //hor value

--- a/patches/SLPM-65752_A70549D6.pnach
+++ b/patches/SLPM-65752_A70549D6.pnach
@@ -1,6 +1,7 @@
+gametitle=Neo Contra [NTSC-J] (SLPM-65752)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Neo Contra [NTSC-J] (SLPM-65752)
 comment=Widescreen hack
 patch=1,EE,00359ed4,word,3c013f40
 patch=1,EE,00359ed8,word,44810000

--- a/patches/SLPM-65755_65FFA9B9.pnach
+++ b/patches/SLPM-65755_65FFA9B9.pnach
@@ -1,6 +1,7 @@
+gametitle=Samurai Western - Katsugeki Samurai-dou [NTSC-J] (SLPM-65755)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Samurai Western - Katsugeki Samurai-dou [NTSC-J] (SLPM-65755)
 comment=Widescreen Hack
 
 patch=1,EE,202BE2A0,extended,3f400000

--- a/patches/SLPM-65809_A79B0491.pnach
+++ b/patches/SLPM-65809_A79B0491.pnach
@@ -1,6 +1,7 @@
+gametitle=NanoBreaker [NTSC-J] (SLPM-65809)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=NanoBreaker [NTSC-J] (SLPM-65809)
 comment=Widescreen hack
 patch=1,EE,001041f4,word,3c013f40
 patch=1,EE,001041f8,word,44810000

--- a/patches/SLPM-65830_51BF4F00.pnach
+++ b/patches/SLPM-65830_51BF4F00.pnach
@@ -1,6 +1,7 @@
+gametitle=Ys - Napishtim no Hako (Limited Edition) [NTSC-J] (SLPM-65830)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Ys - Napishtim no Hako (Limited Edition) [NTSC-J] (SLPM-65830)
 comment=Widescreen Hack (16:9) by ElHecht
 // 16:9
 patch=1,EE,00102e34,word,3c013f40 // 00000000 hor fov

--- a/patches/SLPM-65913_E263BC4B.pnach
+++ b/patches/SLPM-65913_E263BC4B.pnach
@@ -1,6 +1,7 @@
+gametitle=Demento [NTSC-J] (SLPM-65913)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Demento [NTSC-J] (SLPM-65913)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000 )
 
 //16:9

--- a/patches/SLPM-65985_F4D474EB.pnach
+++ b/patches/SLPM-65985_F4D474EB.pnach
@@ -1,6 +1,7 @@
+gametitle=Atelier Iris-Eternal Mana 2 [NTSC-J](SLPM-65985)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Atelier Iris-Eternal Mana 2 [NTSC-J](SLPM-65985)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 //3D scenes

--- a/patches/SLPM-66008_F0E90890.pnach
+++ b/patches/SLPM-66008_F0E90890.pnach
@@ -1,6 +1,7 @@
+gametitle=Musashiden II - Blade Master [NTSC-J] (SLPM-66008)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Musashiden II - Blade Master [NTSC-J] (SLPM-66008)
 comment=Widescreen Hack
 patch=1,EE,203E5D08,extended,3F19999A // 3F4CCCCD
 

--- a/patches/SLPM-66022_EC33CA0D.pnach
+++ b/patches/SLPM-66022_EC33CA0D.pnach
@@ -1,6 +1,7 @@
+gametitle=Kaido - Touge no Densetsu [NTSC-J] (SLPM-66022)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Kaido - Touge no Densetsu [NTSC-J] (SLPM-66022)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 patch=1,EE,0016323c,word,3c043f40 //GamePlay
 patch=1,EE,0036663c,word,3c033f40 //Garage

--- a/patches/SLPM-66033_22031DAA.pnach
+++ b/patches/SLPM-66033_22031DAA.pnach
@@ -1,6 +1,7 @@
+gametitle=Oz [NTSC-J] (SLPM-66033)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Oz [NTSC-J] (SLPM-66033)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 //gameplay

--- a/patches/SLPM-66058_AEA1B3AD.pnach
+++ b/patches/SLPM-66058_AEA1B3AD.pnach
@@ -1,6 +1,7 @@
+gametitle=Sengoku Basara [NTSC-J] (SLPM-66058)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Sengoku Basara [NTSC-J] (SLPM-66058)
 comment=Widescreen Hack by Little Giant
 
 //wide 16:9

--- a/patches/SLPM-66073_54EAD1B8.pnach
+++ b/patches/SLPM-66073_54EAD1B8.pnach
@@ -1,6 +1,7 @@
+gametitle=Hagane no Renkinjutsushi 3 - Kami o Tsugu Shoujo [NTSC-J] (SLPM-66073)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Hagane no Renkinjutsushi 3 - Kami o Tsugu Shoujo [NTSC-J] (SLPM-66073)
 comment=Widescreen hack by Little Giant
 
 //16:9

--- a/patches/SLPM-66105_B808413B.pnach
+++ b/patches/SLPM-66105_B808413B.pnach
@@ -1,6 +1,7 @@
+gametitle=Rhapsodia [NTSC-J] (SLPM-66105)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Rhapsodia [NTSC-J] (SLPM-66105)
 comment=Original Widescreen Hack by nemesis2000 (pnach by nemesis2000 )
 
 patch=1,EE,0037e62c,word,3c013f40 //hor value

--- a/patches/SLPM-66132_DDF29822.pnach
+++ b/patches/SLPM-66132_DDF29822.pnach
@@ -1,6 +1,7 @@
+gametitle=Gladiator - Road to Freedom Remix [NTSC-J] (SLPM-66132)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Gladiator - Road to Freedom Remix [NTSC-J] (SLPM-66132)
 comment=Widescreen hack
 
 patch=1,EE,20C86E5C,extended,43C00000

--- a/patches/SLPM-66164_4A5E94E1.pnach
+++ b/patches/SLPM-66164_4A5E94E1.pnach
@@ -1,6 +1,7 @@
+gametitle=Mahou Tsukai Kurohime [NTSC-J] (SLPM-66164)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Mahou Tsukai Kurohime [NTSC-J] (SLPM-66164)
 comment=Widescreen hack by Little Giant
 
 patch=1,EE,00196ab4,word,3c013f40 //00000000

--- a/patches/SLPM-66175_237B84D3.pnach
+++ b/patches/SLPM-66175_237B84D3.pnach
@@ -1,6 +1,7 @@
+gametitle=Castlevania: Curse of Darkness [NTSC-J] (SLPM-66175)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Castlevania: Curse of Darkness [NTSC-J] (SLPM-66175)
 comment==Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 //gameplay

--- a/patches/SLPM-66286_7380A572.pnach
+++ b/patches/SLPM-66286_7380A572.pnach
@@ -1,6 +1,7 @@
+gametitle=幻想水滸伝 V (SLPM-66286)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=幻想水滸伝 V (SLPM-66286)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000 )
 
 patch=1,EE,001b8804,word,3c023f40 //hor val

--- a/patches/SLPM-66343_88B27A66.pnach
+++ b/patches/SLPM-66343_88B27A66.pnach
@@ -1,6 +1,7 @@
+gametitle=Shin Sangoku Musou 4 Empires [NTSC-J] (SLPM-66343)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Shin Sangoku Musou 4 Empires [NTSC-J] (SLPM-66343)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000 )
 patch=1,EE,0014708c,word,3c0243d6
 patch=1,EE,0019fb2c,word,3c023f2b

--- a/patches/SLPM-66419_774DE8E2.pnach
+++ b/patches/SLPM-66419_774DE8E2.pnach
@@ -1,6 +1,7 @@
+gametitle=Valkyrie Profile 2 - Silmeria [NTSC-J] (SLPM-66419)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Valkyrie Profile 2 - Silmeria [NTSC-J] (SLPM-66419)
 comment=Widescreen fix by nemesis2000 (pnach by nemesis2000)
 
 //16:9

--- a/patches/SLPM-66676_7B23BFF5.pnach
+++ b/patches/SLPM-66676_7B23BFF5.pnach
@@ -1,6 +1,7 @@
+gametitle=Kingdom Hearts Re - Chain of Memories (Ultimate Hits) [NTSC-J] (SLPM-66676)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Kingdom Hearts Re - Chain of Memories (Ultimate Hits) [NTSC-J] (SLPM-66676)
 comment=Widescreen correction by nemesis2000 (pnach by Little Giant)
 
 //gameplay by asmodean

--- a/patches/SLPM-66698_F694D3D9.pnach
+++ b/patches/SLPM-66698_F694D3D9.pnach
@@ -1,6 +1,7 @@
+gametitle=Shijyou Saikyou no Deshi Kenichi - Gekitou! Ragnarok Hachikengou [NTSC-J] (SLPM-66698)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Shijyou Saikyou no Deshi Kenichi - Gekitou! Ragnarok Hachikengou [NTSC-J] (SLPM-66698)
 comment=Widescreen hack by Little Giant
 
 //16:9

--- a/patches/SLPM-66978_4E63E63C.pnach
+++ b/patches/SLPM-66978_4E63E63C.pnach
@@ -1,6 +1,7 @@
+gametitle=Shin Megami Tensei: Persona 4 NTSC-J (SLPM-66978)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Shin Megami Tensei: Persona 4 NTSC-J (SLPM-66978)
 comment=Widescreen hack by nemesis2000 and pavachan (NTSC-J by Arapapa)
 
 //16:9

--- a/patches/SLPM-74209_95264B6F.pnach
+++ b/patches/SLPM-74209_95264B6F.pnach
@@ -1,6 +1,7 @@
+gametitle=Samurai Dou 2 - Kettouban (PlayStation2 the Best) [NTSC-J] (SLPM-74209)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Samurai Dou 2 - Kettouban (PlayStation2 the Best) [NTSC-J] (SLPM-74209)
 comment=Widescreen Hack
 
 patch=1,EE,2030F260,extended,3f400000

--- a/patches/SLPS-20015_06979F19.pnach
+++ b/patches/SLPS-20015_06979F19.pnach
@@ -1,6 +1,7 @@
+gametitle=Tekken Tag Tournament [NTSC-J] (SLPS-20015)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Tekken Tag Tournament [NTSC-J] (SLPS-20015)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000 )
 patch=1,EE,0034b004,word,3c013f40
 patch=1,EE,0034b008,word,44810000

--- a/patches/SLPS-20023_8AE499F2.pnach
+++ b/patches/SLPS-20023_8AE499F2.pnach
@@ -1,6 +1,7 @@
+gametitle=X Fire [NTSC-J] (SLPS-20023)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=X Fire [NTSC-J] (SLPS-20023)
 comment=Widescreen Hack
 patch=1,EE,001c0cac,word,3c013f40
 

--- a/patches/SLPS-25007_F3F906DE.pnach
+++ b/patches/SLPS-25007_F3F906DE.pnach
@@ -1,6 +1,7 @@
+gametitle=Armored Core 2 [NTSC-J] (SLPS-25007)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Armored Core 2 [NTSC-J] (SLPS-25007)
 comment=Widescreen hack by ElHecht
 
 // 16:9

--- a/patches/SLPS-25028_77D0DACC.pnach
+++ b/patches/SLPS-25028_77D0DACC.pnach
@@ -1,6 +1,7 @@
+gametitle=Shutokou Battle 0 [NTSC-J] (SLPS-25028)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Shutokou Battle 0 [NTSC-J] (SLPS-25028)
 comment=Widescreen Hack
 
 //Gameplay

--- a/patches/SLPS-25040_5F2A0E36.pnach
+++ b/patches/SLPS-25040_5F2A0E36.pnach
@@ -1,6 +1,7 @@
+gametitle=Armored Core 2 - Another Age [NTSC-J] (SLPS-25040)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Armored Core 2 - Another Age [NTSC-J] (SLPS-25040)
 comment=Widescreen hack by ElHecht
 
 // 16:9

--- a/patches/SLPS-25044_E26D2E7D.pnach
+++ b/patches/SLPS-25044_E26D2E7D.pnach
@@ -1,6 +1,7 @@
+gametitle=Evergrace II [NTSC-J] (SLPS-25044)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Evergrace II [NTSC-J] (SLPS-25044)
 comment=Widescreen hack
 patch=1,EE,00101ca8,word,3c013f40
 

--- a/patches/SLPS-25074_9883194E.pnach
+++ b/patches/SLPS-25074_9883194E.pnach
@@ -1,6 +1,7 @@
+gametitle=Zero 零 Zero (J)(SLPS-25074)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Zero 零 Zero (J)(SLPS-25074)
 comment=Widescreen Hack by nemesis2000 and devina40 (NTSC-J by Arapapa)
 
 //Game Play

--- a/patches/SLPS-25094_DFC8C288.pnach
+++ b/patches/SLPS-25094_DFC8C288.pnach
@@ -1,6 +1,7 @@
+gametitle=Reveal Fantasia [NTSC-J] (SLPS-25094)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Reveal Fantasia [NTSC-J] (SLPS-25094)
 comment=Widescreen hack by Little Giant
 
 //16:9

--- a/patches/SLPS-25100_26173F9A.pnach
+++ b/patches/SLPS-25100_26173F9A.pnach
@@ -1,6 +1,7 @@
+gametitle=Tekken 4 [NTSC-J] (SLPS-25100)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Tekken 4 [NTSC-J] (SLPS-25100)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 //gameplay
 patch=1,EE,002174e8,word,3c013f40

--- a/patches/SLPS-25112_D00E1931.pnach
+++ b/patches/SLPS-25112_D00E1931.pnach
@@ -1,6 +1,7 @@
+gametitle=Armored Core 3 [NTSC-J] (SLPS-25112)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Armored Core 3 [NTSC-J] (SLPS-25112)
 comment=Widescreen hack by ElHecht
 
 // 16:9

--- a/patches/SLPS-25113_3E359E0B.pnach
+++ b/patches/SLPS-25113_3E359E0B.pnach
@@ -1,6 +1,7 @@
+gametitle=Zettaizetsumei Toshi [NTSC-J] (SLPS-25113)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Zettaizetsumei Toshi [NTSC-J] (SLPS-25113)
 comment=Widescreen Hack by Little Giant
 
 //16:9

--- a/patches/SLPS-25121_C7568140.pnach
+++ b/patches/SLPS-25121_C7568140.pnach
@@ -1,6 +1,7 @@
+gametitle=.hack Kansen Kakudai Vol. 1 [NTSC-J] (SLPS-25121)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=.hack Kansen Kakudai Vol. 1 [NTSC-J] (SLPS-25121)
 comment=Widescreen hack
 patch=1,EE,209A6A70,word,3f400000
 

--- a/patches/SLPS-25143_54E365C5.pnach
+++ b/patches/SLPS-25143_54E365C5.pnach
@@ -1,6 +1,7 @@
+gametitle=.hack Akushou Heni Vol. 2 [NTSC-J] (SLPS-25143)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=.hack Akushou Heni Vol. 2 [NTSC-J] (SLPS-25143)
 comment=Widescreen hack
 patch=1,EE,209EE7D0,word,3f400000
 

--- a/patches/SLPS-25158_91C50B97.pnach
+++ b/patches/SLPS-25158_91C50B97.pnach
@@ -1,6 +1,7 @@
+gametitle=.hack Shinshoku Osen Vol. 3 [NTSC-J] (SLPS-25158)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=.hack Shinshoku Osen Vol. 3 [NTSC-J] (SLPS-25158)
 comment=Widescreen hack
 patch=1,EE,20A62F50,word,3f400000
 

--- a/patches/SLPS-25169_124C0F8D.pnach
+++ b/patches/SLPS-25169_124C0F8D.pnach
@@ -1,6 +1,7 @@
+gametitle=Armored Core 3 - Silent Line [NTSC-J] (SLPS-25169)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Armored Core 3 - Silent Line [NTSC-J] (SLPS-25169)
 comment=Widescreen hack by ElHecht
 
 // 16:9

--- a/patches/SLPS-25202_4E6F9265.pnach
+++ b/patches/SLPS-25202_4E6F9265.pnach
@@ -1,6 +1,7 @@
+gametitle=.hack Zettai Houi Vol. 4 [NTSC-J] (SLPS-25202)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=.hack Zettai Houi Vol. 4 [NTSC-J] (SLPS-25202)
 comment=Widescreen hack
 patch=1,EE,20A920D0,word,3f400000
 

--- a/patches/SLPS-25234_13DD9957.pnach
+++ b/patches/SLPS-25234_13DD9957.pnach
@@ -1,6 +1,7 @@
+gametitle=Tenchu San NTSC-J (SLPS-25234)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Tenchu San NTSC-J (SLPS-25234)
 comment=Widescreen hack
 patch=1,EE,2163DB24,extended,3f400000 //(gameplay)
 patch=1,EE,001551c8,word,3C024455 //3C024422 (render fix)

--- a/patches/SLPS-25303_B292D14D.pnach
+++ b/patches/SLPS-25303_B292D14D.pnach
@@ -1,6 +1,7 @@
+gametitle=Zero: Akai Chou (SLPS-25303)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Zero: Akai Chou (SLPS-25303)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 patch=1,EE,00336d0c,word,3f400000 //aspect

--- a/patches/SLPS-25311_479DC25E.pnach
+++ b/patches/SLPS-25311_479DC25E.pnach
@@ -1,6 +1,7 @@
+gametitle=Spy Fiction [NTSC-J] (SLPS-25311)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Spy Fiction [NTSC-J] (SLPS-25311)
 comment=Widescreen Hack
 patch=1,EE,001CAADC,word,3F2AAAAB
 

--- a/patches/SLPS-25315_E9BE4521.pnach
+++ b/patches/SLPS-25315_E9BE4521.pnach
@@ -1,6 +1,7 @@
+gametitle=One Piece Grand Battle! 3 [NTSC-J] (SLPS-25315)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=One Piece Grand Battle! 3 [NTSC-J] (SLPS-25315)
 comment=Widescreen Hack
 patch=1,EE,2035CCF0,extended,3f400000  //battle
 //patch=1,EE,2036E430,extended,43B40000  //UI fix,but needs a render fix

--- a/patches/SLPS-25320_78E96CCC.pnach
+++ b/patches/SLPS-25320_78E96CCC.pnach
@@ -1,6 +1,7 @@
+gametitle=Inuyasha - Juuso no Kamen [NTSC-J] (SLPS-25320)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Inuyasha - Juuso no Kamen [NTSC-J] (SLPS-25320)
 comment=Widescreen hack by miseru99
 
 //3D field models

--- a/patches/SLPS-25329_D1AD86D6.pnach
+++ b/patches/SLPS-25329_D1AD86D6.pnach
@@ -1,6 +1,7 @@
+gametitle=Kuon [NTSC-J] (SLPS-25329)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Kuon [NTSC-J] (SLPS-25329)
 comment=Widescreen hack
 patch=1,EE,00138104,extended,3c023f19
 patch=1,EE,00138108,extended,3443999a

--- a/patches/SLPS-25338_26D1C561.pnach
+++ b/patches/SLPS-25338_26D1C561.pnach
@@ -1,4 +1,4 @@
-gametitle=Armored Core - Nexus - Disc 2 - Revolution [NTSC-J] (SLPS-25339)
+gametitle=Armored Core - Nexus - Disc 1 - Evolution [NTSC-J] (SLPS-25338)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLPS-25358_AB9E3E64.pnach
+++ b/patches/SLPS-25358_AB9E3E64.pnach
@@ -1,6 +1,7 @@
+gametitle=Konjiki no Gashbell - Yuujou Tag Battle [NTSC-J] (SLPS-25358)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Konjiki no Gashbell - Yuujou Tag Battle [NTSC-J] (SLPS-25358)
 comment=Widescreen Hack by Little Giant
 
 //16:9

--- a/patches/SLPS-25382_3D065BBB.pnach
+++ b/patches/SLPS-25382_3D065BBB.pnach
@@ -1,6 +1,7 @@
+gametitle=One Piece Land Land [NTSC-J] (SLPS-25382)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=One Piece Land Land [NTSC-J] (SLPS-25382)
 comment=Widescreen Hack by ElHecht
 
 // 16:9

--- a/patches/SLPS-25383_7F995E8D.pnach
+++ b/patches/SLPS-25383_7F995E8D.pnach
@@ -1,6 +1,7 @@
+gametitle=Digimon Battle Chronicle NTSC-J (SLPS-25383)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Digimon Battle Chronicle NTSC-J (SLPS-25383)
 comment=Widescreen Hack
 patch=1,EE,0029aee8,word,3c013f22
 patch=1,EE,0021fe74,word,3c013f22

--- a/patches/SLPS-25384_735A10C2.pnach
+++ b/patches/SLPS-25384_735A10C2.pnach
@@ -1,6 +1,7 @@
+gametitle=Tenchu Kurenai NTSC-J (SLPS-25384)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Tenchu Kurenai NTSC-J (SLPS-25384)
 comment=Widescreen Hack
 //16:9
 patch=1,EE,0012ef50,word,3c023f40

--- a/patches/SLPS-25399_CD62245A.pnach
+++ b/patches/SLPS-25399_CD62245A.pnach
@@ -1,6 +1,7 @@
+gametitle=Keroro Gunsou - MeroMero Battle Royale [NTSC-J] (SLPS-25399)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Keroro Gunsou - MeroMero Battle Royale [NTSC-J] (SLPS-25399)
 comment=Widescreen hack by Little Giant
 
 //16:9

--- a/patches/SLPS-25408_5C4E1AC4.pnach
+++ b/patches/SLPS-25408_5C4E1AC4.pnach
@@ -1,6 +1,7 @@
+gametitle=Armored Core - Nine Breaker [NTSC-J] (SLPS-25408)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Armored Core - Nine Breaker [NTSC-J] (SLPS-25408)
 comment=Widescreen hack by ElHecht
 
 // 16:9

--- a/patches/SLPS-25440_FFBE2593.pnach
+++ b/patches/SLPS-25440_FFBE2593.pnach
@@ -1,6 +1,7 @@
+gametitle=Konjiki no Gashbell!! Gekitou! Saikyou no Mamonotachi [NTSC-J] (SLPS-25440)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Konjiki no Gashbell!! Gekitou! Saikyou no Mamonotachi [NTSC-J] (SLPS-25440)
 comment=Widescreen Hack by Little Giant
 
 //16:9

--- a/patches/SLPS-25453_E4F97921.pnach
+++ b/patches/SLPS-25453_E4F97921.pnach
@@ -1,6 +1,7 @@
+gametitle=Digimon World X [NTSC-J] (SLPS-25453)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Digimon World X [NTSC-J] (SLPS-25453)
 comment=Widescreen Hack by ElHecht
 patch=1,EE,001b8450,word,3c013f40 // 00000000 hor fov
 patch=1,EE,001b845c,word,4481f000 // 00000000

--- a/patches/SLPS-25454_491AEEF6.pnach
+++ b/patches/SLPS-25454_491AEEF6.pnach
@@ -1,6 +1,7 @@
+gametitle=Yoshitsune Eiyuuden - The Story of Hero Yoshitsune [NTSC-J] (SLPS-25454)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Yoshitsune Eiyuuden - The Story of Hero Yoshitsune [NTSC-J] (SLPS-25454)
 comment=Widescreen Hack
 
 //gameplay

--- a/patches/SLPS-25461_3E26EEEB.pnach
+++ b/patches/SLPS-25461_3E26EEEB.pnach
@@ -1,6 +1,7 @@
+gametitle=Armored Core - Formula Front [NTSC-J] (SLPS-25461)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Armored Core - Formula Front [NTSC-J] (SLPS-25461)
 comment=Widescreen hack by ElHecht
 
 // 16:9

--- a/patches/SLPS-25462_FEBE1992.pnach
+++ b/patches/SLPS-25462_FEBE1992.pnach
@@ -1,6 +1,7 @@
+gametitle=Armored Core - Last Raven [NTSC-J] (SLPS-25462)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Armored Core - Last Raven [NTSC-J] (SLPS-25462)
 comment=Widescreen hack by ElHecht
 
 // 16:9

--- a/patches/SLPS-25473_66953267.pnach
+++ b/patches/SLPS-25473_66953267.pnach
@@ -1,6 +1,7 @@
+gametitle=One Piece Grand Battle! Rush [NTSC-J] (SLPS-25473)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=One Piece Grand Battle! Rush [NTSC-J] (SLPS-25473)
 comment=Widescreen Hack
 
 patch=1,EE,20425CB8,extended,3F400000

--- a/patches/SLPS-25476_7970F63C.pnach
+++ b/patches/SLPS-25476_7970F63C.pnach
@@ -1,6 +1,7 @@
+gametitle=Saint Seiya The Sanctuary [NTSC-J] (SLPS-25476)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Saint Seiya The Sanctuary [NTSC-J] (SLPS-25476)
 comment=Widescreen Hack
 
 patch=1,EE,0015e300,word,3c033f40

--- a/patches/SLPS-25479_E6DA8929.pnach
+++ b/patches/SLPS-25479_E6DA8929.pnach
@@ -1,6 +1,7 @@
+gametitle=Konjiki no Gashbell!! Yuujou Tag Battle 2 [NTSC-J] (SLPS-25479)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Konjiki no Gashbell!! Yuujou Tag Battle 2 [NTSC-J] (SLPS-25479)
 comment=Widescreen Hack by Little Giant
 
 //16:9

--- a/patches/SLPS-25499_32AF09E8.pnach
+++ b/patches/SLPS-25499_32AF09E8.pnach
@@ -1,6 +1,7 @@
+gametitle=Yuu Yuu Hakusho Forever [NTSC-J](SLPS-25499)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Yuu Yuu Hakusho Forever [NTSC-J](SLPS-25499)
 comment=Widescreen Hack
 
 patch=1,EE,20630240,extended,3f400000

--- a/patches/SLPS-25510_FC46EA61.pnach
+++ b/patches/SLPS-25510_FC46EA61.pnach
@@ -1,6 +1,7 @@
+gametitle=Tekken 5 [NTSC-J] (SLPS-25510)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Tekken 5 [NTSC-J] (SLPS-25510)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 patch=1,EE,00332B78,word,3c013f40 // both fov+

--- a/patches/SLPS-25518_2B8DB1A5.pnach
+++ b/patches/SLPS-25518_2B8DB1A5.pnach
@@ -1,6 +1,7 @@
+gametitle=Inuyasha - Okugi Ranbu [NTSC-J] (SLPS-25518)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Inuyasha - Okugi Ranbu [NTSC-J] (SLPS-25518)
 comment=Widescreen hack by Little Giant
 
 //16:9

--- a/patches/SLPS-25519_ECD5DB23.pnach
+++ b/patches/SLPS-25519_ECD5DB23.pnach
@@ -1,6 +1,7 @@
+gametitle=Sousei no Aquarion [NTSC-J] (SLPS-25519)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Sousei no Aquarion [NTSC-J] (SLPS-25519)
 comment=Widescreen
 
 patch=1,EE,20729434,extended,3F800000

--- a/patches/SLPS-25523_7902B638.pnach
+++ b/patches/SLPS-25523_7902B638.pnach
@@ -1,6 +1,7 @@
+gametitle=Yoshitsune-ki [NTSC-J] (SLPS-25523)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Yoshitsune-ki [NTSC-J] (SLPS-25523)
 comment=Widescreen Hack
 
 patch=1,EE,205A18C0,extended,43700000

--- a/patches/SLPS-25544_3F651512.pnach
+++ b/patches/SLPS-25544_3F651512.pnach
@@ -1,6 +1,7 @@
+gametitle=Zero: Shisei no Koe [NTSC-J] (SLPS-25544)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Zero: Shisei no Koe [NTSC-J] (SLPS-25544)
 comment=Widescreen Hack (Pnach by Little Giant)
 
 //gameplay

--- a/patches/SLPS-25553_7B29DC24.pnach
+++ b/patches/SLPS-25553_7B29DC24.pnach
@@ -1,6 +1,7 @@
+gametitle=Yoshitsune Eiyuuden Shura - The Story of Hero Yoshitsune Shura [NTSC-J] (SLPS-25553)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Yoshitsune Eiyuuden Shura - The Story of Hero Yoshitsune Shura [NTSC-J] (SLPS-25553)
 comment=Widescreen Hack
 
 //gameplay

--- a/patches/SLPS-25575_6E8687AE.pnach
+++ b/patches/SLPS-25575_6E8687AE.pnach
@@ -1,6 +1,7 @@
+gametitle=Keroro Gunsou - MeroMero Battle Royale Z (NTSC-J] (SLPS-25575)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Keroro Gunsou - MeroMero Battle Royale Z (NTSC-J] (SLPS-25575)
 comment=Widescreen hack by Little Giant
 
 //16:9

--- a/patches/SLPS-25576_18338A0F.pnach
+++ b/patches/SLPS-25576_18338A0F.pnach
@@ -1,6 +1,7 @@
+gametitle=One Piece  Pirates' Carnival [NTSC-J] (SLPS-25576)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=One Piece  Pirates' Carnival [NTSC-J] (SLPS-25576)
 comment=Widescreen Hack by Little Giant
 
 //16:9

--- a/patches/SLPS-25640_A707236E.pnach
+++ b/patches/SLPS-25640_A707236E.pnach
@@ -1,6 +1,7 @@
+gametitle=Xenosaga Episode III - Zarathustra wa Kaku Katariki (DEMO) [NTSC-J] [Disc1] (SLPS-25640) / Xenosaga Episode III - Zarathustra wa Kaku Katariki [NTSC-J] [Disc2] (SLPS-25641)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Xenosaga Episode III - Zarathustra wa Kaku Katariki (DEMO) [NTSC-J] [Disc1] (SLPS-25640) / Xenosaga Episode III - Zarathustra wa Kaku Katariki [NTSC-J] [Disc2] (SLPS-25641)
 comment=Widescreen hack by nemesis2000 (pnach by Little Giant)
 
 //gameplay

--- a/patches/SLPS-25640_E0347841.pnach
+++ b/patches/SLPS-25640_E0347841.pnach
@@ -1,6 +1,7 @@
+gametitle=Xenosaga Episode III - Zarathustra wa Kaku Katariki [NTSC-J] [Disc1] (SLPS-25640) / Xenosaga Episode III - Zarathustra wa Kaku Katariki [NTSC-J] [Disc2] (SLPS-25641)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Xenosaga Episode III - Zarathustra wa Kaku Katariki [NTSC-J] [Disc1] (SLPS-25640) / Xenosaga Episode III - Zarathustra wa Kaku Katariki [NTSC-J] [Disc2] (SLPS-25641)
 comment=Widescreen hack by nemesis2000 (pnach by Little Giant)
 
 //gameplay

--- a/patches/SLPS-25657_4A4B623A.pnach
+++ b/patches/SLPS-25657_4A4B623A.pnach
@@ -1,6 +1,7 @@
+gametitle=Kakutou Bijin Wulong [NTSC-J] (SLPS-25657)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Kakutou Bijin Wulong [NTSC-J] (SLPS-25657)
 comment=Widescreen hack
 
 patch=1,EE,203C9EB0,extended,3FE37FA9

--- a/patches/SLPS-25685_DE737FE2.pnach
+++ b/patches/SLPS-25685_DE737FE2.pnach
@@ -1,6 +1,7 @@
+gametitle=Rurouni Kenshin - Enjou! Kyoto Rinne [NTSC-J] (SLPS-25685)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Rurouni Kenshin - Enjou! Kyoto Rinne [NTSC-J] (SLPS-25685)
 comment=Widescreen Hack by Little Giant
 
 //16:9

--- a/patches/SLPS-25716_7915CB1E.pnach
+++ b/patches/SLPS-25716_7915CB1E.pnach
@@ -1,6 +1,7 @@
+gametitle=Digimon Savers - Another Mission [NTSC-J] (SLPS-25716)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Digimon Savers - Another Mission [NTSC-J] (SLPS-25716)
 comment=Widescreen
 patch=1,EE,203649C0,word,3FAAAAAA
 patch=1,EE,203649D0,word,3F400000

--- a/patches/SLPS-25734_C80DF46D.pnach
+++ b/patches/SLPS-25734_C80DF46D.pnach
@@ -1,6 +1,7 @@
+gametitle=Battle of Yuu Yuu Hakusho,Shitou! Ankoku Bujutsukai! 120% [NTSC-J] (SLPS-25734)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Battle of Yuu Yuu Hakusho,Shitou! Ankoku Bujutsukai! 120% [NTSC-J] (SLPS-25734)
 comment=Widescreen
 patch=1,EE,00103a84,word,3c013f40
 patch=1,EE,00103a88,word,44810000

--- a/patches/SLPS-25738_1AB273DA.pnach
+++ b/patches/SLPS-25738_1AB273DA.pnach
@@ -1,6 +1,7 @@
+gametitle=Soul Nomad & the World Eaters [NTSC-J](SLPS-25739)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Soul Nomad & the World Eaters [NTSC-J](SLPS-25739)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 //gameplay

--- a/patches/SLPS-25798_9E98B8AE.pnach
+++ b/patches/SLPS-25798_9E98B8AE.pnach
@@ -1,6 +1,7 @@
+gametitle=Ikki Tousen - Shining Dragon NTSC-J (SLPS-25798)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Ikki Tousen - Shining Dragon NTSC-J (SLPS-25798)
 comment=Widescreen hack
 
 //battle
@@ -56,7 +57,6 @@ patch=1,EE,2076B900,extended,3F400000
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-﻿gametitle=Ikki Tousen - Shining Dragon NTSC-J (SLPS-25798)
 
 //No-Interlacing
 patch=1,EE,00371834,word,30620000

--- a/patches/SLPS-67014_6DEAEFEA.pnach
+++ b/patches/SLPS-67014_6DEAEFEA.pnach
@@ -1,6 +1,7 @@
+gametitle=Sengoku Musou 2 Moushouden[NTSC-J] (SLPS-670.14)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Sengoku Musou 2 Moushouden[NTSC-J] (SLPS-670.14)
 comment=Widescreen patch
 
 patch=1,EE,00181558,word,3c023f19 // 3c023f4c hor fov 1-player

--- a/patches/SLPS-73103_D00037C4.pnach
+++ b/patches/SLPS-73103_D00037C4.pnach
@@ -1,6 +1,7 @@
+gametitle=Disgaea: Hour of Darkness [NTSC-J] (SLPS-20251)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Disgaea: Hour of Darkness [NTSC-J] (SLPS-20251)
 comment=Widescreen hack by nemesis2000 (pnach by Little Giant)
 
 patch=1,EE,0014c39c,word,3c033f40 //3c033f80

--- a/patches/SLUS-20094_238FFAAE.pnach
+++ b/patches/SLUS-20094_238FFAAE.pnach
@@ -1,6 +1,7 @@
+gametitle=X-Squad [NTSC-U] (SLUS-20094)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=X-Squad [NTSC-U] (SLUS-20094)
 comment=Widescreen Hack
 
 patch=1,EE,001c7f64,word,3c013f40 //3c013f80

--- a/patches/SLUS-20393_5848889C.pnach
+++ b/patches/SLUS-20393_5848889C.pnach
@@ -1,6 +1,7 @@
+gametitle=Onimusha 2 [NTSC-U]
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Onimusha 2 [NTSC-U]
 comment=Widescreen correction by nemesis2000 (pnach by Little Giant)
 //gameplay
 patch=1,EE,2010285c,word,3c013f40

--- a/patches/SLUS-20499_588CC41B.pnach
+++ b/patches/SLUS-20499_588CC41B.pnach
@@ -1,6 +1,7 @@
+gametitle=Breath of Fire: Dragon Quarter (SLUS-20499)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Breath of Fire: Dragon Quarter (SLUS-20499)
 comment=Widescreen patch by nemesis2000 (pnach by nemesis2000)
 patch=1,EE,0012dd1c,word,3c024307 //hor val
 patch=1,EE,0012de68,word,3c034074 //render fix

--- a/patches/SLUS-20565_BF5D9AEC.pnach
+++ b/patches/SLUS-20565_BF5D9AEC.pnach
@@ -1,6 +1,7 @@
+gametitle=Gungrave [NTSC-U]
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Gungrave [NTSC-U]
 comment=Widescreen Hack
 
 patch=1,EE,001bec1c,word,3c013f40 //00000000

--- a/patches/SLUS-20677_FCD97245.pnach
+++ b/patches/SLUS-20677_FCD97245.pnach
@@ -1,6 +1,7 @@
+gametitle=XIII (SLUS-20677)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=XIII (SLUS-20677)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 patch=1,EE,001d66fc,word,14400005

--- a/patches/SLUS-20883_21CC1EC3.pnach
+++ b/patches/SLUS-20883_21CC1EC3.pnach
@@ -1,6 +1,7 @@
+gametitle=Tom Clancy's Rainbow Six 3 (SLKA-25173)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Tom Clancy's Rainbow Six 3 (SLKA-25173)
 comment=Widescreen Hack by nemesis2000 (NTSC-K by Arapapa)
 
 //Widescreen hack 16:9

--- a/patches/SLUS-20892_BBBAAF63.pnach
+++ b/patches/SLUS-20892_BBBAAF63.pnach
@@ -1,6 +1,7 @@
+gametitle=Xenosaga Episode II: Jenseits von Gut und Böse (Disc 1) (SLUS-20892) / Xenosaga Episode II: Jenseits von Gut und Böse (Disc 2) (PAL)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Xenosaga Episode II: Jenseits von Gut und Böse (Disc 1) (SLUS-20892) / Xenosaga Episode II: Jenseits von Gut und Böse (Disc 2) (PAL)
 comment=Widescreen hack
 
 //gameplay

--- a/patches/SLUS-20892_EB39ABEC.pnach
+++ b/patches/SLUS-20892_EB39ABEC.pnach
@@ -1,6 +1,7 @@
+gametitle=Xenosaga Episode II: Jenseits von Gut und Böse (Disc 1) (SLUS-20892) / Xenosaga Episode II: Jenseits von Gut und Böse (Disc 2) (SLUS-21133)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Xenosaga Episode II: Jenseits von Gut und Böse (Disc 1) (SLUS-20892) / Xenosaga Episode II: Jenseits von Gut und Böse (Disc 2) (SLUS-21133)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 //gameplay

--- a/patches/SLUS-20975_B049DD5E.pnach
+++ b/patches/SLUS-20975_B049DD5E.pnach
@@ -1,6 +1,7 @@
+gametitle=Shonen Jump's One Piece  Grand Battle [NTSC-U] (SLUS-20975)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Shonen Jump's One Piece  Grand Battle [NTSC-U] (SLUS-20975)
 comment=Widescreen Hack by Little Giant
 
 //16:9

--- a/patches/SLUS-21080_0442B1BD.pnach
+++ b/patches/SLUS-21080_0442B1BD.pnach
@@ -1,6 +1,7 @@
+gametitle=Samurai Warriors: Xtreme Legends (NTSC-U) (SLUS-21080)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Samurai Warriors: Xtreme Legends (NTSC-U) (SLUS-21080)
 comment=Widescreen Hack by ElHecht (Pnach by Little Giant)
 
 // 16:9

--- a/patches/SLUS-21133_BBBAAF63.pnach
+++ b/patches/SLUS-21133_BBBAAF63.pnach
@@ -1,6 +1,7 @@
+gametitle=Xenosaga Episode II: Jenseits von Gut und Böse (Disc 1) (SLUS-20892) / Xenosaga Episode II: Jenseits von Gut und Böse (Disc 2) (PAL)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Xenosaga Episode II: Jenseits von Gut und Böse (Disc 1) (SLUS-20892) / Xenosaga Episode II: Jenseits von Gut und Böse (Disc 2) (PAL)
 comment=Widescreen hack
 
 //gameplay

--- a/patches/SLUS-21133_EB39ABEC.pnach
+++ b/patches/SLUS-21133_EB39ABEC.pnach
@@ -1,6 +1,7 @@
+gametitle=Xenosaga Episode II: Jenseits von Gut und Böse (Disc 1) (SLUS-20892) / Xenosaga Episode II: Jenseits von Gut und Böse (Disc 2) (SLUS-21133)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Xenosaga Episode II: Jenseits von Gut und Böse (Disc 1) (SLUS-20892) / Xenosaga Episode II: Jenseits von Gut und Böse (Disc 2) (SLUS-21133)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 //gameplay

--- a/patches/SLUS-21144_A80FBAAC.pnach
+++ b/patches/SLUS-21144_A80FBAAC.pnach
@@ -1,6 +1,7 @@
+gametitle=Tom Clancy's Rainbow Six 3 (SLUS-20883)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Tom Clancy's Rainbow Six 3 (SLUS-20883)
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 patch=1,EE,0030f100,word,3c023f40

--- a/patches/SLUS-21187_9EE4D67B.pnach
+++ b/patches/SLUS-21187_9EE4D67B.pnach
@@ -1,6 +1,7 @@
+gametitle=Samurai Western (NTSC-U)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Samurai Western (NTSC-U)
 comment=Widescreen Hack
 
 patch=1,EE,202D35A0,extended,3f400000

--- a/patches/SLUS-21254_282CF16E.pnach
+++ b/patches/SLUS-21254_282CF16E.pnach
@@ -1,6 +1,7 @@
+gametitle=Zatch Bell! Mamodo Battles [NTSC-U] (SLUS-21254)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Zatch Bell! Mamodo Battles [NTSC-U] (SLUS-21254)
 comment=Widescreen Hack by Little Giant
 
 //16:9

--- a/patches/SLUS-21283_461F9727.pnach
+++ b/patches/SLUS-21283_461F9727.pnach
@@ -1,6 +1,7 @@
+gametitle=Total Overdose: A Gunslinger's Tale in Mexico (NTSC-U)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Total Overdose: A Gunslinger's Tale in Mexico (NTSC-U)
 comment=Widescreen Hack
 
 patch=1,EE,206927AC,word,3F47AE14 // Zoom

--- a/patches/SLUS-21363_13E18BC1.pnach
+++ b/patches/SLUS-21363_13E18BC1.pnach
@@ -1,6 +1,7 @@
+gametitle=Zatch Bell! Mamodo Fury [NTSC-U] (SLUS-21363)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Zatch Bell! Mamodo Fury [NTSC-U] (SLUS-21363)
 comment=Widescreen Hack by Little Giant
 
 //16:9

--- a/patches/SLUS-21364_7C87580D.pnach
+++ b/patches/SLUS-21364_7C87580D.pnach
@@ -1,6 +1,7 @@
+gametitle=One Piece Pirates' Carnival [NTSC-U] (SLUS-21364)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=One Piece Pirates' Carnival [NTSC-U] (SLUS-21364)
 comment=Widescreen Hack by Little Giant
 
 //16:9

--- a/patches/SLUS-21560_D2790A77.pnach
+++ b/patches/SLUS-21560_D2790A77.pnach
@@ -1,6 +1,7 @@
+gametitle=Family Guy (SLUS-20718)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-﻿gametitle=Family Guy (SLUS-20718)
 comment=Widescreen update by Brandondorf9999
 
 //---


### PR DESCRIPTION
Changes:
- Remove `ZWNBSP` bytes from 148 pnach files
- Move `gametitle=` line from under ws patch to top of file for above 148 files
- Remove duplicated `gametitle=` line from `SLPS-25798_9E98B8AE.pnach`
- Remove wrong `gametitle=` line from `SLPS-25339_26D1C561.pnach`
- Add missing `SLPS-25338_26D1C561.pnach` file