### PR TITLE
Update 60 fps: Sonic heroes and unleashed

### DIFF
--- a/patches/SLES-51950_B7CF071A.pnach
+++ b/patches/SLES-51950_B7CF071A.pnach
@@ -1,12 +1,10 @@
-gametitle=Sonic Heroes (PAL-M5) (SLES-51950)
+gametitle=Sonic Heroes (PAL-M5) (SLES-51950) B7CF071A
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-comment=Widescreen Hack ported from NTSC hack by nemesis2000
-//ported to PAL (ElHecht)
-
-//---
+comment=Renders the game in 16:9 aspect ratio
+//ported to PAL (ElHecht) from NTSC hack by nemesis2000
 patch=1,EE,00167bcc,word,10000042
 patch=1,EE,00167c24,word,1000002c
 patch=1,EE,00167c40,word,10000025
@@ -14,7 +12,6 @@ patch=1,EE,00167be4,word,14400033
 patch=1,EE,00167bf4,word,1020002f
 patch=1,EE,00167c58,word,14400004
 patch=1,EE,00167c60,word,1000001d
-
 patch=1,EE,00167c68,word,3c013f40 //---
 patch=1,EE,00167c6c,word,0c05a92c
 patch=1,EE,00167c70,word,27a50030
@@ -49,22 +46,15 @@ patch=1,EE,00167ce0,word,7bb00000
 patch=1,EE,00167ce4,word,03e00008
 patch=1,EE,00167ce8,word,27bd0060
 patch=1,EE,00167cec,word,00000000
-
-//---
 patch=1,EE,0020bf4c,word,3c013f40 //--
 patch=1,EE,0020bf50,word,0c05a92c
 patch=1,EE,0020bf54,word,24452314
 patch=1,EE,0020bf58,word,1000002c
-
-//---
 patch=1,EE,0020bf6c,word,3c013f40 //--
 patch=1,EE,0020bf70,word,0c05a92c
 patch=1,EE,0020bf74,word,24452314
 patch=1,EE,0020bf78,word,10000024
-
-//---
 patch=1,EE,0020be84,word,10000062
-
 patch=1,EE,0020c000,word,3c013f40 //---
 patch=1,EE,0020c004,word,0c05a92c
 patch=1,EE,0020c008,word,27a50040
@@ -73,8 +63,6 @@ patch=1,EE,0020c010,word,7bb10010
 patch=1,EE,0020c014,word,7bb00000
 patch=1,EE,0020c018,word,03e00008
 patch=1,EE,0020c01c,word,27bd0050
-
-//---
 patch=1,EE,0020c07c,word,3c013f80
 patch=1,EE,0020c080,word,0c05a92c
 patch=1,EE,0020c084,word,27a50028
@@ -82,10 +70,7 @@ patch=1,EE,0020c088,word,dfbf0010
 patch=1,EE,0020c08c,word,7bb00000
 patch=1,EE,0020c090,word,03e00008
 patch=1,EE,0020c094,word,27bd0030
-
-//---
 patch=1,EE,002be498,word,1000001a
-
 patch=1,EE,002be4d8,word,3c013f80
 patch=1,EE,002be4dc,word,0c05a92c
 patch=1,EE,002be4e0,word,27a50048
@@ -103,14 +88,10 @@ patch=1,EE,002be50c,word,7bb10010
 patch=1,EE,002be510,word,7bb00000
 patch=1,EE,002be514,word,03e00008
 patch=1,EE,002be518,word,27bd0050
-
-//---
 patch=1,EE,002ee0dc,word,3c013f80
 patch=1,EE,002ee0e0,word,0c05a92c
 patch=1,EE,002ee0e4,word,27a50028
 patch=1,EE,002ee0e8,word,460c6303
-
-//--
 patch=1,EE,0016a4b0,word,27bdffe0
 patch=1,EE,0016a4b4,word,3c023f80
 patch=1,EE,0016a4b8,word,ffbf0010
@@ -140,15 +121,9 @@ patch=1,EE,0016a514,word,7bb00000
 patch=1,EE,0016a518,word,03e00008
 patch=1,EE,0016a51c,word,27bd0020
 
-[No-Interlacing]
-gsinterlacemode=1
-author=PeterDelta
-comment=480p mode. Only work at 60hz, supports fps unlock patch but will not switch to 50hz even if chosen.
-patch=1,EE,001009CC,word,3C060050
-
 [50/60 FPS]
 author=PeterDelta
-comment=Unlocked at 50/60 FPS. Might need enable EE Overclock to be stable.
+comment=Unlocked at 50/60 FPS. Might need enable 130% EE Overclock to be stable.
 patch=1,EE,00477940,word,00000001 //00000002 srl zero,0x00
 patch=1,EE,0028FF6C,word,24020001 //24020002 li v0,0x2 60hz
 patch=1,EE,E001CFD0,extended,00962BAC
@@ -159,3 +134,12 @@ patch=1,EE,E0015E20,extended,00962BAC
 patch=1,EE,0028FEC8,extended,24030001
 patch=1,EE,E0018580,extended,00962BAC
 patch=1,EE,0028FEC8,extended,24030001
