### PR TITLE
Patches: Various additions and improvements

### DIFF
--- a/patches/SCES-50885_09B3AD4D.pnach
+++ b/patches/SCES-50885_09B3AD4D.pnach
@@ -1,0 +1,8 @@
+gametitle=Ape Escape 2 (Europe) (SCES-50885)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,203E19B4,word,00000001 //00000000 Widescreen
+//patch=1,EE,20535690,word,00000004 //00000002 Widescreen

--- a/patches/SCES-51102_8B6FE2EA.pnach
+++ b/patches/SCES-51102_8B6FE2EA.pnach
@@ -1,0 +1,8 @@
+gametitle=Ape Escape 2 (France) (SCES-51102)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,203E19B4,word,00000001 //00000000 Widescreen
+//patch=1,EE,20535690,word,00000004 //00000002 Widescreen

--- a/patches/SCES-51103_E2B8D3B2.pnach
+++ b/patches/SCES-51103_E2B8D3B2.pnach
@@ -1,0 +1,8 @@
+gametitle=Ape Escape 2 (Italy) (SCES-51103)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,203E19B4,word,00000001 //00000000 Widescreen
+//patch=1,EE,20535690,word,00000004 //00000002 Widescreen

--- a/patches/SCES-51104_BBB21612.pnach
+++ b/patches/SCES-51104_BBB21612.pnach
@@ -1,0 +1,8 @@
+gametitle=Ape Escape 2 (Germany) (SCES-51104)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,203E19B4,word,00000001 //00000000 Widescreen
+//patch=1,EE,20535690,word,00000004 //00000002 Widescreen

--- a/patches/SCES-51105_ADCDCB88.pnach
+++ b/patches/SCES-51105_ADCDCB88.pnach
@@ -1,0 +1,8 @@
+gametitle=Ape Escape 2 (Spain) (SCES-51105)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,203E19B4,word,00000001 //00000000 Widescreen
+//patch=1,EE,20535690,word,00000004 //00000002 Widescreen

--- a/patches/SCES-53642_53898FD0.pnach
+++ b/patches/SCES-53642_53898FD0.pnach
@@ -1,0 +1,7 @@
+gametitle=Ape Escape 3 (SCES-53642)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,2064A188,byte,1 //0 Widescreen

--- a/patches/SCUS-97501_7571AAEE.pnach
+++ b/patches/SCUS-97501_7571AAEE.pnach
@@ -1,0 +1,7 @@
+gametitle=Ape Escape 3 (SCUS-97501)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,20649DC8,byte,1 //0 Widescreen

--- a/patches/SLES-52568_1510E1D1.pnach
+++ b/patches/SLES-52568_1510E1D1.pnach
@@ -1,0 +1,8 @@
+gametitle=Crash Twinsanity (SLES-52568)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,2030AAC4,word,00000001 //00000000
+patch=1,EE,20BEAF64,word,00000001 //00000000

--- a/patches/SLES-54117_28241DFE.pnach
+++ b/patches/SLES-54117_28241DFE.pnach
@@ -2,10 +2,8 @@ gametitle=Torrente 3 - The Protector (E)(SLES-54117)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen hack 16:9
-
+author=Arapapa
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio.
 patch=1,EE,00253c48,word,08123794
 patch=1,EE,0048de50,word,3c013f40
 patch=1,EE,0048de54,word,4481f000
@@ -14,5 +12,3 @@ patch=1,EE,0048de5c,word,c602006c
 patch=1,EE,0048de60,word,461e0843
 patch=1,EE,0048de64,word,e6010068
 patch=1,EE,0048de68,word,08094f14
-
-

--- a/patches/SLES-54135_D693D4CF.pnach
+++ b/patches/SLES-54135_D693D4CF.pnach
@@ -2,7 +2,8 @@ gametitle=Grand Theft Auto: Liberty City Stories (SLES_541.35)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Select widescreen in game otherwise image is zoomed out 4:3 (Original NTSC-U pnach by nemesis2000)
+author=Some Chump + CRASHARKI
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio. (Original widescreen fix by nemesis2000)
 
 //widescreen fix
 patch=1,EE,00291990,word,468010a0
@@ -56,6 +57,9 @@ patch=1,EE,00291a4c,word,3c013f9d
 patch=1,EE,00291a50,word,44810000
 patch=1,EE,00291a54,word,0c082128
 patch=1,EE,00291a58,word,46006302
+
+//Force widescreen from the start
+patch=1,EE,203D8DAA,byte,1
 
 [50 FPS]
 author=Snake356

--- a/patches/SLES-54622_B3AD1EA4.pnach
+++ b/patches/SLES-54622_B3AD1EA4.pnach
@@ -2,8 +2,8 @@ gametitle=Grand Theft Auto: Vice City Stories (SLES_546.22)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Some Chump
-comment=Select widescreen in game otherwise image is zoomed out 4:3 (Original NTSC-U pnach by nemesis2000)
+author=Some Chump + CRASHARKI
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio. (Original widescreen fix by nemesis2000)
 
 //widescreen fix pal
 patch=1,EE,00265568,word,3c013f9d
@@ -16,6 +16,9 @@ patch=1,EE,0026557c,word,e44c7784
 patch=1,EE,0037afb4,word,0c09955a
 patch=1,EE,003ba014,word,0c09955d
 patch=1,EE,003ba4b0,word,0c09955d
