### PR TITLE
Patches: Various additions and improvements

### DIFF
--- a/patches/SLES-50326_52E0597D.pnach
+++ b/patches/SLES-50326_52E0597D.pnach
@@ -1,4 +1,5 @@
 gametitle=Max Payne [PAL-M4] (SLES_503.26)
+//This pnach corresponds to the main CRC of the game, but it's just meant to activate SLES-50326_C669B63C.pnach
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLES-50326_52E0597D.pnach
+++ b/patches/SLES-50326_52E0597D.pnach
@@ -2,15 +2,5 @@ gametitle=Max Payne [PAL-M4] (SLES_503.26)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by El_Patas
-
-//Gameplay 16:9
-//ELF file is called "MAIN_P.RUN"
-patch=1,EE,0050eae0,word,3c013f40 //00000000 (Increases hor. axis)
-patch=1,EE,0050eae8,word,4481f000 //00000000
-patch=1,EE,0050eaec,word,0c04821c //00000000
-patch=1,EE,0050eaf0,word,00000000 //0c04821c
-patch=1,EE,0050eaf4,word,461e0003 //00000000
-patch=1,EE,0050eb04,word,461e0082 //c68201f8
-
-
+author=El_Patas
+comment=Widescreen Hack

--- a/patches/SLES-50326_C669B63C.pnach
+++ b/patches/SLES-50326_C669B63C.pnach
@@ -1,0 +1,15 @@
+gametitle=Max Payne [PAL-M4] (SLES_503.26)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=El_Patas
+comment=Widescreen Hack
+
+//Gameplay 16:9
+//ELF file is called "MAIN_P.RUN"
+patch=1,EE,0050eae0,word,3c013f40 //00000000 (Increases hor. axis)
+patch=1,EE,0050eae8,word,4481f000 //00000000
+patch=1,EE,0050eaec,word,0c04821c //00000000
+patch=1,EE,0050eaf0,word,00000000 //0c04821c
+patch=1,EE,0050eaf4,word,461e0003 //00000000
+patch=1,EE,0050eb04,word,461e0082 //c68201f8

--- a/patches/SLES-52382_4CF48A70.pnach
+++ b/patches/SLES-52382_4CF48A70.pnach
@@ -1,4 +1,5 @@
 gametitle=Shrek 2 (Spain) (SLES_523.82)
+//This pnach corresponds to the main CRC of the game, but it's just meant to activate SLES-52382_76C01D41.pnach
 //Main CRC 4CF48A70
 //SHREK2.ELF CRC 76C01D41
 

--- a/patches/SLES-52382_4CF48A70.pnach
+++ b/patches/SLES-52382_4CF48A70.pnach
@@ -1,0 +1,8 @@
+gametitle=Shrek 2 (Spain) (SLES_523.82)
+//Main CRC 4CF48A70
+//SHREK2.ELF CRC 76C01D41
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio. (Original NTSC-U pnach by Arapapa)

--- a/patches/SLES-52382_76C01D41.pnach
+++ b/patches/SLES-52382_76C01D41.pnach
@@ -1,0 +1,14 @@
+gametitle=Shrek 2 (Spain) (SLES_523.82)
+//Main CRC 4CF48A70
+//SHREK2.ELF CRC 76C01D41
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio. (Original NTSC-U pnach by Arapapa)
+
+//Wide 16:9 (EA4ED1BC 00000000 7FAAAA3F 00000000)
+patch=1,EE,20379A30,word,3F800000 // 3FAAAA7F
+
+//00 00 80 3F 00 00 80 3F 00 00 00 00
+patch=1,EE,20367674,extended,3f400000 //3f800000 HUD fix

--- a/patches/SLES-54904_4C7BB3C8.pnach
+++ b/patches/SLES-54904_4C7BB3C8.pnach
@@ -1,7 +1,7 @@
-gametitle=Simpsons Game, The (PAL-S-I) SLES-54906 565B7E04
+gametitle=Simpsons Game, The (PAL-M4) SLES-54904 4C7BB3C8
 
 [50 FPS]
-author=PeterDelta
+author=CRASHARKI
 comment=Unlocked at 50 FPS. Set EE Cycle Skipping to Mild Underclock to prevent framedrops and 130% EE Overclock to be stable.
 patch=1,EE,00215954,word,00000000 //1440FFFA
-patch=1,EE,003603AC,word,00000000 //1040FFF8
+patch=1,EE,003603B4,word,00000000 //1040FFF8

--- a/patches/SLES-54905_5C1EBF61.pnach
+++ b/patches/SLES-54905_5C1EBF61.pnach
@@ -1,0 +1,7 @@
+gametitle=Simpsons Game, The (PAL-F) SLES-54905 5C1EBF61
+
+[50 FPS]
+author=CRASHARKI
+comment=Unlocked at 50 FPS. Set EE Cycle Skipping to Mild Underclock to prevent framedrops and 130% EE Overclock to be stable.
+patch=1,EE,00215904,word,00000000 //1440FFFA
+patch=1,EE,0036033C,word,00000000 //1040FFF8

--- a/patches/SLES-55020_5C1EBD61.pnach
+++ b/patches/SLES-55020_5C1EBD61.pnach
@@ -1,0 +1,7 @@
+gametitle=Simpsons Game, The (PAL-G) SLES-55020 5C1EBD61
+
+[50 FPS]
+author=CRASHARKI
+comment=Unlocked at 50 FPS. Set EE Cycle Skipping to Mild Underclock to prevent framedrops and 130% EE Overclock to be stable.
+patch=1,EE,00215904,word,00000000 //1440FFFA
+patch=1,EE,0036033C,word,00000000 //1040FFF8

