### PR TITLE
Maintain patches for Armored Core games

### DIFF
--- a/patches/SLPS-25338_26D1C561.pnach
+++ b/patches/SLPS-25338_26D1C561.pnach
@@ -2,35 +2,26 @@ gametitle=Armored Core - Nexus - Disc 1 - Evolution [NTSC-J] (SLPS-25338)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
-
-// 16:9
-patch=1,EE,0023f6bc,word,3c013f40 // 00000000 hor fov menu
-patch=1,EE,0023f6c8,word,44810000 // 00000000
-patch=1,EE,0023f6cc,word,4600c602 // 00000000
-patch=1,EE,00120f70,word,3c033f19 // 3c033f4c hor fov gameplay
-patch=1,EE,00120f78,word,3462999a // 3462cccd hor fov gameplay
-patch=1,EE,00158370,word,3c0243d6 // 3c0243a0 renderfix
-
-// 16:10
-//patch=1,EE,0023f6bc,word,3c013f55 // 00000000 hor fov menu
-//patch=1,EE,0023f6c0,word,34215555 // 00000000 hor fov menu
-//patch=1,EE,0023f6c8,word,44810000 // 00000000
-//patch=1,EE,0023f6cc,word,4600c602 // 00000000
-//patch=1,EE,00120f70,word,3c033f2a // 3c033f4c hor fov gameplay
-//patch=1,EE,00120f78,word,3462aaab // 3462cccd hor fov gameplay
-//patch=1,EE,00158370,word,3c0243c1 // 3c0243a0 renderfix
+description=Widescreen Hack
+patch=1,EE,00120F70,extended,00000019 // 3C033F4C hor fov gameplay
+patch=1,EE,10120F78,extended,0000999A // 3462CCCD hor fov gameplay
+patch=1,EE,00158370,extended,000000D6 // 3C0243A0 renderfix
+patch=1,EE,C1E15D18,extended,3C023F80
+patch=1,EE,01E15D18,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-patch=1,EE,0023C2DC,word,00000000
+patch=1,EE,D0487740,extended,01100000
+patch=1,EE,0023C2DC,extended,00000001
+patch=1,EE,D0487740,extended,01000000
+patch=1,EE,0023C2DC,extended,00000000
 
 [Remove Blur]
 author=001 & Berylskid
 description=Removes blur effects.
 patch=1,EE,201317F0,extended,00000000
-patch=1,EE,E0020000,extended,10487740
+patch=1,EE,D0487740,extended,02100000
 patch=1,EE,61CC66E8,extended,00000000
 patch=1,EE,00000001,extended,0000005F
 

--- a/patches/SLPS-25339_26D1C561.pnach
+++ b/patches/SLPS-25339_26D1C561.pnach
@@ -2,35 +2,26 @@ gametitle=Armored Core - Nexus - Disc 2 - Revolution [NTSC-J] (SLPS-25339)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
-
-// 16:9
-patch=1,EE,0023f6bc,word,3c013f40 // 00000000 hor fov menu
-patch=1,EE,0023f6c8,word,44810000 // 00000000
-patch=1,EE,0023f6cc,word,4600c602 // 00000000
-patch=1,EE,00120f70,word,3c033f19 // 3c033f4c hor fov gameplay
-patch=1,EE,00120f78,word,3462999a // 3462cccd hor fov gameplay
-patch=1,EE,00158370,word,3c0243d6 // 3c0243a0 renderfix
-
-// 16:10
-//patch=1,EE,0023f6bc,word,3c013f55 // 00000000 hor fov menu
-//patch=1,EE,0023f6c0,word,34215555 // 00000000 hor fov menu
-//patch=1,EE,0023f6c8,word,44810000 // 00000000
-//patch=1,EE,0023f6cc,word,4600c602 // 00000000
-//patch=1,EE,00120f70,word,3c033f2a // 3c033f4c hor fov gameplay
-//patch=1,EE,00120f78,word,3462aaab // 3462cccd hor fov gameplay
-//patch=1,EE,00158370,word,3c0243c1 // 3c0243a0 renderfix
+description=Widescreen Hack
+patch=1,EE,00120F70,extended,00000019 // 3C033F4C hor fov gameplay
+patch=1,EE,10120F78,extended,0000999A // 3462CCCD hor fov gameplay
+patch=1,EE,00158370,extended,000000D6 // 3C0243A0 renderfix
+patch=1,EE,C1E15D18,extended,3C023F80
+patch=1,EE,01E15D18,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-patch=1,EE,0023C2DC,word,00000000
+patch=1,EE,D0487740,extended,01100000
+patch=1,EE,0023C2DC,extended,00000001
+patch=1,EE,D0487740,extended,01000000
+patch=1,EE,0023C2DC,extended,00000000
 
 [Remove Blur]
 author=001 & Berylskid
 description=Removes blur effects.
 patch=1,EE,201317F0,extended,00000000
