### PR TITLE
Update patches

### DIFF
--- a/patches/SCES-50294_B590CE04.pnach
+++ b/patches/SCES-50294_B590CE04.pnach
@@ -3,4 +3,12 @@ description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,2025B4E8,extended,34020001
 
-
+[60 FPS]
+author=PeterDelta
+comment=Forces progressive scan and run at 60 fps
+patch=1,EE,2028F840,extended,24120052
+patch=1,EE,2035163C,extended,3C888889 //speed flags 
+patch=1,EE,20351F1C,extended,3C888889 //speed cars
+patch=1,EE,20351980,extended,3C888889 //speed icon ilumination
+patch=1,EE,203519D4,extended,3C888889 //speed icon menu principal
+patch=1,EE,201F0D30,extended,24420032 //speed timer

--- a/patches/SCES-51719_44A61C8F.pnach
+++ b/patches/SCES-51719_44A61C8F.pnach
@@ -18,17 +18,23 @@ patch=1,EE,204959B8,extended,4614D682 // mul.s f26, f26, f20
 patch=1,EE,204959BC,extended,08124B83 // j 00492E0C
 patch=1,EE,2044DF60,extended,00000000 // nop
 
-[No-Interlacing]
-gsinterlacemode=1
+[Mode 480p]
 author=Silent
-comment=480p mode in race. Set to Graphics "Deinterlacing: Adaptive (Top Field First)". Incompatible with 1080i
+comment=480p mode in race. Disable deinterlacing patch
+patch=1,EE,20A57E70,extended,00000000
+patch=1,EE,2035812C,extended,2442003C
+patch=1,EE,E0020001,extended,00A57E7C
 patch=1,EE,20A57E70,extended,00000001
+patch=1,EE,2035812C,extended,24420032 //speed timer 
 
 [Mode 1080i]
 author=PeterDelta
-comment=1080i mode in race. Disable it before entering in zone Replay Theatre. Disable all deinterlacing patches.
-patch=1,EE,E0030001,extended,00A57E7C
+comment=1080i mode in race. Disable it before entering in zone Replay Theatre.
+patch=1,EE,20A57E70,extended,00000000
+patch=1,EE,2035812C,extended,2442003C
+patch=1,EE,E0050001,extended,00A57E7C
+patch=1,EE,20A57E70,extended,00000002
 patch=1,EE,206184D4,extended,00000051
 patch=1,EE,20618504,extended,00000240
-patch=1,EE,20618508,extended,000003c0
-patch=1,EE,20A57E70,extended,00000000
+patch=1,EE,20618508,extended,000003C0
+patch=1,EE,2035812C,extended,24420032 //speed timer

--- a/patches/SCES-53372_CA9AA903.pnach
+++ b/patches/SCES-53372_CA9AA903.pnach
@@ -1,12 +1,13 @@
 gametitle=Tourist Trophy - The Real Riding Simulator (PAL-M) SCES-53372 CA9AA903
 
-[No-Interlacing]
-gsinterlacemode=1
+[Mode 480p]
 author=PeterDelta
-comment=480p mode in race. Set to Graphics "Deinterlacing: Adaptive (Top Field First)". Fix tremor at start game
+comment=480p mode in race. Forces progressive scan at 60 fps.
 patch=1,EE,00830648,word,00000001
+patch=1,EE,002054F4,word,24420032 //speed timer
 
 [Mode 1080i]
 author=PeterDelta
-comment=1080i mode in race. Set to Graphics "Deinterlacing: Adaptive (Top Field First)". Fix tremor at start game
+comment=1080i mode in race. Forces progressive scan at 60 fps.
 patch=1,EE,00830648,word,00000002
+patch=1,EE,002054F4,word,24420032 //speed timer

--- a/patches/SLES-52843_F8F8CD47.pnach
+++ b/patches/SLES-52843_F8F8CD47.pnach
@@ -23,3 +23,7 @@ patch=1,EE,0020eee0,word,461e0002
 patch=1,EE,0020eee4,word,080c535f
 
 
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
+patch=1,EE,005C7D60,word,42700000 //41F00000

--- a/patches/SLES-53155_99AD19EE.pnach
+++ b/patches/SLES-53155_99AD19EE.pnach
@@ -25,3 +25,5 @@ patch=1,EE,0051bcf0,word,461e4a42 // 00000000
 author=PeterDelta
 comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
 patch=1,EE,001AF538,word,00000001 //00000002
+patch=1,EE,E0010002,extended,001B4344
+patch=1,EE,201AF538,extended,00000001

--- a/patches/SLES-53225_D3051E54.pnach
+++ b/patches/SLES-53225_D3051E54.pnach
@@ -1,0 +1,8 @@
+gametitle=Madagascar (PAL-E) SLES-53225 D3051E54
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
+patch=1,EE,004B0604,byte,0001 //0002
+patch=1,EE,00346D24,word,00000064 //00000032
+patch=1,EE,01ADA8F4,word,3F000000 //3F800000 animations

--- a/patches/SLES-53246_D3051E54.pnach
+++ b/patches/SLES-53246_D3051E54.pnach
@@ -1,0 +1,8 @@
+gametitle=Madagascar (PAL-S) SLES-53246 D3051E54
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
+patch=1,EE,004B0604,byte,0001 //0002
+patch=1,EE,00346D24,word,00000064 //00000032
+patch=1,EE,01ADA8F4,word,3F000000 //3F800000 animations

--- a/patches/SLES-54172_627B8252.pnach
+++ b/patches/SLES-54172_627B8252.pnach
@@ -16,3 +16,7 @@ patch=1,EE,002b1274,word,3c023f80 //3c023faa
 patch=1,EE,002b1278,word,34420000 //3442aaab
 
 
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
+patch=1,EE,0021A580,word,1000000F

--- a/patches/SLES-54817_98317385.pnach
+++ b/patches/SLES-54817_98317385.pnach
@@ -8,3 +8,7 @@ comment=Widescreen Hack by El_Patas
 patch=1,EE,001c3a74,word,3c033f40 //3c033f80
 
 
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
+patch=1,EE,0026BBF4,word,00000001 //00000002


### PR DESCRIPTION
A few weeks ago I included patches deinterlacing in gt4 and Tourist Trophy with gsinterlacemode=1 that in reality only force progressive scanning, since when I included it the screen vibrated in the menus and when I removed it it worked perfectly, I come to correct that error resulting from my ignorance, now I know that only those intended for deinterlacing have to go there, that at least in these games they are not necessary with new versions of the emulator. With these changes they run perfectly with the emulator's default options without the need for any patch, the screen does not vibrate and looks correct.
I hope I expressed myself well. I've tested the rest and they work fine.