### PR TITLE
Patches: Various additions and corrections

### DIFF
--- a/patches/SLES-50330_021396FD.pnach
+++ b/patches/SLES-50330_021396FD.pnach
@@ -1,0 +1,27 @@
+gametitle=Grand Theft Auto III (v1.40) (SLES_503.30)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Some Chump
+comment=Select widescreen in game otherwise image is zoomed out 4:3 (Original NTSC-U pnach by nemesis2000)
+
+//widescreen fix
+patch=1,EE,001849FC,word,3C013F9D
+patch=1,EE,00184A00,word,44810000
+patch=1,EE,00184A04,word,46006302
+patch=1,EE,00184A08,word,03E00008
+patch=1,EE,00184A0C,word,E78C85C8
+
+patch=1,EE,00253A68,word,0C06127F
+patch=1,EE,00253C1C,word,0C061282
+patch=1,EE,0027B9B4,word,0C061282
+patch=1,EE,0027BE8C,word,0C061282
+
+[No-Interlacing]
+gsinterlacemode=1
+patch=1,EE,2011299C,extended,00000000
+
+[50 FPS]
+author=Snake356
+comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,2027D64C,extended,28420001

--- a/patches/SLES-50330_581954FC.pnach
+++ b/patches/SLES-50330_581954FC.pnach
@@ -1,8 +1,9 @@
-gametitle=Grand Theft Auto III (PAL SLES_503.30)
+gametitle=Grand Theft Auto III (v1.60) (SLES_503.30)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Converted from NTSC Widescreen fix by nemesis2000 (pnach by Somechump)
+author=Some Chump
+comment=Select widescreen in game otherwise image is zoomed out 4:3 (Original NTSC-U pnach by nemesis2000)
 
 //widescreen fix
 patch=1,EE,00184A4C,word,3C013F9D
@@ -16,4 +17,11 @@ patch=1,EE,00253D6C,word,0C061296
 patch=1,EE,0027BB34,word,0C061296
 patch=1,EE,0027C00C,word,0C061296
 
+[No-Interlacing]
+gsinterlacemode=1
+patch=1,EE,2011299C,extended,00000000
 
+[50 FPS]
+author=Snake356
+comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,2027D7CC,extended,28420001

--- a/patches/SLES-50487_5E641834.pnach
+++ b/patches/SLES-50487_5E641834.pnach
@@ -2,7 +2,8 @@ gametitle=Looney Tunes - Space Race (E)(SLES-50487)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
+author=Arapapa
+comment=Widescreen hack
 
 //Widescreen hack 16:9
 
@@ -10,4 +11,7 @@ comment=Widescreen hack by Arapapa
 //80bf023c e001b027
 patch=1,EE,002ac728,word,3c02bf40 //3c02bf80
 
-
+[50/60 FPS]
+author=PeterDelta
+comment=Patches the game to run at 50/60 FPS (Might need 130% EE Overclock to be stable).
+patch=1,EE,003881F4,word,00000001

--- a/patches/SLES-51061_26954C46.pnach
+++ b/patches/SLES-51061_26954C46.pnach
@@ -1,8 +1,9 @@
-gametitle=Grand Theft Auto: Vice City SLES_510.61 / Ver 3
+gametitle=Grand Theft Auto: Vice City (v3.00) (SLES_510.61)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen converted from NTSC fix by nemesis2000 (pnach by Some Chump)
+author=Some Chump
+comment=Select widescreen in game otherwise image is zoomed out 4:3 (Original NTSC-U pnach by nemesis2000)
 
 //widescreen fix
 patch=1,EE,001324BC,word,3C013F9D
@@ -15,4 +16,11 @@ patch=1,EE,002485dc,word,0C04C92F
 patch=1,EE,002764AC,word,0C04C932
 patch=1,EE,00276A7C,word,0C04C932
 
+[No-Interlacing]
+gsinterlacemode=1
+patch=1,EE,20112444,extended,00000000
 
+[50 FPS]
+author=Snake356
+comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,202788AC,extended,28420001

