### PR TITLE
Adds several 60fps and widescreen patches

### DIFF
--- a/patches/SCES-50959_B74A2938.pnach
+++ b/patches/SCES-50959_B74A2938.pnach
@@ -1,13 +1,13 @@
-gametitle=Disney Stitch: Experiment 626 [PAL-M2] [Esp-Por] (SCES_509.59)
+gametitle=Disney Stitch: Experiment 626 [PAL-M2] [Esp-Por] (SCES_509.59) B74A2938
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by El_Patas
+author=El_Patas
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,00236AE4,word,3C023F1E //3C023F00 Zoom 16:9
+patch=1,EE,00236F34,word,3C03BFAC //3C03BF80 Y-FOV 16:9
 
-//Zoom 16:9
-patch=1,EE,00236AE4,word,3C023F1E //3C023F00
-
-//Y-FOV 16:9
-patch=1,EE,00236F34,word,3C03BFAC //3C03BF80
-
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,00628C88,byte,01

--- a/patches/SCES-51248_531061F2.pnach
+++ b/patches/SCES-51248_531061F2.pnach
@@ -1,0 +1,6 @@
+gametitle=Dog's Life (PAL-M) SCES-51248 531061F2
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,00791350,word,3CA3D70A

--- a/patches/SCES-51635_27D961D2.pnach
+++ b/patches/SCES-51635_27D961D2.pnach
@@ -1,0 +1,8 @@
+gametitle=Brave - The Search for Spirit Dancer (PAL-M) SCES-51635 27D961D2
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,2033A784,extended,00000000
+patch=1,EE,E0010000,extended,003C66C8
+patch=1,EE,2033A784,extended,1040FFFA

--- a/patches/SLES-50277_12526265.pnach
+++ b/patches/SLES-50277_12526265.pnach
@@ -1,0 +1,6 @@
+gametitle=Red Faction (PAL-M) SLES-50277 12526265
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0016505C,word,24040001 //24040002

--- a/patches/SLES-50288_790A4ACB.pnach
+++ b/patches/SLES-50288_790A4ACB.pnach
@@ -1,20 +1,16 @@
-gametitle=Stuntman (E)(SLES-50288)
+gametitle=Stuntman (E)(SLES-50288) 790A4ACB
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa and FlatOut
-
-//Gameplay 16:9
-
-//Render fix
-patch=1,EE,001d4c94,word,3c013f30 //3c013f00
-
-//Zoom
+author=Arapapa and FlatOut
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,001d4c94,word,3c013f30 //3c013f00 Render fix
 //Other Zoom : 003f013c 00a88144 06650046
 patch=1,EE,00293058,word,3FD66666 //3eaaaaab Fiexed FlatOut
-
-//Y-Fov
-patch=1,EE,001d4cd8,word,3c013fe3 //3c013faa
+patch=1,EE,001d4cd8,word,3c013fe3 //3c013faa Y-Fov
 patch=1,EE,001d4cdc,word,34218e3f //3421aaab
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,005C21B4,word,00000001 //00000002

--- a/patches/SLES-50644_27F2EA5F.pnach
+++ b/patches/SLES-50644_27F2EA5F.pnach
@@ -1,0 +1,13 @@
+gametitle=Shifters (PAL-E) SLES-50644 27F2EA5F
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,004C4B00,word,3F81DE4A //3FAD2867
+patch=1,EE,004C4B80,word,3F81DE4B //3FAD2868
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,004C4AC4,word,00000001 //00000002

--- a/patches/SLES-50645_C8F64115.pnach
+++ b/patches/SLES-50645_C8F64115.pnach
@@ -1,0 +1,13 @@
+gametitle=Shifters (PAL-S-I) SLES-50645 C8F64115
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,004C5390,word,3F81DE4A //3FAD2867
+patch=1,EE,004C5410,word,3F81DE4B //3FAD2868
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,004C5354,word,00000001 //00000002

--- a/patches/SLES-50714_8A6875C4.pnach
+++ b/patches/SLES-50714_8A6875C4.pnach
@@ -1,11 +1,9 @@
-gametitle=Defender (E)(SLES-50714)
+gametitle=Defender (E)(SLES-50714) 8A6875C4
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen hack 16:9
-
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
 //X-Fov
 patch=1,EE,0010bc34,word,3c013fd5 //3c013fa0
 patch=1,EE,00137940,word,3c013fd5 //3c013fa0
@@ -13,4 +11,7 @@ patch=1,EE,00184ba8,word,3c013fd5 //3c013fa0 Menu
 patch=1,EE,001c9efc,word,3c013fd5 //3c013fa0
 patch=1,EE,001c9fb4,word,3c013fd5 //3c013fa0 Gameplay
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,00228DC0,word,00000000 //1040FFFD

--- a/patches/SLES-51126_FB45FA8E.pnach
+++ b/patches/SLES-51126_FB45FA8E.pnach
@@ -1,13 +1,13 @@
-gametitle=Whirl Tour [PAL-M5] (SLES_511.26)
+gametitle=Whirl Tour [PAL-M5] (SLES_511.26) FB45FA8E
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by El_Patas
-
-//Gameplay 16:9
+author=El_Patas
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,001B4334,word,3C014440 //3C014480 (Increases horiz. axis)
+patch=1,EE,001AA394,word,3C013C2E //3C013C0E Render fix
 
-//Render fix
-patch=1,EE,001AA394,word,3C013C2E //3C013C0E
-
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0027B36C,word,42480000

--- a/patches/SLES-51133_1629D655.pnach
+++ b/patches/SLES-51133_1629D655.pnach
@@ -1,10 +1,9 @@
-gametitle=Red Faction II (PAL-M3) (SLES-51133)
+gametitle=Red Faction II (PAL-M3) (SLES-51133) 1629D655
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
-
-// 16:9
+author=ElHecht
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,0018c650,word,3c013f40 // 00000000 hor fov
 patch=1,EE,0018c664,word,4481f000 // 00000000
 patch=1,EE,0018c668,word,461ea502 // 00000000
@@ -21,4 +20,7 @@ patch=1,EE,001a2f58,word,3c023fab // 3c023f80 shadow fix
 //patch=1,EE,001a3038,word,3c034318 // 3c034334 shadow fix
 //patch=1,EE,001a2f58,word,3c023f9a // 3c023f80 shadow fix
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,00121960,word,24040001 //24040002

--- a/patches/SLES-51156_6BBD4932.pnach
+++ b/patches/SLES-51156_6BBD4932.pnach
@@ -1,26 +1,20 @@
-gametitle=Silent Hill 2: Director's Cut (SLES-51156)
+gametitle=Silent Hill 2 - Director's Cut (PAL-M) SLES-51156 6BBD4932
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000 )
+author=nemesis2000
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,002D7530,word,3F28F5C3 //hor asp
 patch=1,EE,00189d84,word,3c034455 // partial render fix
-
-//FMV's fix
-patch=1,EE,00281118,word,24100004 //hor black border
+patch=1,EE,00281118,word,24100004 //hor black border FMV's fix
 patch=1,EE,0028111c,word,24030004 //hor black border
 patch=1,EE,002810fc,word,340692b0 //bottom
 //patch=1,EE,00281104,word,34c68c80 //right
 patch=1,EE,002810cc,word,3c026d50 //top
 //patch=1,EE,002810d0,word,34467380 //left
-
-//Lens Flare's fix
-patch=1,EE,0018B6E0,word,3C024010
-
+patch=1,EE,0018B6E0,word,3C024010 //Lens Flare's fix
 patch=1,EE,0018B75C,word,3C0243A8
-
 patch=1,EE,0018C3B4,word,3C024010
