### PR TITLE
Patches: Crash of the Titans and Crash Mind Over Mutant missing versions

### DIFF
--- a/patches/SLES-54842_B4B4E877.pnach
+++ b/patches/SLES-54842_B4B4E877.pnach
@@ -4,12 +4,12 @@ gametitle=Crash of the Titans (PAL)
 gsaspectratio=16:9
 author=CRASHARKI
 comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
-patch=1,EE,21BD8268,byte,1 //00000000 //In-game option
-patch=1,EE,21BD82A2,byte,10 //40 //Zoom 1
-patch=1,EE,21BD82A8,word,3F000000 //3F2AAAAA //Zoom 2
+patch=1,EE,21BD74E8,byte,1 //00000000 //In-game option
+patch=1,EE,21BD7522,byte,10 //40 //Zoom 1
+patch=1,EE,21BD7528,word,3F000000 //3F2AAAAA //Zoom 2
 
 [50 FPS]
-author=IWILLCRAFT
+author=CRASHARKI
 description=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
 //01 00 02 24 12 00 82 14 5C
-patch=1,EE,204924B8,extended,24020000 //24020001
+patch=1,EE,20491CC8,extended,24020000 //24020001

--- a/patches/SLES-54843_AEFD7D25.pnach
+++ b/patches/SLES-54843_AEFD7D25.pnach
@@ -4,12 +4,12 @@ gametitle=Crash of the Titans (PAL)
 gsaspectratio=16:9
 author=CRASHARKI
 comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
-patch=1,EE,21BD8268,byte,1 //00000000 //In-game option
-patch=1,EE,21BD82A2,byte,10 //40 //Zoom 1
-patch=1,EE,21BD82A8,word,3F000000 //3F2AAAAA //Zoom 2
+patch=1,EE,21BD81E8,byte,1 //00000000 //In-game option
+patch=1,EE,21BD8222,byte,10 //40 //Zoom 1
+patch=1,EE,21BD8228,word,3F000000 //3F2AAAAA //Zoom 2
 
 [50 FPS]
-author=IWILLCRAFT
+author=CRASHARKI
 description=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
 //01 00 02 24 12 00 82 14 5C
-patch=1,EE,204924B8,extended,24020000 //24020001
+patch=1,EE,20492588,extended,24020000 //24020001

--- a/patches/SLES-55205_0F89A154.pnach
+++ b/patches/SLES-55205_0F89A154.pnach
@@ -1,0 +1,22 @@
+gametitle=Crash - Mind Over Mutant (PAL)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,21A2A0C8,byte,1 //00000000 //HUD
+patch=1,EE,21A2A102,byte,10 //40 //Zoom 1
+patch=1,EE,21A2A108,extended,3F000000 //3F2AAAAA //Zoom without Progressive Scan
+patch=1,EE,E0010001,extended,01A2A0A8 //Check if Progressive Scan is on
+patch=1,EE,21A2A108,extended,3F066666 //3F333333 //Zoom with Progressive Scan
+
+[Progressive Scan]
+author=CRASHARKI
+comment=Run the game with Progressive Scan enabled from the start.
+patch=1,EE,20715330,byte,1 //00000000 //Progressive Scan\60 FPS from the beginning
+
+[50/60 FPS]
+author=IWILLCRAFT
+description=Patches the game to run at 50 FPS (Activate Progressive Scan for 60 FPS).
+//01 00 02 24 12 00 82
+patch=1,EE,20582168,extended,24020000 //24020001

--- a/patches/SLES-55206_0F89A154.pnach
+++ b/patches/SLES-55206_0F89A154.pnach
@@ -1,0 +1,22 @@
+gametitle=Crash - Mind Over Mutant (PAL)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,21A2A0C8,byte,1 //00000000 //HUD
+patch=1,EE,21A2A102,byte,10 //40 //Zoom 1
+patch=1,EE,21A2A108,extended,3F000000 //3F2AAAAA //Zoom without Progressive Scan
+patch=1,EE,E0010001,extended,01A2A0A8 //Check if Progressive Scan is on
+patch=1,EE,21A2A108,extended,3F066666 //3F333333 //Zoom with Progressive Scan
+
+[Progressive Scan]
+author=CRASHARKI
+comment=Run the game with Progressive Scan enabled from the start.
+patch=1,EE,20715330,byte,1 //00000000 //Progressive Scan\60 FPS from the beginning
+
+[50/60 FPS]
+author=IWILLCRAFT
+description=Patches the game to run at 50 FPS (Activate Progressive Scan for 60 FPS).
+//01 00 02 24 12 00 82
+patch=1,EE,20582168,extended,24020000 //24020001


### PR DESCRIPTION
Changes:

- Add missing patches to Russian and Scandinavian versions of Crash of the Titans.
- Add missing patches to Russian and Scandinavian versions of Crash Mind Over Mutant.
- Changed the EE Overclock recommendation to Crash of the Titans.

All of the patches have been tested for all versions of the games, and relevant comments such as activating widescreen in-game or the need for EE Overclock have been added.