--- a/patches/SLES-51061_C498A04F.pnach
+++ b/patches/SLES-51061_C498A04F.pnach
@@ -1,0 +1,26 @@
+gametitle=Grand Theft Auto: Vice City (v1.50) (SLES_510.61)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Snake356
+comment=Select widescreen in game otherwise image is zoomed out 4:3
+
+//widescreen fix
+patch=1,EE,001325BC,word,3C013F9D
+patch=1,EE,001325C0,word,44810000
+patch=1,EE,001325C4,word,46006302
+patch=1,EE,001325C8,word,03E00008
+patch=1,EE,001325CC,word,E78C87F8
+
+patch=1,EE,002434EC,word,0C04C96F
+patch=1,EE,0027088C,word,0C04C972
+patch=1,EE,00270E64,word,0C04C972
+
+[No-Interlacing]
+gsinterlacemode=1
+patch=1,EE,20112B24,extended,00000000
+
+[50 FPS]
+author=Snake356
+comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,20272C84,extended,28420001

--- a/patches/SLES-51061_CFCB0D20.pnach
+++ b/patches/SLES-51061_CFCB0D20.pnach
@@ -1,0 +1,26 @@
+gametitle=Grand Theft Auto: Vice City (v2.03) (SLES_510.61)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Snake356
+comment=Select widescreen in game otherwise image is zoomed out 4:3
+
+//widescreen fix
+patch=1,EE,001323AC,word,3C013F9D
+patch=1,EE,001323B0,word,44810000
+patch=1,EE,001323B4,word,46006302
+patch=1,EE,001323B8,word,03E00008
+patch=1,EE,001323BC,word,E78C87F8
+
+patch=1,EE,0024335C,word,0C04C8EB
+patch=1,EE,002706DC,word,0C04C8EE
+patch=1,EE,00270CB4,word,0C04C8EE
+
+[No-Interlacing]
+gsinterlacemode=1
+patch=1,EE,201123C4,extended,00000000
+
+[50 FPS]
+author=Snake356
+comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,20272AD4,extended,28420001

--- a/patches/SLES-52256_D13BEF2C.pnach
+++ b/patches/SLES-52256_D13BEF2C.pnach
@@ -1,0 +1,6 @@
+gametitle=Max Payne 2 - Fall of Max Payne (Spain) (SLES-52256)
+
+[50 FPS]
+author=PeterDelta
+comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,005C0DF8,word,00000001

--- a/patches/SLES-52541_A1B3F232.pnach
+++ b/patches/SLES-52541_A1B3F232.pnach
@@ -1,8 +1,9 @@
-gametitle=Grand Theft Auto: San Andreas (SLES-52541)
+gametitle=Grand Theft Auto: San Andreas (v1.03) (SLES-52541)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=nemesis2000 + shaolinassassin
+comment=Select widescreen in game otherwise image is zoomed out 4:3
 
 //widescreen fix
 patch=1,EE,001130BC,word,3C013F9D
@@ -14,13 +15,15 @@ patch=1,EE,001130CC,word,E78C9A90
 patch=1,EE,0021DF84,word,0C044C2F
 patch=1,EE,00242D54,word,0C044C32
 
+[No-Interlacing]
+gsinterlacemode=1
+patch=1,EE,2054996C,extended,00000000
+
 [Remove Radiosity Filter]
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
-
 patch=1,EE,2051A0C8,extended,00000000
 
-[Force 50FPS]
+[50 FPS]
 author=Boludoz
-description=Forces the game to run at 50 fps internally.
-
+comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
 patch=1,EE,006679CC,extended,00000001

--- a/patches/SLES-52541_B440A8FE.pnach
+++ b/patches/SLES-52541_B440A8FE.pnach
@@ -2,7 +2,8 @@ gametitle=Grand Theft Auto: San Andreas [PAL-M5] (v2.01) (SLES-52541)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by El_Patas
+author=El_Patas
+comment=Select widescreen in game otherwise image is zoomed out 4:3
 
 //Widescreen fix
 patch=1,EE,001130BC,word,3C013F9D
@@ -14,9 +15,15 @@ patch=1,EE,001130CC,word,E78C9A90
 patch=1,EE,0021DFE4,word,0C044C2F //0C044C30
 patch=1,EE,00242DB4,word,0C044C32 //0C044C30
 
+[No-Interlacing]
+gsinterlacemode=1
+patch=1,EE,2054A06C,extended,00000000
+
 [Remove Radiosity Filter]
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
-
-//Remove Radiosity Filter
 patch=1,EE,2051A7C8,extended,00000000
 
+[50 FPS]
+author=Snake356
+comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,0066814C,extended,00000001