-
 patch=1,EE,0018C44C,word,3C0243A8
 patch=1,EE,0018C4C8,word,3C0243A8
 patch=1,EE,0018CA94,word,3C0243A8
@@ -35,31 +29,21 @@ patch=1,EE,0018D394,word,3C0243A8
 patch=1,EE,0018D400,word,3C0243A8
 patch=1,EE,0018D54C,word,3C0243A8
 patch=1,EE,0018D5B8,word,3C0243A8
-
-//Loading scene (Foot Print)
-//403f023c 00088244 c000a0c7
-patch=1,EE,00291734,word,3c023f10 //3c023f40
-
-//Item & Equipment Y-Fov
-//8042023c 00008244 00000000 02001446
-patch=1,EE,001eac40,word,3c0242aa //3c024280
+patch=1,EE,00291734,word,3c023f10 //3c023f40 Loading scene (Foot Print)
+patch=1,EE,001eac40,word,3c0242aa //3c024280 Item & Equipment Y-Fov
 patch=1,EE,001eac44,word,3442aaab //44820000
 patch=1,EE,001eac48,word,44820000 //00000000
-
 patch=1,EE,001eafa0,word,3c0242aa //3c024280
 patch=1,EE,001eafa4,word,3442aaab //44820000
 patch=1,EE,001eafa8,word,44820000 //00000000
-
-//Item Zoom
-//993e033c 9a996334 00008344
-patch=1,EE,001db4dc,word,3c033daa //3c033e99
+patch=1,EE,001db4dc,word,3c033daa //3c033e99 Item Zoom
 patch=1,EE,001db4e0,word,3463aaab //3463999a
 patch=1,EE,001db4dc,word,3c033daa //3c033e99
 patch=1,EE,001db4e0,word,3463aaab //3463999a
-
-//Equipment Zoom
-//663f023c 66664234 00088244
-patch=1,EE,001db998,word,3c023f2c //3c023f66
+patch=1,EE,001db998,word,3c023f2c //3c023f66 Equipment Zoom
 patch=1,EE,001db99c,word,3442cccd //34426666
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,001A7060,word,10000009 //14400009

--- a/patches/SLES-51181_11DB467D.pnach
+++ b/patches/SLES-51181_11DB467D.pnach
@@ -1,19 +1,18 @@
-gametitle=Tom Clancy's Ghost Recon (SLES_511.81)
+gametitle=Tom Clancy's Ghost Recon (PAL-M) (SLES_511.81) 11DB467D
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (Converted to PAL by Somechump)
-
-//sp
-patch=1,EE,003a89c4,word,3c023f40
+author=Somechump
+comment=Renders the game in 16:9 aspect ratio
+//Widescreen hack by nemesis2000 (Converted to PAL by Somechump)
+patch=1,EE,003a89c4,word,3c023f40 //sp
 patch=1,EE,003a89e4,word,3c0243d6
-
-//mp
-patch=1,EE,003a8ae4,word,3c023f40
+patch=1,EE,003a8ae4,word,3c023f40 //mp
 patch=1,EE,003a8b04,word,3c0243d6
-
-//menu
-patch=1,EE,0053ba44,word,3c023f0c
+patch=1,EE,0053ba44,word,3c023f0c //menu
 patch=1,EE,0053ba54,word,3c0243d6
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,002729D4,word,1000000E //1040000E

--- a/patches/SLES-51315_647D9161.pnach
+++ b/patches/SLES-51315_647D9161.pnach
@@ -1,21 +1,17 @@
-gametitle=The Great Escape (E)(SLES-51315)
+gametitle=The Great Escape (E)(SLES-51315) 647D9161
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen hack 16:9
-
-//Zoom
-patch=1,EE,002b3b34,word,3c013b01 //3c013acc
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,002b3b34,word,3c013b01 //3c013acc Zoom
 patch=1,EE,002b3b38,word,34210000 //3421cccd
-
-//Y-Fov
-patch=1,EE,002b3bbc,word,3c013b35 //3c013b08
+patch=1,EE,002b3bbc,word,3c013b35 //3c013b08 Y-Fov
 patch=1,EE,002b3bc0,word,3421fe54 //34218889
-
-//Render fix
-patch=1,EE,002c4f30,word,3c013d00 //3c013c8e
+patch=1,EE,002c4f30,word,3c013d00 //3c013c8e Render fix
 patch=1,EE,002c4f34,word,34210000 //3421fa36
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,002AEBF8,word,2C420001 //2C420002

--- a/patches/SLES-51385_4603820E.pnach
+++ b/patches/SLES-51385_4603820E.pnach
@@ -1,0 +1,6 @@
+gametitle=Rugrats Rescate Real (PAL-S) SLES-51385 4603820E
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0042D820,word,00000001 //00000002

--- a/patches/SLES-51636_9D395452.pnach
+++ b/patches/SLES-51636_9D395452.pnach
@@ -1,18 +1,18 @@
-gametitle=XGRA - Extreme G Racing Association (E)(SLES-51636)
+gametitle=XGRA - Extreme G Racing Association (E)(SLES-51636) 9D395452
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen hack 16:9
-
-//Zoom
-patch=1,EE,0019d5dc,word,3c013ec0 //3c013f00
-
-//Y-Fov
-patch=1,EE,0019d5fc,word,3c013faa //00000000
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,0019d5dc,word,3c013ec0 //3c013f00 Zoom
+patch=1,EE,0019d5fc,word,3c013faa //00000000 Y-Fov
 patch=1,EE,0019d600,word,3421aaab //00000000
 patch=1,EE,0019d608,word,4481f000 //00000000
 patch=1,EE,0019d60c,word,461ebdc2 //00000000
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,00205404,word,1040FFFA
+patch=1,EE,E0010000,extended,01FFE32C
+patch=1,EE,20205404,extended,00000000

--- a/patches/SLES-51820_EF47C233.pnach
+++ b/patches/SLES-51820_EF47C233.pnach
@@ -1,13 +1,15 @@
-gametitle=Sniper Elite [PAL-M5] (SLES-51820)
+gametitle=Sniper Elite [PAL-M5] (SLES-51820) EF47C233
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=El_Patas
-comment=Widescreen Hack ported from NTSC hack by Arapapa
-//Zoom
-patch=1,EE,005015d0,word,3f9faaab //3eaaaaab
+comment=Renders the game in 16:9 aspect ratio
+//Widescreen Hack ported from NTSC hack by Arapapa
+patch=1,EE,005015d0,word,3f9faaab //3eaaaaab Zoom
+patch=1,EE,00502848,word,3fe38e2a //3faaaaab Y-FOV
 
-//Y-FOV
-patch=1,EE,00502848,word,3fe38e2a //3faaaaab
-
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,00474F04,word,00000000
+patch=1,EE,00198FCC,word,00000000

--- a/patches/SLES-51883_8F6A1960.pnach
+++ b/patches/SLES-51883_8F6A1960.pnach
@@ -1,0 +1,17 @@
+gametitle=Scooby-Doo! Mystery Mayhem (PAL-E) SLES-51883 8F6A1960
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,001978a0,word,0809fa4c
+patch=1,EE,0027e930,word,46010043
+patch=1,EE,0027e934,word,3c013f40
+patch=1,EE,0027e938,word,4481f000
+patch=1,EE,0027e93c,word,461e0842
+patch=1,EE,0027e940,word,08065e29
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0049AAB8,word,0000003C