--- a/patches/SLUS-20230_513CA7D9.pnach
+++ b/patches/SLUS-20230_513CA7D9.pnach
@@ -1,0 +1,15 @@
+gametitle=Max Payne (NTSC-U)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=ElHecht
+comment=Widescreen Hack
+
+// 16:9
+// ELF file is called "MAIN.RUN"
+patch=1,EE,0050e030,word,3c013f40 // 00000000 hor fov
+patch=1,EE,0050e038,word,4481f000 // 00000000
+patch=1,EE,0050e03c,word,0c04821c // 00000000
+patch=1,EE,0050e040,word,00000000 // 0c04821c
+patch=1,EE,0050e044,word,461e0003 // 00000000
+patch=1,EE,0050e054,word,461e0082 // c68201f8

--- a/patches/SLUS-20230_BEB4577E.pnach
+++ b/patches/SLUS-20230_BEB4577E.pnach
@@ -2,15 +2,5 @@ gametitle=Max Payne (NTSC-U)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
-
-// 16:9
-// ELF file is called "MAIN.RUN"
-patch=1,EE,0050e030,word,3c013f40 // 00000000 hor fov
-patch=1,EE,0050e038,word,4481f000 // 00000000
-patch=1,EE,0050e03c,word,0c04821c // 00000000
-patch=1,EE,0050e040,word,00000000 // 0c04821c
-patch=1,EE,0050e044,word,461e0003 // 00000000
-patch=1,EE,0050e054,word,461e0082 // c68201f8
-
-
+author=ElHecht
+comment=Widescreen Hack

--- a/patches/SLUS-20230_BEB4577E.pnach
+++ b/patches/SLUS-20230_BEB4577E.pnach
@@ -1,4 +1,5 @@
 gametitle=Max Payne (NTSC-U)
+//This pnach corresponds to the main CRC of the game, but it's just meant to activate SLUS-20230_513CA7D9.pnach
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLUS-20745_11D7EC66.pnach
+++ b/patches/SLUS-20745_11D7EC66.pnach
@@ -1,13 +1,18 @@
 gametitle=Shrek 2 (U) (SLUS_207.45)
+//Main CRC 11D7EC66
+//SHREK2.ELF CRC 9C41124B
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Wide 16:9 (EA4ED1BC 00000000 7FAAAA3F 00000000)
-patch=1,EE,203792B0,word,3F800000 // 3FAAAA7F
-
-//00 00 80 3F 00 00 80 3F 00 00 00 00 25 64 20 00
-patch=1,EE,203604B4,extended,3f400000 //3f800000 HUD fix
+author=Arapapa
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio.
 
 
+
+
+
+
+
+[60 FPS]
+author=asasega
+comment=Patches the game to run at 60 FPS.

--- a/patches/SLUS-20745_11D7EC66.pnach
+++ b/patches/SLUS-20745_11D7EC66.pnach
@@ -1,4 +1,5 @@
 gametitle=Shrek 2 (U) (SLUS_207.45)
+//This pnach corresponds to the main CRC of the game, but it's just meant to activate SLUS-20745_9C41124B.pnach
 //Main CRC 11D7EC66
 //SHREK2.ELF CRC 9C41124B
 
@@ -6,12 +7,6 @@ gametitle=Shrek 2 (U) (SLUS_207.45)
 gsaspectratio=16:9
 author=Arapapa
 comment=Patches the game to run at 16:9 Widescreen Aspect Ratio.
-
-
-
-
-
-
 
 [60 FPS]
 author=asasega

--- a/patches/SLUS-20745_9C41124B.pnach
+++ b/patches/SLUS-20745_9C41124B.pnach
@@ -1,0 +1,20 @@
+gametitle=Shrek 2 (U) (SLUS_207.45)
+//Main CRC 11D7EC66
+//SHREK2.ELF CRC 9C41124B
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Arapapa
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio.
+
+//Wide 16:9 (EA4ED1BC 00000000 7FAAAA3F 00000000)
+patch=1,EE,203792B0,word,3F800000 // 3FAAAA7F
+
+//00 00 80 3F 00 00 80 3F 00 00 00 00 25 64 20 00
+patch=1,EE,203604B4,extended,3f400000 //3f800000 HUD fix
+
+[60 FPS]
+author=asasega
+comment=Patches the game to run at 60 FPS.
+patch=1,EE,2014B6C8,word,24040001
+patch=1,EE,202ADFA8,word,3C013F00

--- a/patches/SLUS-21665_BBE4D862.pnach
+++ b/patches/SLUS-21665_BBE4D862.pnach
@@ -1,0 +1,7 @@
+gametitle=Simpsons Game, The (NTSC-U) SLUS-21665 BBE4D862
+
+[60 FPS]
+author=asasega
+comment=Unlocked at 60 FPS. Set EE Cycle Skipping to Mild Underclock to prevent framedrops and 130% EE Overclock to be stable.
+patch=1,EE,002158DC,word,00000000 //1440FFFA
+patch=1,EE,0035FEA4,word,00000000 //1040FFF8


### PR DESCRIPTION
Changes:

- Add 50/60 FPS patches to The Simpsons Game
- Fix Max Payne patches to use correct CRCs
- Add Widescreen and 60 FPS patches to Shrek 2 + correct CRCs

All of the patches have been tested for all versions of the games, and relevant comments such as activating widescreen in-game or the need for EE Overclock have been added.