--- a/patches/SLES-53439_E2FF6D3D.pnach
+++ b/patches/SLES-53439_E2FF6D3D.pnach
@@ -12,6 +12,6 @@ patch=1,EE,002DA688,word,3C013FAB //3c013f80
 
 [50 FPS]
 //02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 C1 03 00 00 01 00 00 00 01 00 00 00 30 95 57 00
-author=asasega
+author=PeterDelta
 description=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
-patch=1,EE,207B3ADC,extended,00000001 //00000002
+patch=1,EE,007B3ADC,word,00000001 //00000002

--- a/patches/SLES-54126_E393DFE5.pnach
+++ b/patches/SLES-54126_E393DFE5.pnach
@@ -1,4 +1,4 @@
-gametitle=Family Guy (SLUS-20718)
+gametitle=Family Guy (SLES-54126)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -8,7 +8,7 @@ patch=1,EE,0011B3A8,word,00000000 //10400009
 patch=1,EE,0011B3BC,word,3C013F80 //3C013F59
 patch=1,EE,0011B3C0,word,34210000 //3421999A
 
-[60 FPS]
-author=asasega
-comment=Patches the game to run at 60 FPS.
-patch=1,EE,20259698,word,00000001 //00000002
+[50 FPS]
+author=CRASHARKI
+comment=Patches the game to run at 50 FPS. (Original NTSC-U pnach by asasega)
+patch=1,EE,2025989C,word,00000001 //00000002

--- a/patches/SLES-54135_D693D4CF.pnach
+++ b/patches/SLES-54135_D693D4CF.pnach
@@ -58,6 +58,6 @@ patch=1,EE,00291a54,word,0c082128
 patch=1,EE,00291a58,word,46006302
 
 [50 FPS]
-author=CRASHARKI
+author=Snake356
 comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
 patch=1,EE,202D9384,word,00000000 //14820017

--- a/patches/SLES-54182_301A1B6E.pnach
+++ b/patches/SLES-54182_301A1B6E.pnach
@@ -1,0 +1,6 @@
+gametitle=Scarface - The World is Yours (MULTI4) (SLES-54182)
+
+[50 FPS]
+author=Gabominated
+comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,00DAFCBC,word,00000000 //00000001

--- a/patches/SLES-54400_B1F87437.pnach
+++ b/patches/SLES-54400_B1F87437.pnach
@@ -2,7 +2,8 @@ gametitle=SpongeBob SquarePants - Creature from the Krusty Krab (E)(SLES-54400)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa & ICUP321
+author=Arapapa & ICUP321
+comment=Widescreen hack
 
 //Widescreen hack 16:9
 
@@ -16,4 +17,7 @@ patch=1,EE,0043d938,word,461eb582
 //003f013c 00a08144 98000cc6 (1st)
 patch=1,EE,0041f1f0,word,3c013f20 //3c013f00
 
-
+[50 FPS]
+author=asasega
+comment=Patches the game to run at 50 FPS.
+patch=1,EE,21FAFC98,word,42700000 //41F00000

--- a/patches/SLES-54622_B3AD1EA4.pnach
+++ b/patches/SLES-54622_B3AD1EA4.pnach
@@ -18,6 +18,6 @@ patch=1,EE,003ba014,word,0c09955d
 patch=1,EE,003ba4b0,word,0c09955d
 
 [50 FPS]
-author=CRASHARKI
+author=Snake356
 comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
 patch=1,EE,203704F4,word,00000000 //14820019

--- a/patches/SLES-54841_ECA6BFC5.pnach
+++ b/patches/SLES-54841_ECA6BFC5.pnach
@@ -2,6 +2,6 @@ gametitle=Crash of the Titans (PAL)
 
 [50 FPS]
 //01 00 02 24 12 00 82 14 5C
-author=asasega
+author=IWILLCRAFT
 description=Patches the game to run at 50 FPS (Might need 130% EE Overclock to be stable).
 patch=1,EE,204924B8,extended,24020000 //24020001

--- a/patches/SLES-55024_AE28C9C7.pnach
+++ b/patches/SLES-55024_AE28C9C7.pnach
@@ -2,7 +2,8 @@ gametitle=SpongeBob's Atlantis SquarePantis (E)(SLES-55024)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
+author=Arapapa
+comment=Widescreen Hack
 
 //Widescreen hack 16:9
 
@@ -14,4 +15,7 @@ patch=1,EE,003b3708,word,461eb582
 //Render fix
 patch=1,EE,00393220,word,3c013f2b //3c013f00
 
