### PR TITLE
Patches: Fix Crash Twinsanity widescreen patches again

### DIFF
--- a/patches/SLES-52568_1510E1D1.pnach
+++ b/patches/SLES-52568_1510E1D1.pnach
@@ -5,4 +5,3 @@ gsaspectratio=16:9
 author=CRASHARKI
 comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
 patch=1,EE,2030AAC4,word,00000001 //00000000
-patch=1,EE,20BEAF64,word,00000001 //00000000

--- a/patches/SLPM-65801_0CA02D02.pnach
+++ b/patches/SLPM-65801_0CA02D02.pnach
@@ -5,4 +5,3 @@ gsaspectratio=16:9
 author=CRASHARKI
 comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
 patch=1,EE,2030AA44,word,00000001 //00000000
-patch=1,EE,20BD9F34,word,00000001 //00000000

--- a/patches/SLUS-20909_8CFAB4EA.pnach
+++ b/patches/SLUS-20909_8CFAB4EA.pnach
@@ -2,13 +2,6 @@ gametitle=Crash Twinsanity (v2.00) (SLUS-20909)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=TechieSaru
-comment=Forces the game into widescreen mode
-patch=1,EE,20166E64,extended,24060001
-patch=1,EE,201798AC,extended,24020001
-patch=1,EE,2019B270,extended,24030001
-patch=1,EE,2019FE7C,extended,24020001
-patch=1,EE,2019FF0C,extended,24020001
-patch=1,EE,201A04C0,extended,24020001
-patch=1,EE,201A6E74,extended,24030001
-patch=1,EE,202AE764,extended,24020001
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,2030A744,word,00000001 //00000000

--- a/patches/SLUS-20909_B318AA3C.pnach
+++ b/patches/SLUS-20909_B318AA3C.pnach
@@ -2,13 +2,6 @@ gametitle=Crash Twinsanity (v1.00) (SLUS-20909)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=TechieSaru
-comment=Forces the game into widescreen mode
-patch=1,EE,20166EE4,extended,24060001
-patch=1,EE,20179994,extended,24020001
-patch=1,EE,2019B398,extended,24030001
-patch=1,EE,2019FFA4,extended,24020001
-patch=1,EE,201A0034,extended,24020001
-patch=1,EE,201A05E8,extended,24020001
-patch=1,EE,201A6F9C,extended,24030001
-patch=1,EE,202AEB54,extended,24020001
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,2030A144,word,00000001 //00000000


### PR DESCRIPTION
The (NTSC-U) patches are now officially fundamentally broken.

The 1.0 version of the game greets you with this mess (and if you continue the game crashes):
![Crash Twinsanity_SLUS-20909_20231104095721](https://github.com/PCSX2/pcsx2_patches/assets/126416290/1b1511f2-717c-40b1-828e-c772c414b202)
And this is what it should look like (And what it looks like with my patch):
![Crash Twinsanity_SLUS-20909_20231104100726](https://github.com/PCSX2/pcsx2_patches/assets/126416290/93946a58-be32-4295-a81a-43091726d1a9)

And 2.0 version doesn't even go past a black screen.

And after a quick check, one of the lines in my patches wasn't necessary, so now there's no more writing to dynamically allocated memory, and therefore my patches only include a single line, that's why I'm updating not only the broken patches but all four of them.