### PR TITLE
Add various patches for PAL Armored Core games

### DIFF
--- a/patches/SLES-53819_98BE10F8.pnach
+++ b/patches/SLES-53819_98BE10F8.pnach
@@ -2,23 +2,29 @@ gametitle=Armored Core - Nine Breaker (PAL-E) (SLES-53819)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
+description=Widescreen Hack
+patch=1,EE,00172570,extended,00000019 // 3C033F4C hor fov gameplay
+patch=1,EE,10172578,extended,0000999A // 3462CCCD hor fov gameplay
+patch=1,EE,001A8760,extended,000000D6 // 3C0243A0 renderfix
+patch=1,EE,C1EC2C88,extended,3C023F80
+patch=1,EE,01EC2C88,extended,00000040 // 3C023F80 hor fov menu
 
-// 16:9
-patch=1,EE,00139fac,word,3c013f40 // 00000000 hor fov menu
-patch=1,EE,00139fb8,word,44810000 // 00000000
-patch=1,EE,00139fbc,word,4600c602 // 00000000
-patch=1,EE,00172570,word,3c033f19 // 3c033f4c hor fov gameplay
-patch=1,EE,00172578,word,3462999a // 3462cccd hor fov gameplay
-patch=1,EE,001a8760,word,3c0243d6 // 3c0243a0 renderfix
+[No-Interlacing]
+description=Attempts to disable interlaced offset rendering.
+gsinterlacemode=1
+patch=1,EE,D1DF6722,extended,0100656D
+patch=1,EE,0011F014,extended,00000001
+patch=1,EE,D1DF6722,extended,01006F73
+patch=1,EE,0011F014,extended,00000000
 
-// 16:10
-//patch=1,EE,00139fac,word,3c013f55 // 00000000 hor fov menu
-//patch=1,EE,00139fb0,word,34215555 // 00000000 hor fov menu
-//patch=1,EE,00139fb8,word,44810000 // 00000000
-//patch=1,EE,00139fbc,word,4600c602 // 00000000
-//patch=1,EE,00172570,word,3c033f2a // 3c033f4c hor fov gameplay
-//patch=1,EE,00172578,word,3462aaab // 3462cccd hor fov gameplay
-//patch=1,EE,001a8760,word,3c0243c1 // 3c0243a0 renderfix
+[Remove Blur]
+author=001 & Berylskid
+description=Removes blur effects.
+patch=1,EE,D1DF6722,extended,02006F73
+patch=1,EE,61D8AA68,extended,00000000
+patch=1,EE,00000001,extended,0000005F
 
-
+[Correct HUD]
+author=001 & Berylskid
+description=Removes HUD artifacts on hardware renderer.
+patch=1,EE,0024839A,extended,00000000

--- a/patches/SLES-82036_F3A5EC6F.pnach
+++ b/patches/SLES-82036_F3A5EC6F.pnach
@@ -2,23 +2,30 @@ gametitle=Armored Core - Nexus - Disc 1 - Evolution (PAL-M5) (SLES-82036)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
+description=Widescreen Hack
+patch=1,EE,001211D0,extended,00000019 // 3C033F4C hor fov gameplay
+patch=1,EE,101211D8,extended,0000999A // 3462CCCD hor fov gameplay
+patch=1,EE,00158880,extended,000000D6 // 3C0243A0 renderfix
+patch=1,EE,C1E16E68,extended,3C023F80
+patch=1,EE,01E16E68,extended,00000040 // 3C023F80 hor fov menu
 
-// 16:9
-patch=1,EE,0024070c,word,3c013f40 // 00000000 hor fov menu
-patch=1,EE,00240718,word,44810000 // 00000000
-patch=1,EE,0024071c,word,4600c602 // 00000000
-patch=1,EE,001211d0,word,3c033f19 // 3c033f4c hor fov gameplay
-patch=1,EE,001211d8,word,3462999a // 3462cccd hor fov gameplay
-patch=1,EE,00158880,word,3c0243d6 // 3c0243a0 renderfix
+[No-Interlacing]
+description=Attempts to disable interlaced offset rendering.
+gsinterlacemode=1
+patch=1,EE,D1D47A22,extended,0100656D
+patch=1,EE,0023D32C,extended,00000001
+patch=1,EE,D1D47A22,extended,01006F73
+patch=1,EE,0023D32C,extended,00000000
 
