### PR TITLE
Add visual patches for Armored Core games

### DIFF
--- a/patches/SLES-53820_B1A38C05.pnach
+++ b/patches/SLES-53820_B1A38C05.pnach
@@ -12,10 +12,26 @@ patch=1,EE,00174e3c,word,461e2f83 // e48402cc
 patch=1,EE,00174e64,word,e49e02cc // 00000000
 
 // 16:10
-patch=1,EE,00174dd4,word,3c094440 // 3c024420 hor fov
-patch=1,EE,00174ddc,word,35290000 // 44822000 hor fov
-patch=1,EE,00174e38,word,4489f000 // 46042903
-patch=1,EE,00174e3c,word,461e2f83 // e48402cc
-patch=1,EE,00174e64,word,e49e02cc // 00000000
+//patch=1,EE,00174dd4,word,3c094440 // 3c024420 hor fov
+//patch=1,EE,00174ddc,word,35290000 // 44822000 hor fov
+//patch=1,EE,00174e38,word,4489f000 // 46042903
+//patch=1,EE,00174e3c,word,461e2f83 // e48402cc
+//patch=1,EE,00174e64,word,e49e02cc // 00000000
 
+[No-Interlacing]
+gsinterlacemode=1
+author=PsxFan107
+patch=1,EE,2011236C,extended,00000000
+patch=1,EE,20177E5C,extended,0000102D
+
+[Remove Blur]
+author=PsxFan107 & 001
+description=Removes motion blur/ghosting
+patch=1,EE,2018C37C,extended,00000000 //by PsxFan107
+patch=1,EE,20177E60,extended,00000000 //by 001
+
+[Correct HUD]
+author=001 & Berylskid
+description=Removes HUD artifacts on hardware renderer.
+patch=1,EE,00246C1A,extended,00000000
 

--- a/patches/SLES-82037_F3A5EC6F.pnach
+++ b/patches/SLES-82037_F3A5EC6F.pnach
@@ -1,4 +1,4 @@
-gametitle=Armored Core - Nexus - Disc 1 - Evolution (PAL-M5) (SLES-82036)
+gametitle=Armored Core - Nexus - Disc 2 - Revolution (PAL-M5) (SLES-82037)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLKA-25202_1102F889.pnach
+++ b/patches/SLKA-25202_1102F889.pnach
@@ -1,4 +1,4 @@
-gametitle=Armored Core - Nexus - Disc 1 - Evolution (NTSC-K) (SLKA-25201)
+gametitle=Armored Core - Nexus - Disc 2 - Revolution (NTSC-K) (SLKA-25202)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLPS-25338_26D1C561.pnach
+++ b/patches/SLPS-25338_26D1C561.pnach
@@ -21,8 +21,19 @@ patch=1,EE,00158370,word,3c0243d6 // 3c0243a0 renderfix
 //patch=1,EE,00120f78,word,3462aaab // 3462cccd hor fov gameplay
 //patch=1,EE,00158370,word,3c0243c1 // 3c0243a0 renderfix
 
-
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,0023C2DC,word,00000000
+
+[Remove Blur]
+author=001 & Berylskid
+description=Removes blur effects.
+patch=1,EE,E0020000,extended,10487740
+patch=1,EE,61CC66E8,extended,00000000
+patch=1,EE,00000001,extended,0000005F
+
+[Correct HUD]
+author=001 & Berylskid
+description=Removes HUD artifacts on hardware renderer.
+patch=1,EE,002096EA,extended,00000000

--- a/patches/SLPS-25339_26D1C561.pnach
+++ b/patches/SLPS-25339_26D1C561.pnach
@@ -21,8 +21,19 @@ patch=1,EE,00158370,word,3c0243d6 // 3c0243a0 renderfix
 //patch=1,EE,00120f78,word,3462aaab // 3462cccd hor fov gameplay
 //patch=1,EE,00158370,word,3c0243c1 // 3c0243a0 renderfix
 
