### PR TITLE
Project Zero - Remove Post Processing patch update

### DIFF
--- a/patches/SLES-50821_22E91837.pnach
+++ b/patches/SLES-50821_22E91837.pnach
@@ -131,10 +131,10 @@ patch=1,EE,00135B18,word,3C014270
 patch=1,EE,00135BFC,word,3C0140F0
 patch=1,EE,00135BC4,word,3C014110
 patch=1,EE,00135B80,word,3C014190
-//Remove Post Processing
+
+[Remove Post Processing]
+comment=Remove Post Processing effects
 patch=1,EE,00350C0C,word,00000000 //blurry bloom
 patch=1,EE,0035108C,word,00000000 //dark filter
 patch=1,EE,00350F1C,word,00000000 //post process and noise in-game
-//patch=1,EE,0035905C,word,00000000 //post process and noise on menus, optional, makes main menu bland looking.
-
-
+patch=1,EE,0035905C,word,00000000 //post process and noise on menus, optional, makes main menu bland looking.


### PR DESCRIPTION
this patch used to be mixed with [No interlacing]
so I decided to separate these patches, as one of them is an attempt against the atmosphere of the game.
now the user will be able to disable/enable as desired

without patch
![Project Zero_SLES-50821_20231217171825](https://github.com/PCSX2/pcsx2_patches/assets/144561229/366986b7-6ee1-45f8-be21-85a4fddfba7c)
![Project Zero_SLES-50821_20231217171955](https://github.com/PCSX2/pcsx2_patches/assets/144561229/019cd383-cf19-4582-bb73-8028a6f585c4)
with patch
![Project Zero_SLES-50821_20231217172109](https://github.com/PCSX2/pcsx2_patches/assets/144561229/cf4e3f81-d56f-4eae-8886-bacb0f28727f)
![Project Zero_SLES-50821_20231217172028](https://github.com/PCSX2/pcsx2_patches/assets/144561229/751f87c7-d311-4567-9663-2a14b5d36ddb)
