### PR TITLE
Fix some Armored Core patches

### DIFF
--- a/patches/SLES-53820_B1A38C05.pnach
+++ b/patches/SLES-53820_B1A38C05.pnach
@@ -26,12 +26,12 @@ patch=1,EE,20177E5C,extended,0000102D
 
 [Remove Blur]
 author=PsxFan107 & 001
-description=Removes motion blur/ghosting
+description=Removes blur effects.
 patch=1,EE,2018C37C,extended,00000000 //by PsxFan107
+patch=1,EE,D0177E5C,extended,0000102D //by 001
 patch=1,EE,20177E60,extended,00000000 //by 001
 
 [Correct HUD]
 author=001 & Berylskid
 description=Removes HUD artifacts on hardware renderer.
 patch=1,EE,00246C1A,extended,00000000
-

--- a/patches/SLPS-25338_26D1C561.pnach
+++ b/patches/SLPS-25338_26D1C561.pnach
@@ -29,6 +29,7 @@ patch=1,EE,0023C2DC,word,00000000
 [Remove Blur]
 author=001 & Berylskid
 description=Removes blur effects.
+patch=1,EE,201317F0,extended,00000000
 patch=1,EE,E0020000,extended,10487740
 patch=1,EE,61CC66E8,extended,00000000
 patch=1,EE,00000001,extended,0000005F

--- a/patches/SLPS-25339_26D1C561.pnach
+++ b/patches/SLPS-25339_26D1C561.pnach
@@ -29,6 +29,7 @@ patch=1,EE,0023C2DC,word,00000000
 [Remove Blur]
 author=001 & Berylskid
 description=Removes blur effects.
+patch=1,EE,201317F0,extended,00000000
 patch=1,EE,E0020000,extended,10487740
 patch=1,EE,61CC66E8,extended,00000000
 patch=1,EE,00000001,extended,0000005F

--- a/patches/SLPS-25462_FEBE1992.pnach
+++ b/patches/SLPS-25462_FEBE1992.pnach
@@ -27,8 +27,9 @@ patch=1,EE,00177D5C,word,0000102D
 [Remove Blur]
 author=PsxFan107 & 001
 description=Removes blur effects.
-patch=1,EE,0018C09C,word,00000000 //by PsxFan107
-patch=1,EE,00177D60,word,00000000 //by 001
+patch=1,EE,2018C09C,extended,00000000 //by PsxFan107
+patch=1,EE,D0177D5C,extended,0000102D //by 001
+patch=1,EE,20177D60,extended,00000000 //by 001
 
 [Correct HUD]
 author=001 & Berylskid

--- a/patches/SLUS-20986_7E5F690C.pnach
+++ b/patches/SLUS-20986_7E5F690C.pnach
@@ -18,6 +18,7 @@ patch=1,EE,2023C9AC,extended,30420000
 [Remove Blur]
 author=001 & Berylskid
 description=Removes blur effects.
+patch=1,EE,20131AB0,extended,00000000
 patch=1,EE,E0020000,extended,10298C50
 patch=1,EE,61CC6EE8,extended,00000000
 patch=1,EE,00000001,extended,0000005F

--- a/patches/SLUS-21079_7E5F690C.pnach
+++ b/patches/SLUS-21079_7E5F690C.pnach
@@ -18,6 +18,7 @@ patch=1,EE,2023C9AC,extended,30420000
 [Remove Blur]
 author=001 & Berylskid
 description=Removes blur effects.
+patch=1,EE,20131AB0,extended,00000000
 patch=1,EE,E0020000,extended,10298C50
 patch=1,EE,61CC6EE8,extended,00000000
 patch=1,EE,00000001,extended,0000005F

--- a/patches/SLUS-21338_1F34E107.pnach
+++ b/patches/SLUS-21338_1F34E107.pnach
@@ -16,9 +16,10 @@ patch=1,EE,00177D5C,word,0000102D
 
 [Remove Blur]
 author=PsxFan107 & 001
-description=blur removal
-patch=1,EE,0018C09C,word,00000000 //by PsxFan107
-patch=1,EE,00177D60,word,00000000 //by 001
+description=Removes blur effects.
+patch=1,EE,2018C09C,extended,00000000 //by PsxFan107
+patch=1,EE,D0177D5C,extended,0000102D //by 001
+patch=1,EE,20177D60,extended,00000000 //by 001
 
 [Correct HUD]
 author=001 & Berylskid


### PR DESCRIPTION
Changes:
- Fixed `Remove Blur` patch doesn't work in some missions. (Armored Core - Nexus)
- Fixed `Remove Blur` patch messes up screen without NI patch. (Armored Core - Last Raven)