-
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,0023C2DC,word,00000000
+
+[Remove Blur]
+author=001 & Berylskid
+description=Removes blur effects.
+patch=1,EE,E0020000,extended,10487740
+patch=1,EE,61CC66E8,extended,00000000
+patch=1,EE,00000001,extended,0000005F
+
+[Correct HUD]
+author=001 & Berylskid
+description=Removes HUD artifacts on hardware renderer.
+patch=1,EE,002096EA,extended,00000000

--- a/patches/SLPS-25408_5C4E1AC4.pnach
+++ b/patches/SLPS-25408_5C4E1AC4.pnach
@@ -21,8 +21,19 @@ patch=1,EE,001a78c0,word,3c0243d6 // 3c0243a0 renderfix
 //patch=1,EE,00171798,word,3462aaab // 3462cccd hor fov gameplay
 //patch=1,EE,001a78c0,word,3c0243c1 // 3c0243a0 renderfix
 
-
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,0011F014,word,00000000
+
+[Remove Blur]
+author=001 & Berylskid
+description=Removes blur effects.
+patch=1,EE,E0020000,extended,1027CC74
+patch=1,EE,61D8D4C8,extended,00000000
+patch=1,EE,00000001,extended,0000005F
+
+[Correct HUD]
+author=001 & Berylskid
+description=Removes HUD artifacts on hardware renderer.
+patch=1,EE,002470CA,extended,00000000

--- a/patches/SLPS-25461_3E26EEEB.pnach
+++ b/patches/SLPS-25461_3E26EEEB.pnach
@@ -21,8 +21,20 @@ patch=1,EE,00201e70,word,3c0243d6 // 3c0243a0 renderfix
 //patch=1,EE,001d84d8,word,3462aaab // 3462cccd hor fov gameplay
 //patch=1,EE,00201e70,word,3c0243c1 // 3c0243a0 renderfix
 
-
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,00128CBC,word,00000000
+
+[Remove Blur]
+author=001 & Berylskid
+description=Removes blur effects.
+patch=1,EE,E0020000,extended,102C0B54
+patch=1,EE,61C07A08,extended,00000000
+patch=1,EE,00000001,extended,0000005F
+
+[Correct HUD]
+author=001 & Berylskid
+description=Removes HUD artifacts on hardware renderer.
+patch=1,EE,D1CCE7FA,extended,00001040
+patch=1,EE,01CCE7FA,extended,00000000

--- a/patches/SLPS-25462_FEBE1992.pnach
+++ b/patches/SLPS-25462_FEBE1992.pnach
@@ -18,9 +18,19 @@ patch=1,EE,00174ef4,word,e49e02cc //00000000
 //patch=1,EE,00174ecc,word,461e2f83 //e48402cc
 //patch=1,EE,00174ef4,word,e49e02cc //00000000
 
-
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,00112424,word,00000000
 patch=1,EE,00177D5C,word,0000102D
+
+[Remove Blur]
+author=PsxFan107 & 001
+description=Removes blur effects.
+patch=1,EE,0018C09C,word,00000000 //by PsxFan107
+patch=1,EE,00177D60,word,00000000 //by 001
+
+[Correct HUD]
+author=001 & Berylskid
+description=Removes HUD artifacts on hardware renderer.
+patch=1,EE,002469FA,extended,00000000

--- a/patches/SLUS-20986_7E5F690C.pnach
+++ b/patches/SLUS-20986_7E5F690C.pnach
@@ -1,4 +1,4 @@
-gametitle=Armored Core - Nexus SLUS_209.86  SLUS_210.79
+gametitle=Armored Core - Nexus SLUS_209.86
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -6,7 +6,6 @@ comment=Widescreen Hack
 patch=1,EE,001211c8,word,3c023f22
 patch=1,EE,01e16348,word,3c023f40
 patch=1,EE,202B757C,word,43C00000
-
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
@@ -16,4 +15,14 @@ patch=1,EE,2023C9AC,extended,30420001
 patch=1,EE,E0019000,extended,002C1050
 patch=1,EE,2023C9AC,extended,30420000
 
