### PR TITLE
WS: Myth Makers Super Cart GP

### DIFF
--- a/patches/SLES-52159_51AB1AB0.pnach
+++ b/patches/SLES-52159_51AB1AB0.pnach
@@ -1,20 +1,22 @@
-gametitle=Myth Makers - Super Kart GP (E)(SLES-52159)
+//gametitle=Myth Makers - Super Kart GP (E)(SLES-52159)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//comment=Widescreen hack by Arapapa
 
 //Widescreen hack 16:9
 
-patch=1,EE,003220c8,word,080e25f8 // c6010068
-patch=1,EE,003220cc,word,00000000 // c602006c
+//patch=1,EE,003220c8,word,080e25f8 // c6010068
+//patch=1,EE,003220cc,word,00000000 // c602006c
 
-patch=1,EE,003897e0,word,3c013f40 // 00000000
-patch=1,EE,003897e4,word,4481f000 // 00000000
-patch=1,EE,003897e8,word,c6010068 // 00000000
-patch=1,EE,003897ec,word,c602006c // 00000000
-patch=1,EE,003897f0,word,461e0843 // 00000000
-patch=1,EE,003897f4,word,e6010068 // 00000000
-patch=1,EE,003897f8,word,080c8834 // 00000000
+//patch=1,EE,003897e0,word,3c013f40 // 00000000
+//patch=1,EE,003897e4,word,4481f000 // 00000000
+//patch=1,EE,003897e8,word,c6010068 // 00000000
+//patch=1,EE,003897ec,word,c602006c // 00000000
+//patch=1,EE,003897f0,word,461e0843 // 00000000
+//patch=1,EE,003897f4,word,e6010068 // 00000000
+//patch=1,EE,003897f8,word,080c8834 // 00000000
+
+//Start game -> Grand Prix -> look on the position locked screens on the characters that are unselectable, they should align, they don't so disable this whole patch
 
 


### PR DESCRIPTION
Fixes offset elements like locked screen in Grand Prix

With WS patch:
![image](https://github.com/PCSX2/pcsx2_patches/assets/24227051/b73a55e5-5df5-4489-9cf0-5998aac321ae)

Without it:
![image](https://github.com/PCSX2/pcsx2_patches/assets/24227051/8b661071-25cf-4a72-aa2d-2ce0fcb0c395)
