### PR TITLE
Add widescreen patches to Pac-Man World 2

### DIFF
--- a/patches/SLUS-20224_047D8AA6.pnach
+++ b/patches/SLUS-20224_047D8AA6.pnach
@@ -1,5 +1,13 @@
 gametitle=Pac-Man World 2 (U)(SLUS-20224)
 
+[Widescreen 16:9]
+gsaspectratio=16:9
+comment=Widescreen hack
+
+//Official Widescreen auto-enable (vertical screen skewed)
+patch=1,EE,205A68C0,extended,00000001 // change value to 0 for 4:3
+
+
 [No-Interlacing]
 gsinterlacemode=1
 comment=No Interlacing


### PR DESCRIPTION
This PR adds in widescreen patches which are taken from `Pac-Man World 2 (Greatest Hits)` (https://github.com/PCSX2/pcsx2_patches/blob/main/patches/SLUS-20224_E7EA3288.pnach#L7) as the patch seems to also works fine on the base game, tested several levels and no graphical issues so far.