+[Remove Blur]
+author=001 & Berylskid
+description=Removes blur effects.
+patch=1,EE,E0020000,extended,10298C50
+patch=1,EE,61CC6EE8,extended,00000000
+patch=1,EE,00000001,extended,0000005F
 
+[Correct HUD]
+author=001 & Berylskid
+description=Removes HUD artifacts on hardware renderer.
+patch=1,EE,00209A9A,extended,00000000

--- a/patches/SLUS-21079_7E5F690C.pnach
+++ b/patches/SLUS-21079_7E5F690C.pnach
@@ -1,4 +1,4 @@
-gametitle=Armored Core - Nexus SLUS_209.86  SLUS_210.79
+gametitle=Armored Core - Nexus SLUS_210.79
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -6,7 +6,6 @@ comment=Widescreen Hack
 patch=1,EE,001211c8,word,3c023f22
 patch=1,EE,01e16348,word,3c023f40
 patch=1,EE,202B757C,word,43C00000
-
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
@@ -16,4 +15,14 @@ patch=1,EE,2023C9AC,extended,30420001
 patch=1,EE,E0019000,extended,002C1050
 patch=1,EE,2023C9AC,extended,30420000
 
+[Remove Blur]
+author=001 & Berylskid
+description=Removes blur effects.
+patch=1,EE,E0020000,extended,10298C50
+patch=1,EE,61CC6EE8,extended,00000000
+patch=1,EE,00000001,extended,0000005F
 
+[Correct HUD]
+author=001 & Berylskid
+description=Removes HUD artifacts on hardware renderer.
+patch=1,EE,00209A9A,extended,00000000

--- a/patches/SLUS-21200_72486978.pnach
+++ b/patches/SLUS-21200_72486978.pnach
@@ -7,8 +7,19 @@ patch=1,EE,00172538,word,3c023f22
 patch=1,EE,01ec2218,word,3c023f40
 patch=1,EE,202B067C,word,43c00000
 
-
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,0011F014,word,00000000
+
+[Remove Blur]
+author=001 & Berylskid
+description=Removes blur effects.
+patch=1,EE,E0020000,extended,1027CD3C
+patch=1,EE,61D8A268,extended,00000000
+patch=1,EE,00000001,extended,0000005F
+
+[Correct HUD]
+author=001 & Berylskid
+description=Removes HUD artifacts on hardware renderer.
+patch=1,EE,00247C6A,extended,00000000

--- a/patches/SLUS-21338_1F34E107.pnach
+++ b/patches/SLUS-21338_1F34E107.pnach
@@ -1,23 +1,26 @@
-gametitle=Armored Core: Last Raven SLUS_213.38
+gametitle=Armored Core - Last Raven SLUS_213.38
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack
+description=Widescreen Hack
 patch=1,EE,00174e64,word,3c024455
-
 
 [No-Interlacing]
 gsinterlacemode=1
-comment=De-interlace and blur removal by PsxFan107
-
-//De-Interlace
-patch=1,EE, 00112424,word,00000000
-patch=1,EE, 00177D5C,word,0000102D
+author=PsxFan107
+patch=1,EE,00112424,word,00000000
+patch=1,EE,00177D5C,word,0000102D
 
 //Disable Anti-Aliasing
-patch=1,EE, 001786E8,word,24020001
+//patch=1,EE,001786E8,word,24020001
 
-//Remove Blur
-patch=1,EE, 0018C09C,word,00000000
+[Remove Blur]
+author=PsxFan107 & 001
+description=blur removal
+patch=1,EE,0018C09C,word,00000000 //by PsxFan107
+patch=1,EE,00177D60,word,00000000 //by 001
 
-
+[Correct HUD]
+author=001 & Berylskid
+description=Removes HUD artifacts on hardware renderer.
+patch=1,EE,00246A8A,extended,00000000


### PR DESCRIPTION
Changes:
- Added `[No-Interlacing]` patch for `SLES-53820_B1A38C05.pnach`
- Added `[Remove Blur]` and `[Correct HUD]` patches for some Armored Core games.
- Fixed gametitle for Armored Core Nexus games.