--- a/patches/SLES-51934_7100A15F.pnach
+++ b/patches/SLES-51934_7100A15F.pnach
@@ -1,14 +1,12 @@
-gametitle=Curse - The Eye Of Isis (PAL-M6) (SLES-51934)
+gametitle=Curse - The Eye Of Isis (PAL-M6) (SLES-51934) 7100A15F
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by sergx12 / ElHecht
-
-// 16:9
+author=sergx12 and ElHecht
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,002b5890,word,3c013fe3 // 3c013faa ver fov
 patch=1,EE,002b5894,word,34218e39 // 3421aaab ver fov
 patch=1,EE,0011cef4,word,461e0003 // 00000000 zoom loading screen
-
 patch=1,EE,0039d4e4,word,08143f8f // 00000000
 patch=1,EE,0050fe3c,word,3c013f40 // 00000000 zoom
 patch=1,EE,0050fe40,word,4481f000 // 00000000
@@ -17,14 +15,12 @@ patch=1,EE,0050fe48,word,00000000 // 00000000
 patch=1,EE,0050fe4c,word,461e1083 // 00000000
 patch=1,EE,0050fe50,word,00000000 // 00000000
 patch=1,EE,0050fe54,word,080e753a // 00000000
-
 patch=1,EE,001a1980,word,08143f89 // e7a00000 default fov function
 patch=1,EE,001a1984,word,00000000 // 4600a502
 patch=1,EE,0050fe24,word,461e0003 // 00000000
 patch=1,EE,0050fe28,word,e7a00000 // 00000000
 patch=1,EE,0050fe30,word,4600a502 // 00000000
 patch=1,EE,0050fe34,word,08068661 // 00000000
-
 patch=1,EE,0013604c,word,08143f4b // 8c42b11c gameplay-to-inventory function
 patch=1,EE,00136050,word,00000000 // 8c644408
 patch=1,EE,0050fd2c,word,8c42b11c // 00000000
@@ -32,14 +28,12 @@ patch=1,EE,0050fd30,word,8c644408 // 00000000
 patch=1,EE,0050fd34,word,461ef783 // 00000000
 patch=1,EE,0050fd38,word,3c1b3f40 // 00000000
 patch=1,EE,0050fd3c,word,0804d814 // 00000000
-
 patch=1,EE,00140688,word,08143f51 // 3c020043 map-to-inventory function
 patch=1,EE,0014068c,word,00000000 // 8c444408
 patch=1,EE,0050fd44,word,3c020043 // 00000000
 patch=1,EE,0050fd48,word,8c444408 // 00000000
 patch=1,EE,0050fd4c,word,461ef783 // 00000000
 patch=1,EE,0050fd50,word,080501a3 // 00000000
-
 patch=1,EE,001347bc,word,08143f56 // 3c020043 inventory-to-gameplay function
 patch=1,EE,001347c0,word,00000000 // 8c444408
 patch=1,EE,0050fd58,word,3c020043 // 00000000
@@ -47,7 +41,9 @@ patch=1,EE,0050fd5c,word,8c444408 // 00000000
 patch=1,EE,0050fd60,word,461ef783 // 00000000
 patch=1,EE,0050fd64,word,3c1b3f80 // 00000000
 patch=1,EE,0050fd68,word,0804d1f0 // 00000000
-
 patch=1,EE,0011e8b4,word,461ef783 // 00000000 inventory-to-documents function
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,00510300,byte,01

--- a/patches/SLES-51976_FE1720F1.pnach
+++ b/patches/SLES-51976_FE1720F1.pnach
@@ -1,19 +1,18 @@
-gametitle=Tom Clancy's Ghost Recon: Jungle Storm (SLES_519.76) PAL
+gametitle=Tom Clancy's Ghost Recon: Jungle Storm (PAL-M) (SLES_519.76) FE1720F1
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Converted from NTSC Widescreen hack by nemesis2000 (PAL by Somechump)
-
-//sp
-patch=1,EE,0051d978,word,3c023f40
+author=Somechump
+comment=Renders the game in 16:9 aspect ratio
+//Converted from NTSC Widescreen hack by nemesis2000 (PAL by Somechump)
+patch=1,EE,0051d978,word,3c023f40 //sp
 patch=1,EE,0051d9b8,word,3c0243b6
-
-//mp
-patch=1,EE,00387324,word,3c023f40
+patch=1,EE,00387324,word,3c023f40 //mp
 patch=1,EE,00387350,word,3c0243b6
-
-//unk
-patch=1,EE,0051d8e4,word,3C053f40
+patch=1,EE,0051d8e4,word,3C053f40 //unk
 patch=1,EE,0051d928,word,3C0243b6
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,00159E9C,word,24020000 //24020001

--- a/patches/SLES-51989_BF45EFF4.pnach
+++ b/patches/SLES-51989_BF45EFF4.pnach
@@ -1,0 +1,7 @@
+gametitle=Wallace & Gromit in Project Zoo (PAL-M) SLES-51989 BF45EFF4
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,E001D70A,extended,00867780
+patch=1,EE,20867780,extended,3CA3D70A

--- a/patches/SLES-51997_0E40BA6A.pnach
+++ b/patches/SLES-51997_0E40BA6A.pnach
@@ -1,20 +1,18 @@
-gametitle=SWAT - Global Strike Team (E)(SLES-51997)
+gametitle=SWAT - Global Strike Team (E)(SLES-51997) 0E40BA6A
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen hack 16:9
-
-//Zoom
-patch=1,EE,002a6774,word,3c013f23 //3c013f00
-
-//Y-Fov
-patch=1,EE,0025fa14,word,080a5248 //460039c2
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,002a6774,word,3c013f23 //3c013f00 Zoom
+patch=1,EE,0025fa14,word,080a5248 //460039c2 Y-Fov
 patch=1,EE,00294920,word,460039c2
 patch=1,EE,00294924,word,3c013f40
 patch=1,EE,00294928,word,4481f000
 patch=1,EE,0029492c,word,461e39c3
 patch=1,EE,00294930,word,08097e86
 
-
+[50/60 FPS]
+author=PeterDelta
+comment=Unlocked at 50/60 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,00468DC0,word,00000001 //00000002

--- a/patches/SLES-52023_FE419424.pnach
+++ b/patches/SLES-52023_FE419424.pnach
@@ -1,8 +1,9 @@
-gametitle=Manhunt SLES_520.23
+gametitle=Manhunt SLES_520.23 FE419424
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack
+author=sergx12
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,001c88a8,word,3c023f03
 patch=1,EE,001c88c8,word,3c033f6e
 patch=1,EE,001c88d0,word,3462eeee

--- a/patches/SLES-52362_5D0235B7.pnach
+++ b/patches/SLES-52362_5D0235B7.pnach
@@ -1,0 +1,6 @@
+gametitle=Bad Boys II (PAL-M) SLES-52362 5D0235B7
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0051C4C4,word,42480000 //41C80000

--- a/patches/SLES-52372_6B68932C.pnach
+++ b/patches/SLES-52372_6B68932C.pnach
@@ -1,9 +1,10 @@
-gametitle=Spider-Man 2 (PAL) (SLES_523.72)
+gametitle=Spider-Man 2 (PAL) (SLES_523.72) 6B68932C
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=flameofrecca + CRASHARKI
-comment=Patches the game to run at 16:9 Widescreen Aspect Ratio. (Original NTSC-U pnach by flameofrecca; new zoom value, gauge_hero, some map and the unused boss hud codes found by CRASHARKI)
+comment=Patches the game to run at 16:9 Widescreen Aspect Ratio.
+//Original NTSC-U pnach by flameofrecca; new zoom value, gauge_hero, some map and the unused boss hud codes found by CRASHARKI
 patch=1,EE,2067ac70,word,3f947ae1  //vertical fov 3f5eb852
 patch=1,EE,2067ac68,word,3c28a2f7  //zoom value 3c0efa35
 
