### PR TITLE
Add scanmsk removal patch

### DIFF
--- a/patches/SLES-50920_401F4726.pnach
+++ b/patches/SLES-50920_401F4726.pnach
@@ -8,4 +8,7 @@ patch=1,EE,0022d3bc,word,3c013f40 //00000000
 patch=1,EE,0022d3c0,word,44810000 //00000000
 patch=1,EE,0022d3c8,word,4600c602 //00000000
 
-
+[Remove Scanmask Blur]
+author=refraction
+description=Disables scanmask usage to reduce blur when turning.
+patch=1,EE,201069E0,extended,24050000

--- a/patches/SLPS-25057_04C3765E.pnach
+++ b/patches/SLPS-25057_04C3765E.pnach
@@ -10,4 +10,7 @@ patch=1,EE,0022c1a4,word,3c013f40 //00000000
 patch=1,EE,0022c1a8,word,44810000 //00000000
 patch=1,EE,0022c1b0,word,4600c602 //00000000
 
-
+[Remove Scanmask Blur]
+author=refraction
+description=Disables scanmask usage to reduce blur when turning.
+patch=1,EE,20107588,extended,24050000

--- a/patches/SLUS-20318_36E02E91.pnach
+++ b/patches/SLUS-20318_36E02E91.pnach
@@ -16,4 +16,7 @@ patch=1,EE,202218B4,extended,00000000
 patch=1,EE,2022193C,extended,00000000
 patch=1,EE,0021F710,word,00000000
 
-
+[Remove Scanmask Blur]
+author=refraction
+description=Disables scanmask usage to reduce blur when turning.
+patch=1,EE,20107588,extended,24050000


### PR DESCRIPTION
Removes scanmask usage from the game, which doesn't seem to do much but make things blurrier when turning.

It still looks a bit blurry to me when actually in motion, but as you can see below from the stills taken when turning, it's clearer.

Normal:
![image](https://github.com/PCSX2/pcsx2_patches/assets/6278726/7c8a48c7-1007-4bd5-9e11-0803f6f7ccbe)

Patched:
![image](https://github.com/PCSX2/pcsx2_patches/assets/6278726/26c8108b-b1b3-4ad1-a27e-5094b9ee642e)
