### PR TITLE
Add 120 FPS patch for Burnout Revenge (U)

### DIFF
--- a/patches/SLUS-21242_D224D348.pnach
+++ b/patches/SLUS-21242_D224D348.pnach
@@ -44,3 +44,12 @@ patch=1,EE,201125EC,extended,00108002
 author=SuperType1/remco
 description=Makes the Crashes & Crash Mode run in 60 FPS.
 patch=1,EE,20104B9C,extended,90850608
+
+[120 FPS]
+author=Scirvir
+description=Requires setting PCSX2 framerate to 120FPS in Properties>Emulation>Speed Controls.
+patch=1,EE,10103238,extended,3c104205
+patch=1,EE,10104a30,extended,3c104205
+patch=1,EE,10103230,extended,24040078
+patch=1,EE,001125d4,extended,24040078
+patch=1,EE,00303f00,extended,3c014e0c


### PR DESCRIPTION
120 FPS for Burnout Revenge:
- Compatible with existing 60 FPS patches for Crash mode. Applying those patches at the same time as this one only makes said gamemode run at 120 FPS aswell
- All audio is sped up. Not particularly annoying for game sounds but very much so for music
- No major gameplay problems except for colission against very steep ramps. Video attached as an example.
https://github.com/PCSX2/pcsx2_patches/assets/106109476/0e75d04e-c770-42dd-ba01-a5aff28b4209

Proof: https://youtu.be/VQRiaeKFrc8