+
+[Mode 480p]
+author=PeterDelta
+comment=Forces progressive scan when selecting 60hz
+patch=1,EE,E0040000,extended,004758E8
+patch=1,EE,201009C4,extended,3C050000
+patch=1,EE,201009CC,extended,3C060050
+patch=1,EE,201009D4,extended,3C070001
+patch=1,EE,20100C94,extended,3C090010

--- a/patches/SLES-53350_4A198252.pnach
+++ b/patches/SLES-53350_4A198252.pnach
@@ -1,9 +1,0 @@
-gametitle=Sonic Gems collection (pal)(SLES-53350)
-
-[Widescreen 16:9]
-gsaspectratio=16:9
-comment=Widescreen hack by Esppiral
-patch=1,EE,00290960,word,3FAAAAAB
-patch=1,EE,216CC190,word,3F400000
-
-

--- a/patches/SLES-55380_8C913264.pnach
+++ b/patches/SLES-55380_8C913264.pnach
@@ -1,20 +1,16 @@
-gametitle=Sonic Unleashed (PAL-M5) (SLES-55380)
+gametitle=Sonic Unleashed (PAL-M5) (SLES-55380) 8C913264
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=ElHecht
+author=PeterDelta
 comment=Renders the game in 16:9 aspect ratio
-patch=1,EE,0038d71c,word,3c014340 // 00000000 hor fov
-patch=1,EE,0038d720,word,3c1b008a // 00000000
-patch=1,EE,0038d724,word,af6143b0 // 00000000
-patch=1,EE,0038d728,word,03e00008 // 00000000
-patch=1,EE,00528cf4,word,3c023fab // 3c023f80 renderfix
-patch=1,EE,0043657c,word,3c024436 // 3c024420 2d char fix pos
-patch=1,EE,007638c0,word,3faaaaab // 3f800000 2d char fix fov
+patch=1,EE,00872D50,word,3FD21DA8 //3F9D9643
+patch=1,EE,00ED1AD8,word,00000000 //42600000 fmv
+patch=1,EE,00ED1AE8,word,43E00000 //43C40000
 
 [50 FPS]
 author=PeterDelta
-comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
 patch=1,EE,0087C3B4,word,00000032 //00000019
 patch=1,EE,00870A2C,word,3F99999A //3F800000
 

--- a/patches/SLES-55380_8C913264.pnach
+++ b/patches/SLES-55380_8C913264.pnach
@@ -3,8 +3,7 @@ gametitle=Sonic Unleashed (PAL-M5) (SLES-55380)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-comment=Widescreen Hack
-// 16:9
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,0038d71c,word,3c014340 // 00000000 hor fov
 patch=1,EE,0038d720,word,3c1b008a // 00000000
 patch=1,EE,0038d724,word,af6143b0 // 00000000
@@ -13,14 +12,16 @@ patch=1,EE,00528cf4,word,3c023fab // 3c023f80 renderfix
 patch=1,EE,0043657c,word,3c024436 // 3c024420 2d char fix pos
 patch=1,EE,007638c0,word,3faaaaab // 3f800000 2d char fix fov
 
-
 [50 FPS]
 author=PeterDelta
 comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
 patch=1,EE,0087C3B4,word,00000032 //00000019
 patch=1,EE,00870A2C,word,3F99999A //3F800000
 
-[Mode 480p]
+[60 FPS]
 author=PeterDelta
-comment=Unlocked progressive Mode 480p
-patch=1,EE,00671D04,word,3C060050
+comment=Forces progressive scan mode at 60 fps
+patch=1,EE,00671CFC,word,3C050000
+patch=1,EE,00671D04,word,3C060052
+patch=1,EE,00671D0C,word,3C070001
+patch=1,EE,00671FCC,word,3C090010


### PR DESCRIPTION
Sonic Heroes: You can choose between 50 and 60hz without altering anything in the game if 50hz is selected by mistake, this way it is more faithful. Selecting 60 Hz automatically switches to progressive mode

Sonic Unleashed: Fixed aspect ratio as shown in the images.
What I have marked with a red arrow is from the panoramic patch, when enabled it cannot be hidden because it is part of the map. I haven't been able to fix it but it doesn't affect the gameplay.

![Sonic unleashed](https://github.com/PCSX2/pcsx2_patches/assets/151682118/dd2ec8ab-9b9e-47a8-98b0-b4b1d7a31620)

![Sonic Unleashed_SLES-55380_20231216025210](https://github.com/PCSX2/pcsx2_patches/assets/151682118/b94c2e75-4b59-4d0e-83e1-690009475679)


Update: In the end I found the direction of widescreen, it does not require a rendering fix and works very well, plus the HUD looks better this way without showing that part of the map that I marked in red.
___________________________________________________________________________________________________________________________________

Sonic Gems Collection: The widescreen patch does not correspond to this crc. It corresponds to the Japanese version and is included in this repository SLPM-66074_E0068D0A. It seems that it is for the Sonic R but in the PAL version it does not work and also the Sonic R would have a different crc than this one.