-patch=1,EE,E0020000,extended,10487740
+patch=1,EE,D0487740,extended,02100000
 patch=1,EE,61CC66E8,extended,00000000
 patch=1,EE,00000001,extended,0000005F
 

--- a/patches/SLPS-25408_5C4E1AC4.pnach
+++ b/patches/SLPS-25408_5C4E1AC4.pnach
@@ -2,34 +2,22 @@ gametitle=Armored Core - Nine Breaker [NTSC-J] (SLPS-25408)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
-
-// 16:9
-patch=1,EE,00139fac,word,3c013f40 // 00000000 hor fov menu
-patch=1,EE,00139fb8,word,44810000 // 00000000
-patch=1,EE,00139fbc,word,4600c602 // 00000000
-patch=1,EE,00171790,word,3c033f19 // 3c033f4c hor fov gameplay
-patch=1,EE,00171798,word,3462999a // 3462cccd hor fov gameplay
-patch=1,EE,001a78c0,word,3c0243d6 // 3c0243a0 renderfix
-
-// 16:10
-//patch=1,EE,00139fac,word,3c013f55 // 00000000 hor fov menu
-//patch=1,EE,00139fb0,word,34215555 // 00000000 hor fov menu
-//patch=1,EE,00139fb8,word,44810000 // 00000000
-//patch=1,EE,00139fbc,word,4600c602 // 00000000
-//patch=1,EE,00171790,word,3c033f2a // 3c033f4c hor fov gameplay
-//patch=1,EE,00171798,word,3462aaab // 3462cccd hor fov gameplay
-//patch=1,EE,001a78c0,word,3c0243c1 // 3c0243a0 renderfix
+description=Widescreen Hack
+patch=1,EE,00171790,extended,00000019 // 3C033F4C hor fov gameplay
+patch=1,EE,10171798,extended,0000999A // 3462CCCD hor fov gameplay
+patch=1,EE,001A78C0,extended,000000D6 // 3C0243A0 renderfix
+patch=1,EE,C1EC6DA8,extended,3C023F80
+patch=1,EE,01EC6DA8,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-patch=1,EE,0011F014,word,00000000
+patch=1,EE,2011F014,extended,00000000
 
 [Remove Blur]
 author=001 & Berylskid
 description=Removes blur effects.
-patch=1,EE,E0020000,extended,1027CC74
+patch=1,EE,D027CC74,extended,02100000
 patch=1,EE,61D8D4C8,extended,00000000
 patch=1,EE,00000001,extended,0000005F
 

--- a/patches/SLPS-25461_3E26EEEB.pnach
+++ b/patches/SLPS-25461_3E26EEEB.pnach
@@ -2,39 +2,27 @@ gametitle=Armored Core - Formula Front [NTSC-J] (SLPS-25461)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
-
-// 16:9
-patch=1,EE,0013e12c,word,3c013f40 // 00000000 hor fov menu
-patch=1,EE,0013e138,word,44810000 // 00000000
-patch=1,EE,0013e13c,word,4600c602 // 00000000
-patch=1,EE,001d84d0,word,3c033f19 // 3c033f4c hor fov gameplay
-patch=1,EE,001d84d8,word,3462999a // 3462cccd hor fov gameplay
-patch=1,EE,00201e70,word,3c0243d6 // 3c0243a0 renderfix
-
-// 16:10
-//patch=1,EE,0013e12c,word,3c013f55 // 00000000 hor fov menu
-//patch=1,EE,0013e130,word,34215555 // 00000000
-//patch=1,EE,0013e138,word,44810000 // 00000000
-//patch=1,EE,0013e13c,word,4600c602 // 00000000
-//patch=1,EE,001d84d0,word,3c033f2a // 3c033f4c hor fov gameplay
-//patch=1,EE,001d84d8,word,3462aaab // 3462cccd hor fov gameplay
-//patch=1,EE,00201e70,word,3c0243c1 // 3c0243a0 renderfix
+description=Widescreen Hack
+patch=1,EE,001D84D0,extended,00000019 // 3C033F4C hor fov gameplay
+patch=1,EE,101D84D8,extended,0000999A // 3462CCCD hor fov gameplay
+patch=1,EE,00201E70,extended,000000D6 // 3C0243A0 renderfix
+patch=1,EE,C1D10978,extended,3C023F80
+patch=1,EE,01D10978,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-patch=1,EE,00128CBC,word,00000000
+patch=1,EE,20128CBC,extended,00000000
 
 [Remove Blur]
 author=001 & Berylskid
 description=Removes blur effects.
-patch=1,EE,E0020000,extended,102C0B54
+patch=1,EE,D02C0B54,extended,02100000
 patch=1,EE,61C07A08,extended,00000000
 patch=1,EE,00000001,extended,0000005F
 
 [Correct HUD]
 author=001 & Berylskid
 description=Removes HUD artifacts on hardware renderer.