+
+//Force widescreen from the start
+patch=1,EE,21FB5830,byte,1
 
 [50 FPS]
 author=Snake356

--- a/patches/SLPM-65801_0CA02D02.pnach
+++ b/patches/SLPM-65801_0CA02D02.pnach
@@ -1,0 +1,8 @@
+gametitle=Crash Bandicoot 5 - Crash & Cortex no Yabou (SLPM-65801)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,2030AA44,word,00000001 //00000000
+patch=1,EE,20BD9F34,word,00000001 //00000000

--- a/patches/SLUS-20685_BDD9F5E1.pnach
+++ b/patches/SLUS-20685_BDD9F5E1.pnach
@@ -1,0 +1,8 @@
+gametitle=Ape Escape 2 (USA) (SLUS-20685)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,203E06A4,word,00000001 //00000000 Widescreen
+//patch=1,EE,20534720,word,00000004 //00000002 Widescreen

--- a/patches/SLUS-20909_8CFAB4EA.pnach
+++ b/patches/SLUS-20909_8CFAB4EA.pnach
@@ -1,11 +1,8 @@
+gametitle=Crash Twinsanity (v2.00) (SLUS-20909)
+
 [Widescreen 16:9]
-author=TechieSaru
 gsaspectratio=16:9
-patch=1,EE,20166EE4,extended,24060001
-patch=1,EE,20179994,extended,24020001
-patch=1,EE,2019B398,extended,24030001
-patch=1,EE,2019FFA4,extended,24020001
-patch=1,EE,201A0034,extended,24020001
-patch=1,EE,201A05E8,extended,24020001
-patch=1,EE,201A6F9C,extended,24030001
-patch=1,EE,202AEB54,extended,24020001
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,2030A744,word,00000001 //00000000
+patch=1,EE,20BE1DE4,word,00000001 //00000000

--- a/patches/SLUS-20909_B318AA3C.pnach
+++ b/patches/SLUS-20909_B318AA3C.pnach
@@ -1,11 +1,8 @@
+gametitle=Crash Twinsanity (v1.00) (SLUS-20909)
+
 [Widescreen 16:9]
-author=TechieSaru
 gsaspectratio=16:9
-patch=1,EE,20166EE4,extended,24060001
-patch=1,EE,20179994,extended,24020001
-patch=1,EE,2019B398,extended,24030001
-patch=1,EE,2019FFA4,extended,24020001
-patch=1,EE,201A0034,extended,24020001
-patch=1,EE,201A05E8,extended,24020001
-patch=1,EE,201A6F9C,extended,24030001
-patch=1,EE,202AEB54,extended,24020001
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,2030A144,word,00000001 //00000000
+patch=1,EE,20BE2BE4,word,00000001 //00000000

--- a/patches/SLUS-21423_7EA439F5.pnach
+++ b/patches/SLUS-21423_7EA439F5.pnach
@@ -2,8 +2,8 @@ gametitle=Grand Theft Auto: Liberty City Stories (SLUS-21423)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=nemesis2000
-comment=Select widescreen in game otherwise image is zoomed out 4:3
+author=nemesis2000 + CRASHARKI
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio.
 
 //widescreen fix
 patch=1,EE,002918d0,word,468010a0
@@ -57,6 +57,9 @@ patch=1,EE,0029198c,word,3c013f9d
 patch=1,EE,00291990,word,44810000
 patch=1,EE,00291994,word,0c0820e8
 patch=1,EE,00291998,word,46006302
+
+//Force widescreen from the begginning
+patch=1,EE,203D8B8A,byte,1
 
 [60 FPS]
 author=asasega

--- a/patches/SLUS-21590_4F32A11F.pnach
+++ b/patches/SLUS-21590_4F32A11F.pnach
@@ -2,8 +2,8 @@ gametitle=Grand Theft Auto: Vice City Stories (SLUS-21590)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=nemesis2000
-comment=Select widescreen in game otherwise image is zoomed out 4:3
+author=nemesis2000 + CRASHARKI
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio.
 
 //widescreen fix
 patch=1,EE,002653d8,word,3c013f9d
@@ -16,6 +16,9 @@ patch=1,EE,002653ec,word,e44c7484
 patch=1,EE,0037add4,word,0c0994f6
 patch=1,EE,003b9d14,word,0c0994f9
 patch=1,EE,003ba1b0,word,0c0994f9
+
+//Force widescreen from the start
+patch=1,EE,21FB5830,byte,1
 
 [60 FPS]
 author=asasega


### PR DESCRIPTION
Changes:

- Add Widescreen patches (+ fix existing ones) to Crash Twinsanity to run the game at 16:9 Widescreen Aspect Ratio from the start.
- Add Widescreen patches to Ape Escape 2 to run the game at 16:9 Widescreen Aspect Ratio from the start.
- Add Widescreen patches to Ape Escape 3 to run the game at 16:9 Widescreen Aspect Ratio from the start.
- Improve Widescreen patches to GTA Liberty City Stories to run the game at 16:9 Widescreen Aspect Ratio from the start.
- Improve Widescreen patches to GTA Vice City Stories to run the game at 16:9 Widescreen Aspect Ratio from the start.
- Tidy up.

All of the patches have been tested for all versions of the games, and relevant comments such as activating widescreen in-game or the need for EE Overclock have been added.