### PR TITLE
Redo GTA SA Radiosity patches

### DIFF
--- a/patches/SLES-52541_A1B3F232.pnach
+++ b/patches/SLES-52541_A1B3F232.pnach
@@ -17,8 +17,7 @@ patch=1,EE,00242D54,word,0C044C32
 [Remove Radiosity Filter]
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
 
-//Remove Radiosity Filter
-patch=1,EE,20667A64,extended,00C70C00
+patch=1,EE,2051A0C8,extended,00000000
 
 [Force 50FPS]
 author=Boludoz

--- a/patches/SLES-52541_B440A8FE.pnach
+++ b/patches/SLES-52541_B440A8FE.pnach
@@ -18,5 +18,5 @@ patch=1,EE,00242DB4,word,0C044C32 //0C044C30
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
 
 //Remove Radiosity Filter
-patch=1,EE,206681E4,extended,00C71800
+patch=1,EE,2051A7C8,extended,00000000
 

--- a/patches/SLPM-55292_9E18263C.pnach
+++ b/patches/SLPM-55292_9E18263C.pnach
@@ -2,5 +2,5 @@
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
 
 //Remove Radiosity Filter
-patch=1,EE,206691DC,extended,00C74500
+patch=1,EE,2051B1B8,extended,00000000
 

--- a/patches/SLPM-65984_60FE139C.pnach
+++ b/patches/SLPM-65984_60FE139C.pnach
@@ -16,4 +16,4 @@ patch=1,EE,00242c94,word,0c044c32
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
 
 //Remove Radiosity Filter
-patch=1,EE,2066968C,extended,00C74900
+patch=1,EE,2051B5E8,extended,00000000

--- a/patches/SLUS-20946_2C6BE434.pnach
+++ b/patches/SLUS-20946_2C6BE434.pnach
@@ -18,4 +18,4 @@ patch=1,EE,00242DB4,word,0C044C32
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
 
 //Remove Radiosity Filter
-patch=1,EE,206680E4,extended,00C70700
+patch=1,EE,2051A6D8,extended,00000000

--- a/patches/SLUS-20946_399A49CA.pnach
+++ b/patches/SLUS-20946_399A49CA.pnach
@@ -24,4 +24,4 @@ patch=1,EE,2054986C,word,00000000
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
 
 //Remove Radiosity Filter
-patch=1,EE,20667964,extended,00C70B00
+patch=1,EE,20519FD8,extended,00000000


### PR DESCRIPTION
Redid the patches to nop out the actual function that does the radiosity instead of random bits of memory, it was getting a bit silly modifying pointers and it could break at any time.

This actually nops the function out, the memory search i used for the two instructions before the jump you need to nop was 27a5010c0040202d