-patch=1,EE,D1CCE7FA,extended,00001040
+patch=1,EE,D1CCE7FA,extended,01001040
 patch=1,EE,01CCE7FA,extended,00000000

--- a/patches/SLUS-20986_7E5F690C.pnach
+++ b/patches/SLUS-20986_7E5F690C.pnach
@@ -2,24 +2,26 @@ gametitle=Armored Core - Nexus SLUS_209.86
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack
-patch=1,EE,001211c8,word,3c023f22
-patch=1,EE,01e16348,word,3c023f40
-patch=1,EE,202B757C,word,43C00000
+description=Widescreen Hack
+patch=1,EE,001211D0,extended,00000019 // 3C033F4C hor fov gameplay
+patch=1,EE,101211D8,extended,0000999A // 3462CCCD hor fov gameplay
+patch=1,EE,001587C0,extended,000000D6 // 3C0243A0 renderfix
+patch=1,EE,C1E16348,extended,3C023F80
+patch=1,EE,01E16348,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-patch=1,EE,E0011400,extended,002C1050
-patch=1,EE,2023C9AC,extended,30420001
-patch=1,EE,E0019000,extended,002C1050
-patch=1,EE,2023C9AC,extended,30420000
+patch=1,EE,D02C1050,extended,01001400
+patch=1,EE,0023C9AC,extended,00000001
+patch=1,EE,D02C1050,extended,01009000
+patch=1,EE,0023C9AC,extended,00000000
 
 [Remove Blur]
 author=001 & Berylskid
 description=Removes blur effects.
 patch=1,EE,20131AB0,extended,00000000
-patch=1,EE,E0020000,extended,10298C50
+patch=1,EE,D0298C50,extended,02100000
 patch=1,EE,61CC6EE8,extended,00000000
 patch=1,EE,00000001,extended,0000005F
 

--- a/patches/SLUS-21079_7E5F690C.pnach
+++ b/patches/SLUS-21079_7E5F690C.pnach
@@ -2,24 +2,26 @@ gametitle=Armored Core - Nexus SLUS_210.79
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack
-patch=1,EE,001211c8,word,3c023f22
-patch=1,EE,01e16348,word,3c023f40
-patch=1,EE,202B757C,word,43C00000
+description=Widescreen Hack
+patch=1,EE,001211D0,extended,00000019 // 3C033F4C hor fov gameplay
+patch=1,EE,101211D8,extended,0000999A // 3462CCCD hor fov gameplay
+patch=1,EE,001587C0,extended,000000D6 // 3C0243A0 renderfix
+patch=1,EE,C1E16348,extended,3C023F80
+patch=1,EE,01E16348,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-patch=1,EE,E0011400,extended,002C1050
-patch=1,EE,2023C9AC,extended,30420001
-patch=1,EE,E0019000,extended,002C1050
-patch=1,EE,2023C9AC,extended,30420000
+patch=1,EE,D02C1050,extended,01001400
+patch=1,EE,0023C9AC,extended,00000001
+patch=1,EE,D02C1050,extended,01009000
+patch=1,EE,0023C9AC,extended,00000000
 
 [Remove Blur]
 author=001 & Berylskid
 description=Removes blur effects.
 patch=1,EE,20131AB0,extended,00000000
-patch=1,EE,E0020000,extended,10298C50
+patch=1,EE,D0298C50,extended,02100000
 patch=1,EE,61CC6EE8,extended,00000000
 patch=1,EE,00000001,extended,0000005F
 

--- a/patches/SLUS-21200_72486978.pnach
+++ b/patches/SLUS-21200_72486978.pnach
@@ -2,20 +2,22 @@ gametitle=Armored Core - Nine Breaker SLUS_212.00
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack
-patch=1,EE,00172538,word,3c023f22
-patch=1,EE,01ec2218,word,3c023f40
-patch=1,EE,202B067C,word,43c00000
+description=Widescreen Hack
+patch=1,EE,00172540,extended,00000019 // 3C033F4C hor fov gameplay
+patch=1,EE,10172548,extended,0000999A // 3462CCCD hor fov gameplay
+patch=1,EE,001A8670,extended,000000D6 // 3C0243A0 renderfix
+patch=1,EE,C1EC2218,extended,3C023F80
+patch=1,EE,01EC2218,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-patch=1,EE,0011F014,word,00000000
+patch=1,EE,2011F014,extended,00000000
 
 [Remove Blur]
 author=001 & Berylskid
 description=Removes blur effects.
-patch=1,EE,E0020000,extended,1027CD3C
+patch=1,EE,D027CD3C,extended,02100000
 patch=1,EE,61D8A268,extended,00000000
 patch=1,EE,00000001,extended,0000005F
 


### PR DESCRIPTION
Overhauled Widescreen patches and No-interlace patches of these games:
- Armored Core - Nexus
- Armored Core - Nine Breaker
- Armored Core - Formula Front

Note: Only for NTSC-J and NTSC-U.