### PR TITLE
Add Spyro default TV mode (SLUS 20315)

### DIFF
--- a/patches/SLUS-20315_4B8E0DE8
+++ b/patches/SLUS-20315_4B8E0DE8
@@ -1,4 +1,5 @@
 gametitle=Spyro: Enter the Dragonfly (SLUS_20315)
 
 [Default Widescreen mode]
+gsaspectratio=16:9
 patch=0,EE,00198A64,short,00000030 // Default: 0x20 (4:3); 0x30 (16:9);

--- a/patches/SLUS-20315_4B8E0DE8
+++ b/patches/SLUS-20315_4B8E0DE8
@@ -1,0 +1,4 @@
+gametitle=Spyro: Enter the Dragonfly (SLUS_20315)
+
+[Default Widescreen mode]
+patch=0,EE,00198A64,short,00000030 // Default: 0x20 (4:3); 0x30 (16:9);


### PR DESCRIPTION
Sets, on boot the default screen mode for Spyro: Enter the Dragonfly to be set widescreen instead of standard.