### PR TITLE
Patches: Various additions and improvements

### DIFF
--- a/patches/SLES-50649_DF96CC28.pnach
+++ b/patches/SLES-50649_DF96CC28.pnach
@@ -1,0 +1,9 @@
+gametitle=Taz Wanted (SLES-50649)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,203FEE00,word,00000910 //00000304 //HUD
+patch=1,EE,203FEE24,word,3FE81F26 //3FC39C01 //Rendering
+patch=1,EE,20412454,byte,1 //0 //In-game option

--- a/patches/SLES-54841_ECA6BFC5.pnach
+++ b/patches/SLES-54841_ECA6BFC5.pnach
@@ -1,7 +1,15 @@
 gametitle=Crash of the Titans (PAL)
 
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,21BD8268,byte,1 //00000000 //In-game option
+patch=1,EE,21BD82A2,byte,10 //40 //Zoom 1
+patch=1,EE,21BD82A8,word,3F000000 //3F2AAAAA //Zoom 2
+
 [50 FPS]
-//01 00 02 24 12 00 82 14 5C
 author=IWILLCRAFT
 description=Patches the game to run at 50 FPS (Might need 130% EE Overclock to be stable).
+//01 00 02 24 12 00 82 14 5C
 patch=1,EE,204924B8,extended,24020000 //24020001

--- a/patches/SLES-55204_0F89A154.pnach
+++ b/patches/SLES-55204_0F89A154.pnach
@@ -1,7 +1,17 @@
 gametitle=Crash - Mind Over Mutant (PAL)
 
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,21A2A0C8,byte,1 //00000000 //HUD
+patch=1,EE,21A2A102,byte,10 //40 //Zoom 1
+patch=1,EE,21A2A108,extended,3F000000 //3F2AAAAA //Zoom without Progressive Scan
+patch=1,EE,E0010001,extended,01A2A0A8 //Check if Progressive Scan is on
+patch=1,EE,21A2A108,extended,3F066666 //3F333333 //Zoom with Progressive Scan
+
 [50/60 FPS]
-//01 00 02 24 12 00 82
 author=IWILLCRAFT
 description=Patches the game to run at 50 FPS (Activate Progressive Scan for 60 FPS).
+//01 00 02 24 12 00 82
 patch=1,EE,20582168,extended,24020000 //24020001

--- a/patches/SLES-55204_0F89A154.pnach
+++ b/patches/SLES-55204_0F89A154.pnach
@@ -10,6 +10,8 @@ patch=1,EE,21A2A108,extended,3F000000 //3F2AAAAA //Zoom without Progressive Scan
 patch=1,EE,E0010001,extended,01A2A0A8 //Check if Progressive Scan is on
 patch=1,EE,21A2A108,extended,3F066666 //3F333333 //Zoom with Progressive Scan
 
+patch=1,EE,20715330,byte,1 //00000000 //Progressive Scan\60 FPS from the beginning
+
 [50/60 FPS]
 author=IWILLCRAFT
 description=Patches the game to run at 50 FPS (Activate Progressive Scan for 60 FPS).

--- a/patches/SLES-55204_0F89A154.pnach
+++ b/patches/SLES-55204_0F89A154.pnach
@@ -10,6 +10,9 @@ patch=1,EE,21A2A108,extended,3F000000 //3F2AAAAA //Zoom without Progressive Scan
 patch=1,EE,E0010001,extended,01A2A0A8 //Check if Progressive Scan is on
 patch=1,EE,21A2A108,extended,3F066666 //3F333333 //Zoom with Progressive Scan
 
+[Progressive Scan]
+author=CRASHARKI
+comment=Run the game with Progressive Scan enabled from the start.
 patch=1,EE,20715330,byte,1 //00000000 //Progressive Scan\60 FPS from the beginning
 
 [50/60 FPS]

--- a/patches/SLUS-20236_689339AC.pnach
+++ b/patches/SLUS-20236_689339AC.pnach
@@ -1,0 +1,9 @@
+gametitle=Taz Wanted (SLUS-20236)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,203FEF70,word,00000910 //00000304 //HUD
+patch=1,EE,203FEF94,word,3FE7E9B8 //3FC36507 //Rendering
+patch=1,EE,204125C4,byte,1 //0 //In-game option

--- a/patches/SLUS-21583_C6E85EF0.pnach
+++ b/patches/SLUS-21583_C6E85EF0.pnach
@@ -1,5 +1,13 @@
 gametitle=Crash of the Titans (NTSC-U)
 
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,21BD4F68,byte,1 //00000000 //In-game option
+patch=1,EE,21BD4FA2,byte,10 //40 //Zoom 1
+patch=1,EE,21BD4FA8,word,3F066666 //3F333333 //Zoom 2
+
 [60 FPS]
 author=asasega
 description=Patches the game to run at 60 FPS (Might need 130% EE Overclock to be stable).

--- a/patches/SLUS-21728_6A8448BA.pnach
+++ b/patches/SLUS-21728_6A8448BA.pnach
@@ -1,5 +1,13 @@
 gametitle=Crash - Mind Over Mutant (NTSC-U)
 
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,21A2A3B8,byte,1 //00000000 //HUD
+patch=1,EE,21A2A3F2,byte,10 //40 //Zoom 1
+patch=1,EE,21A2A3F8,word,3F066666 //3F333333 //Zoom 2
+
 [60 FPS]
 author=asasega
 description=Patches the game to run at 60 FPS.

--- a/patches/SLUS-21728_6A8448BA.pnach
+++ b/patches/SLUS-21728_6A8448BA.pnach
@@ -8,6 +8,11 @@ patch=1,EE,21A2A3B8,byte,1 //00000000 //HUD
 patch=1,EE,21A2A3F2,byte,10 //40 //Zoom 1
 patch=1,EE,21A2A3F8,word,3F066666 //3F333333 //Zoom 2
 
+[Progressive Scan]
+author=CRASHARKI
+comment=Run the game with Progressive Scan enabled from the start.
+patch=1,EE,207155B0,byte,1 //00000000 //Progressive Scan from the beginning
+
 [60 FPS]
 author=asasega
 description=Patches the game to run at 60 FPS.


### PR DESCRIPTION
Changes:

- Add Widescreen patches to Taz Wanted to run the game at 16:9 Widescreen Aspect Ratio from the start.
- Add Widescreen patches to Crash of the Titans to run the game at 16:9 Widescreen Aspect Ratio from the start.
- Add Widescreen patches to Crash Mind Over Mutant to run the game at 16:9 Widescreen Aspect Ratio from the start.

All of the patches have been tested for all versions of the games, and relevant comments such as activating widescreen in-game or the need for EE Overclock have been added.