### PR TITLE
NI: Add NI patches for Kaido Battle games (JP&EU)

### DIFF
--- a/patches/SLES-53191_F7780E06.pnach
+++ b/patches/SLES-53191_F7780E06.pnach
@@ -2,9 +2,14 @@ gametitle=Kaido Racer PAL (SLES_531.91)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
+author=El_Patas
 comment=Widescreen hack by El_Patas
-
 //Gameplay 16:9
 patch=1,EE,20431190,extended,3F400000 //3F800000 (Increases hor. axis)
 
 
+[No Interlacing]
+gsinterlacemode=1
+author=val
+description=Attempts to disable interlaced offset rendering.
+patch=1,EE,001350F0,word,00000000

--- a/patches/SLES-53900_C7993BCC.pnach
+++ b/patches/SLES-53900_C7993BCC.pnach
@@ -2,9 +2,14 @@ gametitle=Kaido Racer 2 PAL (SLES_539.00)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
+author=El_Patas
 comment=Widescreen hack by El_Patas
-
 //Gameplay 16:9
 patch=1,EE,203FDFD0,extended,3F400000 //3F800000 (Increases hor. axis)
 
 
+[No Interlacing]
+gsinterlacemode=1
+author=val
+description=Attempts to disable interlaced offset rendering.
+patch=1,EE,001539E8,word,00000000

--- a/patches/SLPM-65246_0AD22FB5.pnach
+++ b/patches/SLPM-65246_0AD22FB5.pnach
@@ -2,8 +2,12 @@ gametitle=Drift Racer - Kaido Battle [NTSC-J] (SLPM-65246)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
-
+author=nemesis2000
+description=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 patch=1,EE,0013bd80,word,3c023f40
 
-
+[No Interlacing]
+gsinterlacemode=1
+author=val
+description=Attempts to disable interlaced offset rendering.
+patch=1,EE,00135ABC,word,00000000

--- a/patches/SLPM-65246_2046216F.pnach
+++ b/patches/SLPM-65246_2046216F.pnach
@@ -1,0 +1,13 @@
+gametitle=Kaido Battle - Nikko, Haruna, Rokko, Hakone [NTSC-J] (SLPM-65246)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=nemesis2000
+description=Widescreen hack by nemesis2000 (pnach by nemesis2000)
+patch=1,EE,0013bd80,word,3c023f40
+
+[No Interlacing]
+gsinterlacemode=1
+author=val
+description=Attempts to disable interlaced offset rendering.
+patch=1,EE,00135ABC,word,00000000

--- a/patches/SLPM-65514_C37C1B76.pnach
+++ b/patches/SLPM-65514_C37C1B76.pnach
@@ -2,8 +2,12 @@ gametitle=Kaido Battle 2 - Chain Reaction [NTSC-J] (SLPM-65514)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
-
+author=nemesis2000
+description=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 patch=1,EE,00149200,word,3c023f40
 
-
+[No Interlacing]
+gsinterlacemode=1
+author=val
+description=Attempts to disable interlaced offset rendering.
+patch=1,EE,0013A204,word,00000000


### PR DESCRIPTION
Adds no interlacing patches for the following games:

[EU] Kaido Racer
[EU] Kaido Racer 2
[JP] Kaido Battle
[JP] Kaido Battle 2 Chain Reaction
[JP] Kaido Touge no Densetsu

Added an additional patch for Kaido Battle 1 JP, since the original CRC doesn't match mine and I can't find anything about the original CRC.