@@ -86,10 +87,17 @@ patch=1,EE,2072421C,word,42340000  //gauge_hero_01 42700000
 //patch=1,EE,208831D8,word,440cd000  //gauge_boss_icon_rhino 440EC000
 //patch=1,EE,208831EC,word,440cd000  //gauge_boss_icon_rhino 440EC000
 
-
 [50 FPS]
-author=asasega + CRASHARKI
+author=PeterDelta + CRASHARKI
 description=Patches the game to run at 50 FPS (Might need 130% EE Overclock to be stable on heavy scenes).
 patch=1,EE,0060AD20,word,00000001 //00000002
 patch=1,EE,E0010001,extended,005E3C90
 patch=1,EE,0060AD20,extended,00000002
+
+[Mode 480p]
+author=PeterDelta
+comment=Forces progressive scan mode 480p at startup
+patch=1,EE,00578864,word,3C050000
+patch=1,EE,0057886C,word,3C060050
+patch=1,EE,00578874,word,3C070001
+patch=1,EE,1060AD04,extended,01E0

--- a/patches/SLES-52450_2CC13DED.pnach
+++ b/patches/SLES-52450_2CC13DED.pnach
@@ -1,0 +1,6 @@
+gametitle=Serious Sam - Next Encounter (PAL-M) SLES-52450 2CC13DED
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,001273A8,word,00000000 //1040FFF9

--- a/patches/SLES-52646_CE64E328.pnach
+++ b/patches/SLES-52646_CE64E328.pnach
@@ -1,0 +1,15 @@
+gametitle=Tom Clancy's Ghost Recon 2 (PAL-M) SLES-52646 CE64E328
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,E0010000,extended,00E966F8
+patch=1,EE,20E966F8,extended,3F400000
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,205D8B50,extended,00000000
+patch=1,EE,E0010001,extended,00722870
+patch=1,EE,205D8B50,extended,1440FFF9

--- a/patches/SLES-52807_5B2962FD.pnach
+++ b/patches/SLES-52807_5B2962FD.pnach
@@ -1,11 +1,9 @@
-gametitle=Lemony Snicket's A Series of Unfortunate Events (E)(SLES-52807)
+gametitle=Lemony Snicket's A Series of Unfortunate Events (E)(SLES-52807) 5B2962FD
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen hack 16:9
-
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
 //Zoom (Gameplay)
 //003f013c 00608144
 patch=1,EE,0019c130,word,3c013f1b //3c013f00
@@ -35,4 +33,8 @@ patch=1,EE,003ad0c0,word,4481f000
 patch=1,EE,003ad0c4,word,461e6302
 patch=1,EE,003ad0c8,word,080ba972
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0047D2C0,word,42C80000 //42480000
+patch=1,EE,0047D2C4,word,3C23D70A //3CA3D70A

--- a/patches/SLES-52825_43A02228.pnach
+++ b/patches/SLES-52825_43A02228.pnach
@@ -1,0 +1,7 @@
+gametitle=Serie de Catastróficas Desdichas de Lemony Snicket, Una (PAL-S) SLES-52825 43A02228
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0047D2C0,word,42C80000 //42480000
+patch=1,EE,0047D2C4,word,3C23D70A //3CA3D70A

--- a/patches/SLES-52989_0158297B.pnach
+++ b/patches/SLES-52989_0158297B.pnach
@@ -1,16 +1,16 @@
-gametitle=Blowout [PAL] (SLES_529.89)
+gametitle=Blowout [PAL] (SLES_529.89) 0158297B
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen pnach by El_Patas
-
-//Gameplay 16:9
+author=El_Patas
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,001D29AC,word,00000000 //AF80C5A8
 patch=1,EE,003BAA18,word,00000001 //00000000
-
-//HUD fix
-patch=1,EE,003B7DF0,word,C0222222 //BFF33333
+patch=1,EE,003B7DF0,word,C0222222 //BFF33333 HUD fix
 patch=1,EE,003B7E08,word,40222222 //3FF33333
 patch=1,EE,003B7E28,word,40222222 //3FF33333
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,002B13B8,word,28630001 //28630002

--- a/patches/SLES-53092_D536E4BA.pnach
+++ b/patches/SLES-53092_D536E4BA.pnach
@@ -1,0 +1,6 @@
+gametitle=Motocross Mania 3 (PAL-M) SLES-53092 D536E4BA
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,003219EC,word,00000001 //00000002

--- a/patches/SLES-53155_99AD19EE.pnach
+++ b/patches/SLES-53155_99AD19EE.pnach
@@ -1,4 +1,4 @@
-gametitle=Star Wars - Episode III - Revenge of the Sith (PAL-M3) (SLES-53155)
+gametitle=Star Wars - Episode III - Revenge of the Sith (PAL-M3) (SLES-53155) 99AD19EE
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -20,10 +20,9 @@ patch=1,EE,0051bcf0,word,461e4a42 // 00000000
 //patch=1,EE,0051bcac,word,4481f000 // 00000000
 //patch=1,EE,0051bcf0,word,461e4a42 // 00000000
 
-
 [50 FPS]
 author=PeterDelta
-comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,001AF538,word,00000001 //00000002
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,001AF538,word,00000002 //00000002
 patch=1,EE,E0010002,extended,001B4344
 patch=1,EE,201AF538,extended,00000001

--- a/patches/SLES-53199_A6786A05.pnach
+++ b/patches/SLES-53199_A6786A05.pnach
@@ -1,0 +1,20 @@
+gametitle=25 to Life (PAL-E) SLES-53199 A6786A05
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,00319794,word,3c013f40 //X-Fov
+patch=1,EE,00319798,word,4481f000
+patch=1,EE,003197bc,word,461e6b43
+patch=1,EE,0022c01c,word,0809a844 //Render fix
+patch=1,EE,0026a110,word,4600b306 //00000000
+patch=1,EE,0026a114,word,3c013f40 //00000000
+patch=1,EE,0026a118,word,4481f000 //00000000
+patch=1,EE,0026a11c,word,461e6303 //00000000
+patch=1,EE,0026a120,word,0808b008 //00000000
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,005F787C,word,00000001 //00000002

--- a/patches/SLES-53225_D3051E54.pnach
+++ b/patches/SLES-53225_D3051E54.pnach
@@ -2,7 +2,17 @@ gametitle=Madagascar (PAL-E) SLES-53225 D3051E54
 
 [50 FPS]
 author=PeterDelta
-comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,004B0604,byte,0001 //0002
-patch=1,EE,00346D24,word,00000064 //00000032
-patch=1,EE,01ADA8F4,word,3F000000 //3F800000 animations
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,004B0604,byte,01 //02
+patch=1,EE,00346D24,byte,64 //32
+
+[60 FPS]
+author=PeterDelta
+comment=Forces progressive scan mode at startup
+patch=1,EE,002F8AE0,word,34050052
+patch=1,EE,002F8AE4,word,24030002
+patch=1,EE,002F8AE8,word,0000000C
+patch=1,EE,002F8AEC,word,03E00008
+patch=1,EE,004DF4C8,word,02051290
+patch=1,EE,004DF4F0,word,02051290
+patch=1,EE,00346D24,byte,76

--- a/patches/SLES-53225_D3051E54.pnach
+++ b/patches/SLES-53225_D3051E54.pnach
@@ -15,4 +15,6 @@ patch=1,EE,002F8AE8,word,0000000C
 patch=1,EE,002F8AEC,word,03E00008
 patch=1,EE,004DF4C8,word,02051290
 patch=1,EE,004DF4F0,word,02051290
-patch=1,EE,00346D24,byte,76
+patch=1,EE,00346D24,byte,38
+patch=1,EE,E0010001,extended,004B0604
+patch=1,EE,00346D24,extended,76