-
+[50 FPS]
+author=asasega
+comment=Patches the game to run at 50 FPS.
+patch=1,EE,21FAFC98,extended,42700000

--- a/patches/SLES-55204_0F89A154.pnach
+++ b/patches/SLES-55204_0F89A154.pnach
@@ -2,6 +2,6 @@ gametitle=Crash - Mind Over Mutant (PAL)
 
 [50/60 FPS]
 //01 00 02 24 12 00 82
-author=asasega
+author=IWILLCRAFT
 description=Patches the game to run at 50 FPS (Activate Progressive Scan for 60 FPS).
 patch=1,EE,20582168,extended,24020000 //24020001

--- a/patches/SLUS-20352_614F7928.pnach
+++ b/patches/SLUS-20352_614F7928.pnach
@@ -2,7 +2,8 @@ gametitle=Looney Tunes - Space Race (U)(SLUS-20352)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
+author=Arapapa
+comment=Widescreen hack
 
 //Widescreen hack 16:9
 
@@ -10,4 +11,7 @@ comment=Widescreen hack by Arapapa
 //80bf023c e001b027
 patch=1,EE,002ac6f8,word,3c02bf40 //3c02bf80
 
-
+[60 FPS]
+author=Super David
+comment=Patches the game to run at 60 FPS (Might need 130% EE Overclock to be stable).
+patch=1,EE,203897F0,word,00000001

--- a/patches/SLUS-20814_CD68E44A.pnach
+++ b/patches/SLUS-20814_CD68E44A.pnach
@@ -1,0 +1,6 @@
+gametitle=Max Payne 2 - Fall of Max Payne (SLUS-20814)
+
+[60 FPS]
+author=asasega
+comment=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,005D8DF8,word,00000001

--- a/patches/SLUS-21111_41F4A178.pnach
+++ b/patches/SLUS-21111_41F4A178.pnach
@@ -1,0 +1,6 @@
+gametitle=Scarface - The World is Yours (SLUS-21111)
+
+[60 FPS]
+author=asasega
+comment=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,20DAFABC,word,00000000 //00000001

--- a/patches/SLUS-21391_82C46B7A.pnach
+++ b/patches/SLUS-21391_82C46B7A.pnach
@@ -2,7 +2,8 @@ gametitle=SpongeBob SquarePants - Creature from the Krusty Krab (U)(SLUS-21391)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa & ICUP321
+author=Arapapa & ICUP321
+comment=Widescreen hack
 
 //Widescreen hack 16:9
 
@@ -16,4 +17,7 @@ patch=1,EE,00438b78,word,461eb582
 //003f013c 00a08144 98000cc6 (1st)
 patch=1,EE,0041a458,word,3c013f20 //3c013f00
 
-
+[60 FPS]
+author=asasega
+comment=Patches the game to run at 60 FPS.
+patch=1,EE,21FAFC98,word,42700000 //41F00000

--- a/patches/SLUS-21644_1FF9C051.pnach
+++ b/patches/SLUS-21644_1FF9C051.pnach
@@ -2,7 +2,8 @@ gametitle=SpongeBob's Atlantis SquarePantis (U)(SLUS-21644)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
+author=Arapapa
+comment=Widescreen Hack
 
 //Widescreen hack 16:9
 
@@ -16,4 +17,7 @@ patch=1,EE,003b3448,word,461eb582
 //003f013c 00a08144 98000cc6 (1st)
 patch=1,EE,00392f60,word,3c013f2b //3c013f00
 
-
+[60 FPS]
+author=asasega
+comment=Patches the game to run at 60 FPS.
+patch=1,EE,21FAFC98,extended,42700000


### PR DESCRIPTION
Changes:

- Add 50/60 FPS patches to Family Guy
- Add Widescreen (PAL) patch to Family Guy (Ported from NTSC-U version)
- Add missing Widescreen, No-interlacing and 50 FPS patches to all (PAL) versions of the GTA Trilogy
- Add 50/60 FPS patches to Looney Tunes Space Race
- Add 50/60 FPS patches to Max Payne 2
- Add 50/60 FPS patches to Scarface
- Add 50/60 FPS patches to SpongeBob Creature from the Krusty Krab
- Add 50/60 FPS patches to SpongeBob's Atlantis SquarePantis
- Various corrections and tidy up formatting

All of the patches have been tested for all versions of the games, and relevant comments such as activating widescreen in-game or the need for EE Overclock have been added.