### PR TITLE
Patches: Correct NFS HP2 NTSC-U ws fix

### DIFF
--- a/patches/SLUS-20362_1D2818AF.pnach
+++ b/patches/SLUS-20362_1D2818AF.pnach
@@ -1,13 +1,9 @@
-gametitle=Need for Speed - Hot Pursuit 2 (PAL-M6) (SLUS-20362)
+gametitle=Need for Speed - Hot Pursuit 2 (NTSC-U) (SLUS-20362)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by nemesis2000/pnach by ElHecht
+comment=Widescreen Hack by nemesis2000
 
-
-// 16:9
-patch=1,EE,0032f6fc,word,3f400000 // 3f800000 hor fov
-patch=1,EE,0032f850,word,3f2aaaab // 3f000000 increase hor fov
-patch=1,EE,0010e840,word,3c013f2b // 3c013f00 renderfix
-
-
+patch=1,EE,0010e994,word,46011702
+patch=1,EE,0032f6ec,word,3f400000
+patch=1,EE,0032f850,word,3f2aaaaa


### PR DESCRIPTION
The previous one is for PAL version and doesn't work for both regions as claimed.

Old "fix"
![image](https://github.com/PCSX2/pcsx2_patches/assets/4414625/61911f57-4151-49b8-bedb-c7bf37cda2e8)
Proper fix
![image](https://github.com/PCSX2/pcsx2_patches/assets/4414625/a6f771a2-3b39-4279-b891-4b6f9bed4d68)