--- a/patches/SLES-53246_D3051E54.pnach
+++ b/patches/SLES-53246_D3051E54.pnach
@@ -2,7 +2,17 @@ gametitle=Madagascar (PAL-S) SLES-53246 D3051E54
 
 [50 FPS]
 author=PeterDelta
-comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,004B0604,byte,0001 //0002
-patch=1,EE,00346D24,word,00000064 //00000032
-patch=1,EE,01ADA8F4,word,3F000000 //3F800000 animations
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,004B0604,byte,01 //02
+patch=1,EE,00346D24,byte,64 //32
+
+[60 FPS]
+author=PeterDelta
+comment=Forces progressive scan mode at startup
+patch=1,EE,002F8AE0,word,34050052
+patch=1,EE,002F8AE4,word,24030002
+patch=1,EE,002F8AE8,word,0000000C
+patch=1,EE,002F8AEC,word,03E00008
+patch=1,EE,004DF4C8,word,02051290
+patch=1,EE,004DF4F0,word,02051290
+patch=1,EE,00346D24,byte,76

--- a/patches/SLES-53246_D3051E54.pnach
+++ b/patches/SLES-53246_D3051E54.pnach
@@ -15,4 +15,6 @@ patch=1,EE,002F8AE8,word,0000000C
 patch=1,EE,002F8AEC,word,03E00008
 patch=1,EE,004DF4C8,word,02051290
 patch=1,EE,004DF4F0,word,02051290
-patch=1,EE,00346D24,byte,76
+patch=1,EE,00346D24,byte,38
+patch=1,EE,E0010001,extended,004B0604
+patch=1,EE,00346D24,extended,76

--- a/patches/SLES-53311_F28709A1.pnach
+++ b/patches/SLES-53311_F28709A1.pnach
@@ -1,0 +1,7 @@
+gametitle=Graffiti Kingdom (PAL-M) SLES-53311 F28709A1
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,001F1510,word,3C023FAB //3C023F80

--- a/patches/SLES-53350_4A198252.pnach
+++ b/patches/SLES-53350_4A198252.pnach
@@ -1,0 +1,6 @@
+gametitle=Sonic Gems Collection (PAL-M) SLES-53350 4A198252 Main CRC
+
+[Sonic CD 60 FPS]
+author=PeterDelta
+comment=Forces progressive scan mode when starting Sonic CD
+//Used to enable SLES-53350_82DB1E89.pnach elf: S1.DAT Sonic CD

--- a/patches/SLES-53350_82DB1E89.pnach
+++ b/patches/SLES-53350_82DB1E89.pnach
@@ -1,0 +1,9 @@
+gametitle=Sonic Gems Collection (PAL-M) SLES-53350 82DB1E89 elf: S1.DAT Sonic CD
+
+[Sonic CD 60 FPS]
+author=PeterDelta
+comment=Forces progressive scan mode when starting Sonic CD
+patch=1,EE,001025DC,word,3C050000
+patch=1,EE,001025E4,word,3C060052
+patch=1,EE,001025EC,word,3C070001
+patch=1,EE,1054F918,extended,01E0

--- a/patches/SLES-53414_BBF8C3D6.pnach
+++ b/patches/SLES-53414_BBF8C3D6.pnach
@@ -1,17 +1,22 @@
-gametitle=Echo Night: Beyond [PAL] (SLES_534.14)
+gametitle=Echo Night: Beyond [PAL] (SLES_534.14) BBF8C3D6
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by El_Patas and Arapapa
-
-//Widescreen hack 16:9
-
+author=El_Patas and Arapapa
+comment=Renders the game in 16:9 aspect ratio
 //Force turn on Internal Widescreen
 //01 00 00 00 00 00 00 3F
 patch=1,EE,202b4001,byte,00000001
-
-//Zoom Fix
 patch=1,EE,00146EA4,word,3C023F1F //3C023F00 Zoom
 //patch=1,EE,00146EA0,word,3C033FA0 //3C033F70 Y-FOV
 
+[60 FPS]
+author=PeterDelta
+comment=Select 60 Hz to unlock fps. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,E001001E,extended,0028A348
+patch=1,EE,0028A348,extended,0000003C
 
+[Performance Fix]
+author=PeterDelta
+comment=Remove flashlight shadows improving performance.
+patch=1,EE,001471C4,word,3C020000 //3C023F80

--- a/patches/SLES-53414_E078914A.pnach
+++ b/patches/SLES-53414_E078914A.pnach
@@ -1,0 +1,19 @@
+gametitle=Echo Night - Beyond (PAL-E) SLES-53414 E078914A (spanish 1.0.1)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=El_Patas and Arapapa
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,002b4001,byte,01 //Force turn on Internal Widescreen
+patch=1,EE,00146EA4,word,3C023F1F //3C023F00 Zoom
+
+[60 FPS]
+author=PeterDelta
+comment=Select 60 Hz to unlock fps. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,E001001E,extended,0028A348
+patch=1,EE,0028A348,extended,0000003C
+
+[Performance Fix]
+author=PeterDelta
+comment=Remove flashlight shadows improving performance.
+patch=1,EE,001471C4,word,3C020000 //3C023F80

--- a/patches/SLES-53416_DFB26142.pnach
+++ b/patches/SLES-53416_DFB26142.pnach
@@ -1,0 +1,8 @@
+gametitle=Call of Duty 2 - Big Red One (PAL-M3) SLES-53416 DFB26142
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,004080A0,extended,00000002
+patch=1,EE,E0010001,extended,004D8DB0
+patch=1,EE,204080A0,extended,00000001

--- a/patches/SLES-53443_FA3C1346.pnach
+++ b/patches/SLES-53443_FA3C1346.pnach
@@ -1,5 +1,10 @@
 gametitle=Warriors, The (PAL-M) SLES-53443 FA3C1346
 
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
+patch=1,EE,00596D70,byte,01
+
 [60 FPS]
 author=PeterDelta
 comment=Forces progressive scan and run at 60 fps

--- a/patches/SLES-53459_F73AC0A0.pnach
+++ b/patches/SLES-53459_F73AC0A0.pnach
@@ -1,8 +1,12 @@
-gametitle=Marc Ecko's Getting Up - Contents Under Pressure SLES_534.59
+gametitle=Marc Ecko's Getting Up - Contents Under Pressure (PAL-M) SLES_534.59 F73AC0A0
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack
+author=sergx12
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,0056768c,word,3c023f40
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,001CC7A8,word,00000001 //00000002

--- a/patches/SLES-53621_7C211BF9.pnach
+++ b/patches/SLES-53621_7C211BF9.pnach
@@ -1,17 +1,13 @@
-gametitle=Wallace & Gromit - The Curse of the Were-Rabbit (E)(SLES-53621)
+gametitle=Wallace & Gromit - The Curse of the Were-Rabbit (E)(SLES-53621) 7C211BF9
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,0011a4f4,word,3c013f1d //3c013f00 Zoom
+patch=1,EE,0011a598,word,3c014080 //3c014040 Y-Fov
 
-//Widescreen hack 16:9
-
-//Zoom
-//003f013c 00008144 7000b07f
-patch=1,EE,0011a4f4,word,3c013f1d //3c013f00
-
-//Y-Fov
-//4040013c 00008144 803e013c 00088144 (2nd)
-patch=1,EE,0011a598,word,3c014080 //3c014040
-
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,004349D5,word,00000000 //4500004D

--- a/patches/SLES-53635_CF3A1D37.pnach
+++ b/patches/SLES-53635_CF3A1D37.pnach
@@ -1,0 +1,12 @@
+gametitle=NASCAR '06 - Total Team Control (PAL-E) SLES-53635 CF3A1D37
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,003C1598,word,3F400000 //3F800000
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,002BBE7C,word,28420001 //28420002

