### PR TITLE
Patches: Fix CTTR (PAL) WS and tidy up formatting

### DIFF
--- a/patches/SLES-53439_E2FF6D3D.pnach
+++ b/patches/SLES-53439_E2FF6D3D.pnach
@@ -2,15 +2,9 @@ gametitle=Crash Tag Team Racing (E)(SLES-53439)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen 16:9
-
-//X-Fov
-//803f013c 00008144 16000446 100065c4 82100046
-patch=1,EE,0039b420,word,3c013fab //3c013f80
-
-//Render fix
-patch=1,EE,002da688,word,3c013fe0 //3c013f80
-
-
+author=Arapapa
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio.
+//X-FOV
+patch=1,EE,002DA664,word,3C013FAB //3c013f80
+//Render Fix
+patch=1,EE,002DA688,word,3C013FAB //3c013f80


### PR DESCRIPTION
This PR Fixes the broken WS patch as was shown on https://github.com/PCSX2/pcsx2_patches/issues/60 but for PAL version.
Also properly fixes the formatting in accordance to the new syntax format.