### PR TITLE
Patches: Shadow Tower Abyss - Remove Scanmask Blur

### DIFF
--- a/patches/SLPS-25217_38145680.pnach
+++ b/patches/SLPS-25217_38145680.pnach
@@ -17,3 +17,7 @@ patch=1,EE,0010180c,word,00000000 //64420008
 patch=1,EE,001E8FB0,word,00000000
 
 
+[Remove Scanmask Blur]
+author=val & refraction
+description=Disables scanmask usage to reduce blur when turning.
+patch=1,EE,20158CA8,extended,24050004


### PR DESCRIPTION
Patch to remove scanmask usage from Shadow Tower Abyss. Same issue as #200 , patch is based off that one.


https://github.com/PCSX2/pcsx2_patches/assets/53349573/bed7e6ef-6dfc-496b-8321-b138a3767c2a