--- a/patches/SLES-53636_64E8F1DC.pnach
+++ b/patches/SLES-53636_64E8F1DC.pnach
@@ -1,0 +1,8 @@
+gametitle=TY the Tasmanian Tiger 3 - Night of the Quinkan (PAL-M) SLES-53636 64E8F1DC
+
+[50 FPS]
+author=PeterDelta and asasega
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0012C85C,extended,28420001
+patch=1,EE,E0010000,extended,00516110
+patch=1,EE,2012C85C,extended,28420002

--- a/patches/SLES-53734_E3F32982.pnach
+++ b/patches/SLES-53734_E3F32982.pnach
@@ -1,49 +1,24 @@
-gametitle=50 Cent - Bulletproof (E)(SLES-53734)
+gametitle=50 Cent - Bulletproof (E)(SLES-53734) E3F32982
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa and 60 FPS by asasega
-
-//Gameplay 16:9
-
-//X-Fov 4:3 fix
-//e63e013c 1a8b2134 00608144 (2nd)
-//083f013c 83882134 00608144
-patch=1,EE,001eb448,word,3c013f08 //3c013ee6
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,001eb448,word,3c013f08 //3c013ee6 (2nd) X-Fov 4:3 fix
 patch=1,EE,001eb44c,word,34218883 //34218b1a
-
-//X-Fov Wide screen fix
-//80df4426 cc3e013c cdcc2134 00608144
-//80df4426 083f013c 83882134 00608144
-patch=1,EE,001eb464,word,3c013F08 //3c013ecc
+patch=1,EE,001eb464,word,3c013F08 //3c013ecc X-Fov Wide screen fix
 patch=1,EE,001eb468,word,34218883 //3421cccd
-
-//Font's Shadow fix
-//803f013c 00888144 01630246
-//403f013c 00888144 01630246
-patch=1,EE,00158464,word,3c013f40 //3c013f80
-
-//868c0046 ac00058e (1st)
-patch=1,EE,00158484,word,0807d744 //46008c86
-
+patch=1,EE,00158464,word,3c013f40 //3c013f80 Font's Shadow fix
+patch=1,EE,00158484,word,0807d744 //46008c86 (1st)
 patch=1,EE,001f5d10,word,3c013f80
 patch=1,EE,001f5d14,word,44819000
 patch=1,EE,001f5d18,word,08056122
-
-//Font fix
-//803f013c 00888144 01030c46
-//403f013c 00888144 01030c46
-patch=1,EE,001584b8,word,3c013f40 //3c013f80
-
-//868c0046 ac00058e (2nd)
-patch=1,EE,001584d4,word,0807d747 //46008c86
-
+patch=1,EE,001584b8,word,3c013f40 //3c013f80 Font fix
+patch=1,EE,001584d4,word,0807d747 //46008c86 868c0046 ac00058e (2nd)
 patch=1,EE,001f5d1c,word,3c013f80
 patch=1,EE,001f5d20,word,44819000
 patch=1,EE,001f5d24,word,08056136
-
-//Font fix (Menu)
-patch=1,EE,204E9668,extended,3F400000
+patch=1,EE,204E9668,extended,3F400000 //Font fix (Menu)
 patch=1,EE,204E9858,extended,3F400000
 patch=1,EE,204E9900,extended,3F400000
 patch=1,EE,204E99A4,extended,3F400000
@@ -125,9 +100,11 @@ patch=1,EE,204ECF98,extended,3F400000
 patch=1,EE,204ED750,extended,3F400000
 patch=1,EE,204ED7F4,extended,3F400000
 patch=1,EE,204ED898,extended,3F400000
-
-//Yes and No
-patch=1,EE,204F92DC,extended,3f400000
+patch=1,EE,204F92DC,extended,3f400000 //Yes and No
 patch=1,EE,204F9380,extended,3f400000
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,001B3CE8,word,3C014270 //3C0141F0
+patch=1,EE,00427FA4,word,3F000000 //3F800000

--- a/patches/SLES-53914_D65DF63F.pnach
+++ b/patches/SLES-53914_D65DF63F.pnach
@@ -1,10 +1,15 @@
-gametitle=The Plan [PAL-Spain] (SLES_539.14)
+gametitle=The Plan [PAL-Spain] (SLES_539.14) D65DF63F
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by El_Patas
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,0010E324,word,3C033F40 //3C033F80
+patch=1,EE,001719A8,word,3C013F40 //hud cross x-fov
+patch=1,EE,0025CF18,word,3C023F40 //hud cross y-fov
+patch=1,EE,0026C0B8,word,3C023FA0 //hud health
 
-//Gameplay 16:9
-patch=1,EE,001126B8,word,3C033FAB //3C033F80 (Increases hor. axis)
-
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,001B1B68,word,24040001 //24040002

--- a/patches/SLES-53965_ACE7A856.pnach
+++ b/patches/SLES-53965_ACE7A856.pnach
@@ -1,0 +1,15 @@
+gametitle=Plan, Th3 (PAL-E) SLES-53965 ACE7A856
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,0010E3F4,word,3C033F40 //3C033F80
+patch=1,EE,00172068,word,3C013F40 //hud cross x-fov
+patch=1,EE,0025E6AC,word,3C023F40 //hud cross y-fov
+patch=1,EE,0026DD38,word,3C023FA0 //hud health
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,001B25C8,word,24040001 //24040002

--- a/patches/SLES-54152_802F7B69.pnach
+++ b/patches/SLES-54152_802F7B69.pnach
@@ -1,0 +1,6 @@
+gametitle=Ant Bully, The (PAL-M) SLES-54152 802F7B69
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0015CD54,word,2C620000 //0062102B

--- a/patches/SLES-54167_247F025E.pnach
+++ b/patches/SLES-54167_247F025E.pnach
@@ -1,0 +1,8 @@
+gametitle=Call of Duty 3 (PAL-M3) SLES-54167 247F025E
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,0053CF84,extended,00000002
+patch=1,EE,E0010001,extended,00479D0C
+patch=1,EE,2053CF84,extended,00000001

--- a/patches/SLES-54223_8AE96AEE.pnach
+++ b/patches/SLES-54223_8AE96AEE.pnach
@@ -1,0 +1,12 @@
+gametitle=NASCAR '07 (PAL-E) SLES-54223 8AE96AEE
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,003E54A8,word,3F400000 //3F800000
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,002E068C,word,28420001 //28420002

--- a/patches/SLES-54237_E6C2F211.pnach
+++ b/patches/SLES-54237_E6C2F211.pnach
@@ -1,4 +1,4 @@
-gametitle=Pirates of The Caribbean - The Legend of Jack Sparrow PAL[M5] (SLES_542.37)
+gametitle=Pirates of The Caribbean - The Legend of Jack Sparrow PAL[M5] (SLES_542.37) E6C2F211
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -7,4 +7,7 @@ author=Bigdemon
 //16:9
 patch=1,EE,204931D8,extended,3FAB851F // 3F800000
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,00385084,word,24030000 //24030001

--- a/patches/SLES-54316_30204F8E.pnach
+++ b/patches/SLES-54316_30204F8E.pnach
@@ -1,22 +1,20 @@
-gametitle=Open Season (E)(SLES-54316)
+gametitle=Open Season (E)(SLES-54316) 30204F8E
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen 16:9
-
-//X-Fov
-//02100046 700120e6
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
+//02100046 700120e6 X-Fov
 patch=1,EE,003f9d2c,word,08153acc
 patch=1,EE,0054eb30,word,46001002
 patch=1,EE,0054eb34,word,3c013f40
 patch=1,EE,0054eb38,word,4481f000
 patch=1,EE,0054eb3c,word,461e0002
 patch=1,EE,0054eb40,word,080fe74c
