### PR TITLE
Patches: Better widescreen fixes for 007: Agent Under Fire

### DIFF
--- a/patches/SLES-50539_992B46DC.pnach
+++ b/patches/SLES-50539_992B46DC.pnach
@@ -1,0 +1,30 @@
+gametitle=James Bond 007 - Agent Under Fire (E) (SLES-50539)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+description=16:9 widescreen patch
+author=Arapapa, Silent
+
+// Action segments
+// English
+patch=1,EE,D0320494,extended,01003F80
+patch=1,EE,10320494,extended,00003FAB // 3F80
+// French
+patch=1,EE,D0320564,extended,01003F80
+patch=1,EE,10320564,extended,00003FAB // 3F80
+// German
+patch=1,EE,D032057C,extended,01003F80
+patch=1,EE,1032057C,extended,00003FAB // 3F80
+// Spanish
+patch=1,EE,D0320574,extended,01003F80
+patch=1,EE,10320574,extended,00003FAB // 3F80
+// Dutch, Swedish
+patch=1,EE,D032059C,extended,01003F80
+patch=1,EE,1032059C,extended,00003FAB // 3F80
+
+// Driving segments
+patch=1,EE,D022E248,extended,04003F80
+patch=1,EE,1022E248,extended,00003F40
+patch=1,EE,1012B7D0,extended,00003FE8
+patch=1,EE,1012B7D4,extended,00008E39
+patch=1,EE,1011B3B0,extended,000043F0 // 480.0

--- a/patches/SLPM-67505_60666E72.pnach
+++ b/patches/SLPM-67505_60666E72.pnach
@@ -1,23 +1,17 @@
-gametitle=James Bond 007 - Agent Under Fire (K)(SLPM-67505)
+gametitle=James Bond 007 - Agent Under Fire (K) (SLPM-67505)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
+description=16:9 widescreen patch
+author=Arapapa, Silent
 
-//Widescreen hack 16:9
+// Action segments
+patch=1,EE,D03202DC,extended,01003F80
+patch=1,EE,103202DC,extended,00003FAB // 3F80
 
-//X-Fov
-//803f013c 00088144 60654224
-patch=1,EE,003202dc,word,3c013fab //3c013f80
-
-///////////////////////
-//0000803F 0000803F 00000000 00000000 00002044 0000E043
-//patch=1,EE,207F728C,extended,3FAAAAAB //3F800000
-
-//Zoom
-//patch=1,EE,0013dee4,word,3c013f40 //3c013f80
-
-//Y-Fov
-//patch=1,EE,00320728,word,3c013f40 //3c013f80
-
-
+// Driving segments
+patch=1,EE,D022DCD8,extended,04003F80
+patch=1,EE,1022DCD8,extended,00003F40
+patch=1,EE,1012B7B0,extended,00003FE8
+patch=1,EE,1012B7B4,extended,00008E39
+patch=1,EE,1011B390,extended,000043F0 // 480.0

--- a/patches/SLUS-20265_79646C72.pnach
+++ b/patches/SLUS-20265_79646C72.pnach
@@ -1,13 +1,17 @@
-gametitle=James Bond 007 - Agent Under Fire (U)(SLUS-20265)
+gametitle=James Bond 007 - Agent Under Fire (U) (SLUS-20265)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
+description=16:9 widescreen patch
+author=Arapapa, Silent
 
-//Widescreen hack 16:9
+// Action segments
+patch=1,EE,D03202DC,extended,01003F80
+patch=1,EE,103202DC,extended,00003FAB // 3F80
 
-//X-Fov
-//803f013c 00088144 60654224
-patch=1,EE,003202dc,word,3c013fab //3c013f80
-
-
+// Driving segments
+patch=1,EE,D022DCD8,extended,04003F80
+patch=1,EE,1022DCD8,extended,00003F40
+patch=1,EE,1012B7B0,extended,00003FE8
+patch=1,EE,1012B7B4,extended,00008E39
+patch=1,EE,1011B390,extended,000043F0 // 480.0


### PR DESCRIPTION
This PR improves the current widescreen patch for 007: Agent Under Fire. The following improvements are now in:

1. Moved to a new naming scheme with an explicitly stated author.
2. Fixed the patch stomping on memory outside of the on-foot segments by making it apply conditionally. The patch was "lucky" that during the driving segments it stomped on some meaningless debug strings. Unfortunately, the game does not switch ELFs via BIOS, so it is not possible to split patches by CRC, and instead "if checks" need to be used.
3. Added a patch for the driving segments of the game that are handled by a separate ELF file.
4. Added support for the PAL version, all languages.

![007 - Agent Under Fire_SLUS-20265_20230819002539](https://github.com/PCSX2/pcsx2_patches/assets/7947461/bc9430d7-bccf-4ba2-a44e-6afeea51af28)
![007 - Agent Under Fire_SLUS-20265_20230819002214](https://github.com/PCSX2/pcsx2_patches/assets/7947461/da17ae9a-dce5-4884-9bb6-bae166390a1d)

Drafted until I've discussed it with the dev of AUF Reloaded, since apparently there were past efforts in fixing the driving segments for widescreen - and I want to avoid missing any gotchas. Once it's un-drafted I'll also submit those patches on the forums.