### PR TITLE
Restore unjustly removed twinsanity widescreen patches

### DIFF
--- a/patches/SLUS-20909_8CFAB4EA.pnach
+++ b/patches/SLUS-20909_8CFAB4EA.pnach
@@ -1,8 +1,13 @@
 gametitle=Crash Twinsanity (v2.00) (SLUS-20909)
 
 [Widescreen 16:9]
+author=TechieSaru
 gsaspectratio=16:9
-author=CRASHARKI
-comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
-patch=1,EE,2030A744,word,00000001 //00000000
-patch=1,EE,20BE1DE4,word,00000001 //00000000
+patch=1,EE,20166E64,extended,24060001
+patch=1,EE,201798AC,extended,24020001
+patch=1,EE,2019B270,extended,24030001
+patch=1,EE,2019FE7C,extended,24020001
+patch=1,EE,2019FF0C,extended,24020001
+patch=1,EE,201A04C0,extended,24020001
+patch=1,EE,201A6E74,extended,24030001
+patch=1,EE,202AE764,extended,24020001

--- a/patches/SLUS-20909_B318AA3C.pnach
+++ b/patches/SLUS-20909_B318AA3C.pnach
@@ -1,8 +1,13 @@
 gametitle=Crash Twinsanity (v1.00) (SLUS-20909)
 
 [Widescreen 16:9]
+author=TechieSaru
 gsaspectratio=16:9
-author=CRASHARKI
-comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
-patch=1,EE,2030A144,word,00000001 //00000000
-patch=1,EE,20BE2BE4,word,00000001 //00000000
+patch=1,EE,20166EE4,extended,24060001
+patch=1,EE,20179994,extended,24020001
+patch=1,EE,2019B398,extended,24030001
+patch=1,EE,2019FFA4,extended,24020001
+patch=1,EE,201A0034,extended,24020001
+patch=1,EE,201A05E8,extended,24020001
+patch=1,EE,201A6F9C,extended,24030001
+patch=1,EE,202AEB54,extended,24020001


### PR DESCRIPTION
I am re-submitting my (TechieSaru's) patches that I strongly believe were replaced with malicious intent for the following three reasons:

The uploader mentioned that their update was a "fix" and delibrately chose not to specify what it was "fixing"
BOTH patches were replaced
I was never directly informed that there was an issue with my patch
The patch I originally created was by request for a friend (Reverie). It was for v2.00 of crash twinsanity and my friend and myself verified that it worked fine.

Upon futher investigation, I figured out that the "fix" that the uploader was, again, being deceitful about, is due to my friend making an erroneus assumption that my hack worked for both versions of Twinsanity.

I have taken the opportunity to correct this error with my patch.