-// 16:10
-//patch=1,EE,0024070c,word,3c013f55 // 00000000 hor fov menu
-//patch=1,EE,00240710,word,34215555 // 00000000 hor fov menu
-//patch=1,EE,00240718,word,44810000 // 00000000
-//patch=1,EE,0024071c,word,4600c602 // 00000000
-//patch=1,EE,001211d0,word,3c033f2a // 3c033f4c hor fov gameplay
-//patch=1,EE,001211d8,word,3462aaab // 3462cccd hor fov gameplay
-//patch=1,EE,00158880,word,3c0243c1 // 3c0243a0 renderfix
+[Remove Blur]
+author=001 & Berylskid
+description=Removes blur effects.
+patch=1,EE,20131AB0,extended,00000000
+patch=1,EE,D1D47A22,extended,02006F73
+patch=1,EE,61CC76E8,extended,00000000
+patch=1,EE,00000001,extended,0000005F
 
-
+[Correct HUD]
+author=001 & Berylskid
+description=Removes HUD artifacts on hardware renderer.
+patch=1,EE,0020A2DA,extended,00000000

--- a/patches/SLES-82037_F3A5EC6F.pnach
+++ b/patches/SLES-82037_F3A5EC6F.pnach
@@ -2,23 +2,30 @@ gametitle=Armored Core - Nexus - Disc 2 - Revolution (PAL-M5) (SLES-82037)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
+description=Widescreen Hack
+patch=1,EE,001211D0,extended,00000019 // 3C033F4C hor fov gameplay
+patch=1,EE,101211D8,extended,0000999A // 3462CCCD hor fov gameplay
+patch=1,EE,00158880,extended,000000D6 // 3C0243A0 renderfix
+patch=1,EE,C1E16E68,extended,3C023F80
+patch=1,EE,01E16E68,extended,00000040 // 3C023F80 hor fov menu
 
-// 16:9
-patch=1,EE,0024070c,word,3c013f40 // 00000000 hor fov menu
-patch=1,EE,00240718,word,44810000 // 00000000
-patch=1,EE,0024071c,word,4600c602 // 00000000
-patch=1,EE,001211d0,word,3c033f19 // 3c033f4c hor fov gameplay
-patch=1,EE,001211d8,word,3462999a // 3462cccd hor fov gameplay
-patch=1,EE,00158880,word,3c0243d6 // 3c0243a0 renderfix
+[No-Interlacing]
+description=Attempts to disable interlaced offset rendering.
+gsinterlacemode=1
+patch=1,EE,D1D47A22,extended,0100656D
+patch=1,EE,0023D32C,extended,00000001
+patch=1,EE,D1D47A22,extended,01006F73
+patch=1,EE,0023D32C,extended,00000000
 
-// 16:10
-//patch=1,EE,0024070c,word,3c013f55 // 00000000 hor fov menu
-//patch=1,EE,00240710,word,34215555 // 00000000 hor fov menu
-//patch=1,EE,00240718,word,44810000 // 00000000
-//patch=1,EE,0024071c,word,4600c602 // 00000000
-//patch=1,EE,001211d0,word,3c033f2a // 3c033f4c hor fov gameplay
-//patch=1,EE,001211d8,word,3462aaab // 3462cccd hor fov gameplay
-//patch=1,EE,00158880,word,3c0243c1 // 3c0243a0 renderfix
+[Remove Blur]
+author=001 & Berylskid
+description=Removes blur effects.
+patch=1,EE,20131AB0,extended,00000000
+patch=1,EE,D1D47A22,extended,02006F73
+patch=1,EE,61CC76E8,extended,00000000
+patch=1,EE,00000001,extended,0000005F
 
-
+[Correct HUD]
+author=001 & Berylskid
+description=Removes HUD artifacts on hardware renderer.
+patch=1,EE,0020A2DA,extended,00000000


### PR DESCRIPTION
For below two PAL games, rewrote Widescreen patch and added No-Interlacing patch, Blur Removal patch, and Fixing HUD patch.
- Armored Core Nexus (Disc 1 and 2)
- Armored Core Nine Breaker

Note:
- I used Blockdumps and SaveStates coming from another user for writing & testing patches.
- As far as I tested, all patches work on both frame rate modes (50Hz and 60Hz).