### PR TITLE
Correct serial for LOTR Two Towers patch

### DIFF
--- a/patches/SLPM-67546_6898435D.pnach
+++ b/patches/SLPM-67546_6898435D.pnach
@@ -1,4 +1,4 @@
-gametitle=The Lord of the Rings - The Two Towers (K) (SLPS-25026)
+gametitle=The Lord of the Rings - The Two Towers (K) (SLPM-67546)
 
 [Widescreen 16:9]
 gsaspectratio=16:9


### PR DESCRIPTION
Patch author obviously forgot to change the serial, so when we used a script to update all the names, it failed here.
Fixes #131