-
-//Render fix
-//3443033c b00421c6
+//3443033c b00421c6 Render fix
 patch=1,EE,00291b6c,word,3c034300 //3c034334
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,00567F18,word,00000001 //00000002

--- a/patches/SLES-54510_C76031E8.pnach
+++ b/patches/SLES-54510_C76031E8.pnach
@@ -1,18 +1,16 @@
-gametitle=Disney's Meet the Robinsons (E)(SLES-54510)
+gametitle=Disney's Meet the Robinsons (E)(SLES-54510) C76031E8
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen hack 16:9
-
-//X-Fov
-patch=1,EE,003a3564,word,3c013faa //00000000
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,003a3564,word,3c013faa //00000000 X-Fov
 patch=1,EE,003a3568,word,3421aaab //00000000
 patch=1,EE,003a358c,word,4481f000 //00000000
 patch=1,EE,003a3590,word,461e6b42 //00000000
+patch=1,EE,002670d0,word,3c013f2b //3c013f00 Render fix
 
-//Render fix
-patch=1,EE,002670d0,word,3c013f2b //3c013f00
-
-
+[50/60 FPS]
+author=PeterDelta
+comment=Unlocked at 50/60 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0060EB1C,word,00000001 //00000002

--- a/patches/SLES-54583_904A9089.pnach
+++ b/patches/SLES-54583_904A9089.pnach
@@ -1,13 +1,13 @@
-gametitle=Surf's Up (E)(SLES-54583)
+gametitle=Surf's Up (PAL-M)(SLES-54583) 904A9089
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen hack 16:9
-
-//X-Fov
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,006056a4,word,3c033ec0 //3c033f00
 patch=1,EE,0060e678,word,3c033ec0 //3c033f00
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0060704C,word,28630001 //28630002

--- a/patches/SLES-54720_55AFBD7E.pnach
+++ b/patches/SLES-54720_55AFBD7E.pnach
@@ -1,0 +1,6 @@
+gametitle=Shield - The Game, The (PAL-M) SLES-54720 55AFBD7E
+
+[50/60 FPS]
+author=PeterDelta
+comment=Unlocked at 50/60 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0036AFFC,word,00000001 //00000002

--- a/patches/SLES-54813_2E98C05B.pnach
+++ b/patches/SLES-54813_2E98C05B.pnach
@@ -1,0 +1,7 @@
+gametitle=NASCAR '08 (PAL-E) SLES-54813 2E98C05B
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,003FC9E0,word,3F400000 //3F800000

--- a/patches/SLES-54820_9454F864.pnach
+++ b/patches/SLES-54820_9454F864.pnach
@@ -1,13 +1,13 @@
-gametitle=Stuntman Ignition (E)(SLES-54820)
-
+gametitle=Stuntman Ignition (PAL-M) SLES-54820 9454F864
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Bigdemon
-comment=Widescreen hack conversion
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,002AA174,word,3C023F10 //3C023F40
+patch=1,EE,005AC8E0,word,3F0BC36F //3F3A59EA
 
-//Zoom
-patch=1,EE,002aa174,word,3c023f10 //3c023f40
-
-//Y-Fov
-patch=1,EE,205AA760,extended,3F252945 //3f5c370f  Memory Hack. but able to ISO patch.
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0033FC60,word,00000000 //1440FFF7

--- a/patches/SLES-54901_678BE0A5.pnach
+++ b/patches/SLES-54901_678BE0A5.pnach
@@ -1,10 +1,12 @@
-gametitle=Spider-Man: Friend or Foe (PAL-M5) (SLES_549.01)
+gametitle=Spider-Man: Friend or Foe (PAL-M5) (SLES_549.01) 678BE0A5
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by El_Patas
-
-//Gameplay 16:9
+author=El_Patas
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,203EC6C8,extended,3FE38E38 //3FAAAAAB (Increases hor. axis)
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,0037DF20,word,00000001 //00000002

--- a/patches/SLES-54997_A97B93F7.pnach
+++ b/patches/SLES-54997_A97B93F7.pnach
@@ -1,0 +1,16 @@
+gametitle=Mercenaries 2 - World in Flames (PAL-E) SLES-54997 A97B93F7
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,0037CC14,word,3C013F40 //3C013F80
+patch=1,EE,00380F1C,word,3C013F2B //3C013F00 render fix
+patch=1,EE,00389870,word,3C013F2B //3C013F00 render fix 2
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,003FD244,extended,3C0200A0
+patch=1,EE,E0010000,extended,0055D9E4
+patch=1,EE,003FD244,extended,3C020050

--- a/patches/SLES-55001_A97C9BFD.pnach
+++ b/patches/SLES-55001_A97C9BFD.pnach
@@ -1,9 +1,9 @@
-gametitle=Mercenaries 2: World in Flames [PAL-Spain] (SLES_550.01)
+gametitle=Mercenaries 2: World in Flames [PAL-Spain] (SLES_550.01) A97C9BFD
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by El_Patas
-
+author=El_Patas
+comment=Renders the game in 16:9 aspect ratio
 // 16:9
 patch=1,EE,0037c350,word,3c013f40 //00000000 hor fov
 
@@ -26,4 +26,9 @@ patch=1,EE,0055684c,word,46030002 //00000000 hud-identification fix
 patch=1,EE,00556850,word,461e0002 //00000000 hud-identification fix
 patch=1,EE,00556854,word,080ce663 //00000000 hud-identification fix
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,003FD244,extended,3C0200A0
+patch=1,EE,E0010000,extended,0055D9E4
+patch=1,EE,003FD244,extended,3C020050

--- a/patches/SLES-55199_CB0AEC6F.pnach
+++ b/patches/SLES-55199_CB0AEC6F.pnach
@@ -1,0 +1,7 @@
+gametitle=NASCAR '09 (PAL-E) SLES-55199 CB0AEC6F
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,003EC430,word,3F400000 //3F800000

--- a/patches/SLES-55429_841CF939.pnach
+++ b/patches/SLES-55429_841CF939.pnach
@@ -1,10 +1,12 @@
-gametitle=Bolt [PAL-M3] (SLES_554.29)
+gametitle=Disney Bolt (PAL-M3) SLES-55429 841CF939
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by El_Patas
-
-//Gameplay 16:9
+author=El_Patas
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,0068C3EC,word,3FE38E39 //3FAAAAAB (Increases hor. axis)
 
-
+[50/60 FPS]
+author=PeterDelta
+comment=Unlocked at 50/60 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,007E65EC,word,00000001 //00000002

--- a/patches/SLES-55430_F77BF348.pnach
+++ b/patches/SLES-55430_F77BF348.pnach
@@ -1,0 +1,12 @@
+gametitle=Disney Bolt (PAL-M3) SLES-55430 F77BF348
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,0068C27C,word,3FE38E39 //3FAAAAAB
+
+[50/60 FPS]
+author=PeterDelta
+comment=Unlocked at 50/60 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,007E886C,word,00000001 //00000002

--- a/patches/SLES-82024_79ED26AD.pnach
+++ b/patches/SLES-82024_79ED26AD.pnach
@@ -1,0 +1,14 @@
+gametitle=Metal Gear Solid 3 - Snake Eater (PAL-I) SLES-82024 79ED26AD
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,00203FAC,word,3F400000 //3F800000
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,001D5E78,word,00000001 //00000002
+patch=1,EE,001D5E7C,word,00000000 //00000001
+patch=1,EE,001D4BA8,word,00000000 //00000040

