### PR TITLE
Patches: Various additions and improvements

### DIFF
--- a/patches/SLES-51794_26F6F521.pnach
+++ b/patches/SLES-51794_26F6F521.pnach
@@ -1,0 +1,16 @@
+gametitle=Looney Tunes - Back in Action (SLES-51794)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio.
+patch=1,EE,202D1FBC,extended,4019999A //Viewport Width (Main Menu)
+patch=1,EE,E0010001,extended,003673F0
+patch=1,EE,202D1FBC,extended,3FE66666 //4019999A Viewport Width
+
+[50 FPS]
+author=PeterDelta
+comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,00373978,word,00000002
+patch=1,EE,E0010001,extended,003673F0 //002F64C8
+patch=1,EE,20373978,extended,00000001

--- a/patches/SLES-52372_6B68932C.pnach
+++ b/patches/SLES-52372_6B68932C.pnach
@@ -1,11 +1,11 @@
-gametitle=Spider-Man 2 (NTSC-U) (SLUS_207.76)
+gametitle=Spider-Man 2 (PAL) (SLES_523.72)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=flameofrecca + CRASHARKI
-comment=Patches the game to run at 16:9 Widescreen Aspect Ratio. (Original pnach by flameofrecca; new zoom value, gauge_hero, some map and the unused boss hud codes found by CRASHARKI)
-patch=1,EE,2067a910,word,3f947ae1  //vertical fov 3f5eb852
-patch=1,EE,2067a908,word,3c28a2f7  //zoom value 3c0efa35
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio. (Original NTSC-U pnach by flameofrecca; new zoom value, gauge_hero, some map and the unused boss hud codes found by CRASHARKI)
+patch=1,EE,2067ac70,word,3f947ae1  //vertical fov 3f5eb852
+patch=1,EE,2067ac68,word,3c28a2f7  //zoom value 3c0efa35
 
 //Map Screen HUD, text fixes
 //search the 206d**** address range for more map screen hud fixes
@@ -87,9 +87,9 @@ patch=1,EE,2072421C,word,42340000  //gauge_hero_01 42700000
 //patch=1,EE,208831EC,word,440cd000  //gauge_boss_icon_rhino 440EC000
 
 
-[60 FPS]
+[50 FPS]
 author=asasega + CRASHARKI
-description=Patches the game to run at 60 FPS (Might need 130% EE Overclock to be stable on heavy scenes).
-patch=1,EE,0060A9A0,word,00000001 //00000002
-patch=1,EE,E0010001,extended,005E3910
-patch=1,EE,0060A9A0,extended,00000002
+description=Patches the game to run at 50 FPS (Might need 130% EE Overclock to be stable on heavy scenes).
+patch=1,EE,0060AD20,word,00000001 //00000002
+patch=1,EE,E0010001,extended,005E3C90
+patch=1,EE,0060AD20,extended,00000002

--- a/patches/SLES-54359_0EE5646B.pnach
+++ b/patches/SLES-54359_0EE5646B.pnach
@@ -1,0 +1,10 @@
+gametitle=Legend of Spyro, The - A New Beginning (SLES-54359)
+
+[50 FPS]
+author=asasega + CRASHARKI
+comment=Patches the game to run at 50 FPS.
+patch=1,EE,201211B4,word,28420001 //28420002
+patch=1,EE,201212B8,word,28420001 //28420002
+patch=1,EE,E0020001,extended,0074A914
+patch=1,EE,201211B4,extended,28420002
+patch=1,EE,201212B8,extended,28420002

--- a/patches/SLES-54815_8AE9536D.pnach
+++ b/patches/SLES-54815_8AE9536D.pnach
@@ -1,0 +1,10 @@
+gametitle=Legend of Spyro, The - The Eternal Night (SLES-54815)
+
+[50 FPS]
+author=asasega + CRASHARKI
+comment=Patches the game to run at 50 FPS.
+patch=1,EE,20124390,word,28420001 //28420002
+patch=1,EE,201244AC,word,28420001 //28420002
+patch=1,EE,E0020001,extended,008CC8B4
+patch=1,EE,20124390,extended,28420002
+patch=1,EE,201244AC,extended,28420002

--- a/patches/SLUS-20853_0BB7AE9B.pnach
+++ b/patches/SLUS-20853_0BB7AE9B.pnach
@@ -1,0 +1,16 @@
+gametitle=Looney Tunes - Back in Action (SLUS-20853)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio.
+patch=1,EE,202D1F3C,extended,4019999A //Viewport Width (Main Menu)
+patch=1,EE,E0010001,extended,00367370
+patch=1,EE,202D1F3C,extended,3FE66666 //4019999A Viewport Width
+
+[60 FPS]
+author=asasega + PeterDelta
+comment=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,003738F8,word,00000002
+patch=1,EE,E0010001,extended,00367370
+patch=1,EE,203738F8,extended,00000001

--- a/patches/SLUS-21372_D03D4C77.pnach
+++ b/patches/SLUS-21372_D03D4C77.pnach
@@ -1,0 +1,10 @@
+gametitle=Legend of Spyro, The - A New Beginning (SLUS-21372)
+
+[60 FPS]
+author=asasega + CRASHARKI
+comment=Patches the game to run at 60 FPS.
+patch=1,EE,201211B4,word,28420001 //28420002
+patch=1,EE,201212B8,word,28420001 //28420002
+patch=1,EE,E0020001,extended,0074A914
+patch=1,EE,201211B4,extended,28420002
+patch=1,EE,201212B8,extended,28420002

--- a/patches/SLUS-21607_B80CE8EC.pnach
+++ b/patches/SLUS-21607_B80CE8EC.pnach
@@ -1,0 +1,10 @@
+gametitle=Legend of Spyro, The - The Eternal Night (SLUS-21607)
+
+[60 FPS]
+author=asasega + CRASHARKI
+comment=Patches the game to run at 60 FPS.
+patch=1,EE,20124360,word,28420001 //28420002
+patch=1,EE,2012447C,word,28420001 //28420002
+patch=1,EE,E0020001,extended,008CC334
+patch=1,EE,20124360,extended,28420002
+patch=1,EE,2012447C,extended,28420002


### PR DESCRIPTION
Changes:

- Add 50/60 FPS patches to The Legend of Spyro A New Beginning
- Add 50/60 FPS patches to The Legend of Spyro The Eternal Night
- Add 50/60 FPS patches to Looney Tunes Back in Action
- Add Widescreen patches to Looney Tunes Back in Action
- Improve Spider-Man 2 (NTSC-U) Widescreen patch (Fixed Spider-Man's shadow, fixed the missing map/compass, added more HUD components, commented some problematic HUD addresses)
- Add Widescreen patch to Spider-Man 2 (PAL): Equivalent to NTSC-U.
- Improve Spider-Man 2 (NTSC-U) 60 FPS patch (Fixed FMVs playing accelerated)
- Add 50 FPS patch to Spider-Man 2 (PAL): Equivalent to NTSC-U.

All of the patches have been tested for all versions of the games, and relevant comments such as activating widescreen in-game or the need for EE Overclock have been added.