### PR TITLE
Patches: Fix 60 FPS patch to The Legend of Spyro A New Beginning

### DIFF
--- a/patches/SLUS-21372_D03D4C77.pnach
+++ b/patches/SLUS-21372_D03D4C77.pnach
@@ -5,6 +5,6 @@ author=asasega + CRASHARKI
 comment=Patches the game to run at 60 FPS.
 patch=1,EE,201211B4,word,28420001 //28420002
 patch=1,EE,201212B8,word,28420001 //28420002
-patch=1,EE,E0020001,extended,0074A914
+patch=1,EE,E0020001,extended,00749F94
 patch=1,EE,201211B4,extended,28420002
 patch=1,EE,201212B8,extended,28420002


### PR DESCRIPTION
A quick fix to the 60 FPS patch for The Legend of Spyro A New Beginning (NTSC-U) that caused FMVs to play accelerated. I tested it and now it works as it should.