### PR TITLE
Patches: Disable Castlevania: Lament of Innocence Widescreen Patch

### DIFF
--- a/patches/SLUS-20733_28270F7D.pnach
+++ b/patches/SLUS-20733_28270F7D.pnach
@@ -1,17 +1,20 @@
-gametitle=Castlevania: Lament of Innocence (SLUS-20733)
+// Patch disabled due to broken icons on screen. Patch appears to be mostly working,
+// but in Buy menus, the icon which is supposed to appear in the Information panel
+// is not AR adjusted and appears over top of the text describing the item. Needs
+// fixed before re-enabling.
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
+//gametitle=Castlevania: Lament of Innocence (SLUS-20733)
+
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
 
 //gameplay
-patch=1,EE,006e70f4,word,23c013f40 //hor value
-patch=1,EE,006e70f8,word,44810000
-patch=1,EE,006e7100,word,4600c602
+//patch=1,EE,006e70f4,word,23c013f40 //hor value
+//patch=1,EE,006e70f8,word,44810000
+//patch=1,EE,006e7100,word,4600c602
 
 //FMV's fix
-patch=1,EE,004511d0,word,24057300//y-pos
-patch=1,EE,004511d4,word,24062000//x width
-patch=1,EE,004511dc,word,24071b00//y width
-
-
+//patch=1,EE,004511d0,word,24057300//y-pos
+//patch=1,EE,004511d4,word,24062000//x width
+//patch=1,EE,004511dc,word,24071b00//y width


### PR DESCRIPTION
![image](https://github.com/PCSX2/pcsx2_patches/assets/6377490/37b1a6fa-c995-42b6-942e-d59b538bc10b)
Patch does not AR adjust item icons in buy menus. Might be a good idea to disable until someone can work out how to fix it.