### PR TITLE
Correct Hitman 2 - Silent Assassin + Blood Money patches

### DIFF
--- a/patches/SLES-50992_5B9ACF79.pnach
+++ b/patches/SLES-50992_5B9ACF79.pnach
@@ -1,4 +1,4 @@
-gametitle=Hitman 2 - Silent Assassin (NTSC-U) (SLUS-20374) (v2.01)
+gametitle=Hitman 2 - Silent Assassin (PAL-E) (SLES-50992) (v1.01 and 2.00)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLES-51107_5B9ACF79.pnach
+++ b/patches/SLES-51107_5B9ACF79.pnach
@@ -1,4 +1,4 @@
-gametitle=Hitman 2 - Silent Assassin (NTSC-U) (SLUS-20374) (v2.01)
+gametitle=Hitman 2 - Silent Assassin (PAL-I) (SLES-51107) (v1.01 and 2.00)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLES-51108_5B9ACF79.pnach
+++ b/patches/SLES-51108_5B9ACF79.pnach
@@ -1,4 +1,4 @@
-gametitle=Hitman 2 - Silent Assassin (NTSC-U) (SLUS-20374) (v2.01)
+gametitle=Hitman 2 - Silent Assassin (PAL-F) (SLES-51108) (v1.01 and 2.00)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLES-51109_5B9ACF79.pnach
+++ b/patches/SLES-51109_5B9ACF79.pnach
@@ -1,4 +1,4 @@
-gametitle=Hitman 2 - Silent Assassin (NTSC-U) (SLUS-20374) (v2.01)
+gametitle=Hitman 2 - Silent Assassin (PAL-G) (SLES-51109) (v1.01 and 2.00)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLES-51110_5B9ACF79.pnach
+++ b/patches/SLES-51110_5B9ACF79.pnach
@@ -1,4 +1,4 @@
-gametitle=Hitman 2 - Silent Assassin (NTSC-U) (SLUS-20374) (v2.01)
+gametitle=Hitman 2 - Silent Assassin (PAL-S) (SLES-51110) (v1.01 and 2.00)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLES-53028_13E1AD6A.pnach
+++ b/patches/SLES-53028_13E1AD6A.pnach
@@ -1,0 +1,13 @@
+gametitle=Hitman - Blood Money (SLES_53028)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+comment=Widescreen hack
+
+patch=1,EE,00178b58,word,3c013f40 //00000000 hor FOV
+patch=1,EE,00178b5c,word,4481f000 //00000000
+patch=1,EE,00178b98,word,461e0003 //00000000
+patch=1,EE,00291610,word,461ea502 //00000000
+patch=1,EE,002b27f4,word,461ea302 //4600a306
+
+

--- a/patches/SLES-53029_72DC82B5.pnach
+++ b/patches/SLES-53029_72DC82B5.pnach
@@ -1,0 +1,14 @@
+gametitle=Hitman - Blood Money (PAL-F) (SLES-53029)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+comment=Widescreen hack by ElHecht
+
+// 16:9
+patch=1,EE,00178c2c,word,3c013f40 // 00000000 hor fov
+patch=1,EE,00178c30,word,4481f000 // 00000000
+patch=1,EE,00178c6c,word,461e0003 // 00000000
+patch=1,EE,002916e0,word,461ea502 // 00000000
+patch=1,EE,002b28c4,word,461ea302 // 4600a306
+
+

--- a/patches/SLES-53031_72DC82B5.pnach
+++ b/patches/SLES-53031_72DC82B5.pnach
@@ -1,0 +1,14 @@
+gametitle=Hitman - Blood Money (PAL-I) (SLES-53031)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+comment=Widescreen hack by ElHecht
+
+// 16:9
+patch=1,EE,00178c2c,word,3c013f40 // 00000000 hor fov
+patch=1,EE,00178c30,word,4481f000 // 00000000
+patch=1,EE,00178c6c,word,461e0003 // 00000000
+patch=1,EE,002916e0,word,461ea502 // 00000000
+patch=1,EE,002b28c4,word,461ea302 // 4600a306
+
+

--- a/patches/SLES-53032_72DC82B5.pnach
+++ b/patches/SLES-53032_72DC82B5.pnach
@@ -1,0 +1,14 @@
+gametitle=Hitman - Blood Money (PAL-S) (SLES-53032)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+comment=Widescreen hack by ElHecht
+
+// 16:9
+patch=1,EE,00178c2c,word,3c013f40 // 00000000 hor fov
+patch=1,EE,00178c30,word,4481f000 // 00000000
+patch=1,EE,00178c6c,word,461e0003 // 00000000
+patch=1,EE,002916e0,word,461ea502 // 00000000
+patch=1,EE,002b28c4,word,461ea302 // 4600a306
+
+


### PR DESCRIPTION
Adds missing patches for variations of Blood Money and Silent Assassin.

Fixes #92