### PR TITLE
Update GTA SA Radiosity patches to not cause TLB misses

### DIFF
--- a/patches/SLES-52541_A1B3F232.pnach
+++ b/patches/SLES-52541_A1B3F232.pnach
@@ -18,7 +18,7 @@ patch=1,EE,00242D54,word,0C044C32
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
 
 //Remove Radiosity Filter
-patch=1,EE,20667A64,extended,00000000
+patch=1,EE,20667A64,extended,00C70C00
 
 [Force 50FPS]
 author=Boludoz

--- a/patches/SLES-52541_B440A8FE.pnach
+++ b/patches/SLES-52541_B440A8FE.pnach
@@ -18,5 +18,5 @@ patch=1,EE,00242DB4,word,0C044C32 //0C044C30
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
 
 //Remove Radiosity Filter
-patch=1,EE,206681E4,extended,00000000
+patch=1,EE,206681E4,extended,00C71800
 

--- a/patches/SLPM-55292_9E18263C.pnach
+++ b/patches/SLPM-55292_9E18263C.pnach
@@ -2,5 +2,5 @@
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
 
 //Remove Radiosity Filter
-patch=1,EE,206691DC,extended,00000000
+patch=1,EE,206691DC,extended,00C74500
 

--- a/patches/SLPM-65984_60FE139C.pnach
+++ b/patches/SLPM-65984_60FE139C.pnach
@@ -16,4 +16,4 @@ patch=1,EE,00242c94,word,0c044c32
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
 
 //Remove Radiosity Filter
-patch=1,EE,2066968C,extended,00000000
+patch=1,EE,2066968C,extended,00C74900

--- a/patches/SLUS-20946_2C6BE434.pnach
+++ b/patches/SLUS-20946_2C6BE434.pnach
@@ -18,4 +18,4 @@ patch=1,EE,00242DB4,word,0C044C32
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
 
 //Remove Radiosity Filter
-patch=1,EE,206680E4,extended,00000000
+patch=1,EE,206680E4,extended,00C70700

--- a/patches/SLUS-20946_399A49CA.pnach
+++ b/patches/SLUS-20946_399A49CA.pnach
@@ -24,4 +24,4 @@ patch=1,EE,2054986C,word,00000000
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
 
 //Remove Radiosity Filter
-patch=1,EE,20667964,extended,00000000
+patch=1,EE,20667964,extended,00C70B00


### PR DESCRIPTION
Original patches caused TLB misses constantly, breaking the game, this should resolve that.