### PR TITLE
Midnight club 2 and 3 widescreen correction

### DIFF
--- a/patches/SLES-51054_ACB1989A.pnach
+++ b/patches/SLES-51054_ACB1989A.pnach
@@ -1,14 +1,17 @@
-gametitle=Midnight Club II (E)(SLES-51054)
+gametitle=Midnight Club II (PAL-M) SLES-51054 ACB1989A
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PeterDelta
-comment=Widescreen hack 16:9
-patch=1,EE,0042F134,word,3FCE38BC //3F955553
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,0042F134,word,3FC71CEA //3F955553
+patch=1,EE,001C74E0,word,3C013F77 //3C013F80
+patch=1,EE,001C7E80,word,3C013EC0 //3C013F00
+patch=1,EE,001C81F4,word,3C013EC5 //3C013F00
 
 [50 FPS]
 author=PeterDelta
-comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,0042F138,extended,00000001
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0042F138,word,00000001
 patch=1,EE,00431804,word,3F000000 //3F800000
 patch=1,EE,004317D4,word,3CA08889 //3C888889

--- a/patches/SLES-51054_ACB1989A.pnach
+++ b/patches/SLES-51054_ACB1989A.pnach
@@ -5,9 +5,6 @@ gsaspectratio=16:9
 author=PeterDelta
 comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,0042F134,word,3FC71CEA //3F955553
-patch=1,EE,001C74E0,word,3C013F77 //3C013F80
-patch=1,EE,001C7E80,word,3C013EC0 //3C013F00
-patch=1,EE,001C81F4,word,3C013EC5 //3C013F00
 
 [50 FPS]
 author=PeterDelta

--- a/patches/SLES-52942_EBE1972D.pnach
+++ b/patches/SLES-52942_EBE1972D.pnach
@@ -1,12 +1,12 @@
-gametitle=Midnight Club 3 - DUB Edition (E)(SLES-52942)
+gametitle=Midnight Club 3 - DUB Edition (E)(SLES-52942) EBE1972D
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PeterDelta
-comment=Widescreen hack 16:9
-patch=1,EE,00617D30,word,3FCE38BD //3F955554
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,00617D30,word,3FC71CEB //3F955554
 
 [50 FPS]
 author=PeterDelta
-comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
+comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
 patch=1,EE,00617D34,word,00000001 //00000002 srl zero,0x00

--- a/patches/SLUS-20209_E5F2DF38.pnach
+++ b/patches/SLUS-20209_E5F2DF38.pnach
@@ -1,13 +1,13 @@
-gametitle=Midnight Club II (U)(SLUS-20209)
+gametitle=Midnight Club II (U)(SLUS-20209) E5F2DF38
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PeterDelta
-comment=Widescreen hack 16:9
-patch=1,EE,0042FAB4,word,3FCE38BC
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,0042FAB4,word,3FC71CEA //3F955553
 
 [60 FPS]
 author=asasega
-comment=Unlocked at 60 FPS. Might need enable EE Overclock to be stable.
+comment=Unlocked at 60 FPS. Might need enable 130% EE Overclock to be stable.
 patch=1,EE,2042FAB8,word,00000001 //FPS
 patch=1,EE,20432164,word,3C888889

--- a/patches/SLUS-21029_0DD3417A.pnach
+++ b/patches/SLUS-21029_0DD3417A.pnach
@@ -1,12 +1,12 @@
-gametitle=Midnight Club 3 - DUB Edition (NTSC-U) SLUS-21029 4A0E5B3A v1.0
+gametitle=Midnight Club 3 - DUB Edition (NTSC-U) SLUS-21029 0DD3417A v2.0
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PeterDelta
 comment=Renders the game in 16:9 aspect ratio
-patch=1,EE,00617AB0,word,3FC71CEB //3F955554
+patch=1,EE,00617EC0,word,3FC71CEB //3F955554
 
 [60 FPS]
 author=PeterDelta
 comment=Unlocked at 60 FPS. Might need enable 180% EE Overclock to be stable.
-patch=1,EE,00617AB4,word,00000001 //00000002
+patch=1,EE,00617F30,word,00000001 //00000002


### PR DESCRIPTION
Based on the 4:3 ratio, I have corrected it and would say it is accurate. With the previous value it is a little narrower. I attached images

![MC2 4](https://github.com/PCSX2/pcsx2_patches/assets/151682118/3f0ef5de-a9e9-4c36-83ca-c356679cc602)
![MC2 16](https://github.com/PCSX2/pcsx2_patches/assets/151682118/c03ae011-3f07-4ce5-ac37-4101a8c3d1f8)

![MC3 4](https://github.com/PCSX2/pcsx2_patches/assets/151682118/58ca18e2-7366-42cd-95fe-e41e4cbd0613)
![MC3 16](https://github.com/PCSX2/pcsx2_patches/assets/151682118/c9ab28d7-fef3-44e7-a57d-4308fc3ea462)
