### PR TITLE
Patches: Spyro Enter the Dragonfly widescreen patch

### DIFF
--- a/patches/SLES-51043_0EF1D4BA.pnach
+++ b/patches/SLES-51043_0EF1D4BA.pnach
@@ -1,0 +1,7 @@
+gametitle=Spyro - Enter the Dragonfly (SLES-51043)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=0,EE,00198E54,short,00000030 // Default: 0x20 (4:3); 0x30 (16:9);

--- a/patches/SLUS-20315_4B8E0DE8
+++ b/patches/SLUS-20315_4B8E0DE8
@@ -1,5 +1,0 @@
-gametitle=Spyro: Enter the Dragonfly (SLUS_20315)
-
-[Default Widescreen mode]
-gsaspectratio=16:9
-patch=0,EE,00198A64,short,00000030 // Default: 0x20 (4:3); 0x30 (16:9);

--- a/patches/SLUS-20315_4B8E0DE8.pnach
+++ b/patches/SLUS-20315_4B8E0DE8.pnach
@@ -1,0 +1,7 @@
+gametitle=Spyro - Enter the Dragonfly (SLUS-20315)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Muzzarino
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=0,EE,00198A64,short,00000030 // Default: 0x20 (4:3); 0x30 (16:9);


### PR DESCRIPTION
Changes:

- Improvements to the NTSC-U patch.
- Add patch to PAL version of the game.

All of the patches have been tested for all versions of the games, and relevant comments such as activating widescreen in-game or the need for EE Overclock have been added.