--- a/patches/SLES-82026_98D4BC93.pnach
+++ b/patches/SLES-82026_98D4BC93.pnach
@@ -1,0 +1,14 @@
+gametitle=Metal Gear Solid 3 - Snake Eater (PAL-S) SLES-82026 98D4BC93
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,00203FAC,word,3F400000 //3F800000
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,001D5E78,word,00000001 //00000002
+patch=1,EE,001D5E7C,word,00000000 //00000001
+patch=1,EE,001D4BA8,word,00000000 //00000040

--- a/patches/SLUS-20271_6CD016D5.pnach
+++ b/patches/SLUS-20271_6CD016D5.pnach
@@ -1,4 +1,4 @@
-gametitle=Shifters SLUS_202.71
+gametitle=Shifters SLUS_202.71 6CD016D5
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -6,4 +6,7 @@ comment=Widescreen Hack
 patch=1,EE,204c4ed0,extended,3F81DE4A
 patch=1,EE,204c4f50,extended,3F81DE4A
 
-
+[60 FPS]
+author=PeterDelta
+comment=Unlocked at 60 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,004C4E9C,word,00000001 //00000002 

--- a/patches/SLUS-20632_56B36513.pnach
+++ b/patches/SLUS-20632_56B36513.pnach
@@ -1,21 +1,21 @@
-gametitle=XGRA - Extreme G Racing Association (U)(SLUS-20632)
+gametitle=XGRA - Extreme G Racing Association (U)(SLUS-20632) 56B36513
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen hack 16:9
-
-//Zoom
-//003f013c 00088144 b00644c6
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
+//003f013c 00088144 b00644c6 Zoom
 patch=1,EE,0019d554,word,3c013ec0 //3c013f00
-
-//Y-Fov
-//00000000 00000000 83b50046 00000000 00000000
+//00000000 00000000 83b50046 00000000 00000000 Y-Fov
 //aa3f013c abaa2134 83b50046 00f08144 c2bd1e46
 patch=1,EE,0019d574,word,3c013faa
 patch=1,EE,0019d578,word,3421aaab
 patch=1,EE,0019d580,word,4481f000
 patch=1,EE,0019d584,word,461ebdc2
 
-
+[60 FPS]
+author=PeterDelta
+comment=Unlocked at 60 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,002052C4,word,1040FFFA
+patch=1,EE,E0010000,extended,01FFE32C
+patch=1,EE,202052C4,extended,00000000

--- a/patches/SLUS-20701_8F6A1960.pnach
+++ b/patches/SLUS-20701_8F6A1960.pnach
@@ -1,19 +1,17 @@
-gametitle=Scooby-Doo! Mystery Mayhem (U)(SLUS-20701)
+gametitle=Scooby-Doo! Mystery Mayhem (U)(SLUS-20701) 8F6A1960
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen hack 16:9
-
-//X-Fov
-//43000146 0400048e
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,001978a0,word,0809fa4c
-
 patch=1,EE,0027e930,word,46010043
 patch=1,EE,0027e934,word,3c013f40
 patch=1,EE,0027e938,word,4481f000
 patch=1,EE,0027e93c,word,461e0842
 patch=1,EE,0027e940,word,08065e29
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0049AAB8,word,0000003C

--- a/patches/SLUS-21015_09052A4D.pnach
+++ b/patches/SLUS-21015_09052A4D.pnach
@@ -1,24 +1,23 @@
-gametitle=DreamWorks Madagascar (U)(SLUS-21015)
+gametitle=DreamWorks Madagascar (U)(SLUS-21015) 09052A4D
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
 comment=Widescreen Hack
-
-//Widescreen hack 16:9
-
 //Zoom
 //003f013c 00008144 3c008cc4
 patch=1,EE,0014a0e0,word,3c013f21 //3c013f00
-
 //Y-Fov
 //43000146 0400048e
 patch=1,EE,002881c8,word,08045ca0
-
 patch=1,EE,00117280,word,46010043
 patch=1,EE,00117284,word,3c013f40
 patch=1,EE,00117288,word,4481f000
 patch=1,EE,0011728c,word,461e1082
 patch=1,EE,00117290,word,080a2073
 
-
+[60 FPS]
+author=PeterDelta
+comment=Unlocked at 60 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,004B0304,byte,01
+patch=1,EE,003469C4,byte,78

--- a/patches/SLUS-21032_1CF99B88.pnach
+++ b/patches/SLUS-21032_1CF99B88.pnach
@@ -1,8 +1,12 @@
-gametitle=Marc Ecko's Getting Up - Contents Under Pressure SLUS_210.32
+gametitle=Marc Ecko's Getting Up - Contents Under Pressure (NTSC-U) SLUS_210.32 1CF99B88
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack
+author=sergx12
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,0056764c,word,3c023f40
 
-
+[60 FPS]
+author=PeterDelta
+comment=Unlocked at 60 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,001CC728,word,00000001 //00000002

--- a/patches/SLUS-21127_17E7E24E.pnach
+++ b/patches/SLUS-21127_17E7E24E.pnach
@@ -1,0 +1,8 @@
+gametitle=Brave - The Search for Spirit Dancer (NTSC-U) SLUS-21127 17E7E24E
+
+[60 FPS]
+author=PeterDelta
+comment=Unlocked at 60 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,2033AF04,extended,00000000
+patch=1,EE,E0010000,extended,003C6D68
+patch=1,EE,2033AF04,extended,1040FFFA

--- a/patches/SLUS-21467_06BBB610.pnach
+++ b/patches/SLUS-21467_06BBB610.pnach
@@ -1,22 +1,20 @@
-gametitle=Open Season (U)(SLUS-21467)
+gametitle=Open Season (U)(SLUS-21467) 06BBB610
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen 16:9
-
-//X-Fov
-//02100046 700120e6
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
+//02100046 700120e6 X-Fov
 patch=1,EE,003f993c,word,08150c04
 patch=1,EE,00543010,word,46001002
 patch=1,EE,00543014,word,3c013f40
 patch=1,EE,00543018,word,4481f000
 patch=1,EE,0054301c,word,461e0002
 patch=1,EE,00543020,word,080fe650
-
-//Render fix
-//3443033c b00421c6
+//3443033c b00421c6 Render fix
 patch=1,EE,00291a1c,word,3c034300 //3c034334
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,00567378,word,00000001 //00000002


### PR DESCRIPTION
I add 60 fps and widescreen patches tested and working without problems.

Notable changes:
Stuntman Ignition SLES-54820_9454F864
![1](https://github.com/PCSX2/pcsx2_patches/assets/151682118/3f31756a-9e43-4859-b3fa-517d11af3363)
4:3 original
![2](https://github.com/PCSX2/pcsx2_patches/assets/151682118/27f5efff-2504-430b-b488-1cb94087e5f6)
My patch maintains the original aspect ratio of the game.
patch=1,EE,002AA174,word,3C023F10 //3C023F40
patch=1,EE,005AC8E0,word,3F0BC36F //3F3A59EA

![3](https://github.com/PCSX2/pcsx2_patches/assets/151682118/14b9dce3-1e67-4633-8672-d81ed27b2af3)
This patch does not maintain the aspect ratio for 16:9.
patch=1,EE,002aa174,word,3c023f10 //3c023f40
patch=1,EE,205AA760,extended,3F252945 //3f5c370f
______________________________________________________________________________________________________
Plan, Th3 SLES-53914_D65DF63F

![the plan](https://github.com/PCSX2/pcsx2_patches/assets/151682118/3f74550a-6909-4681-baac-7a0f6b096ae5)

The old address 001126B8 is valid, but the appropriate one is 0010E324. Just below this, the address 0010E328 occupies the Y axis, which is not necessary for 16:9. I also added small adjustments to the HUD.