### PR TITLE
Remove no-interlaced patches

### DIFF
--- a/patches/SCES-50240_68707E85.pnach
+++ b/patches/SCES-50240_68707E85.pnach
@@ -8,12 +8,3 @@ comment=Widescreen Hack
 //Gameplay 16:9
 patch=1,EE,001D3158,word,3C023F19 //3C023F4C (Increases hor. axis)
 patch=1,EE,001D315C,word,3442AAAB //3442CCCD
-
-
-[No-Interlacing]
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-patch=1,EE,00101614,word,00000000
-patch=1,EE,0010187c,word,00000000
-
-

--- a/patches/SCUS-97112_0AE679AF.pnach
+++ b/patches/SCUS-97112_0AE679AF.pnach
@@ -5,12 +5,3 @@ gsaspectratio=16:9
 comment=Widescreen Hack
 patch=1,EE,001d2978,extended,3c023f19
 patch=1,EE,001d297c,extended,3442999a
-
-
-[No-Interlacing]
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-patch=1,EE,20101614,word,00000000
-patch=1,EE,2010187C,word,00000000
-
-

--- a/patches/SLES-50672_4A9D8E01.pnach
+++ b/patches/SLES-50672_4A9D8E01.pnach
@@ -31,12 +31,3 @@ patch=1,EE,00152C40,word,3C014440 // 3C014480
 ; Render fix
 patch=1,EE,003224C8,word,3FE2FC96 // 3FAA3D71
 patch=1,EE,003224EC,word,3FE2FC96 // 3FAA3D71
-; ==========
-
-
-[No-Interlacing]
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-patch=1,EE,00204C58,word,30420000
-
-

--- a/patches/SLES-51433_CDD0C904.pnach
+++ b/patches/SLES-51433_CDD0C904.pnach
@@ -1,16 +1,7 @@
-gametitle=Ghost Vibration SLES_514.33
+gametitle=Ghost Vibration (PAL-E) SLES_514.33 CDD0C904
 
 [Widescreen 16:9]
 gsaspectratio=16:9
+author=sergx12
 comment=Widescreen Hack
 patch=1,EE,001F26F0,word,3F400000 // 3F800000
-
-
-[No-Interlacing]
-gsinterlacemode=1
-comment=No interlacing
-
-//No interlacing
-patch=1,EE,201020CC,extended,64420000
-
-

--- a/patches/SLES-53039_5C64E73A.pnach
+++ b/patches/SLES-53039_5C64E73A.pnach
@@ -34,13 +34,3 @@ patch=1,EE,001869f0,word,461ece43 // 44810800
 //patch=1,EE,001869d4,word,4499f000 // 00000000
 //patch=1,EE,001869ec,word,4600b047 // 3c01bf80
 //patch=1,EE,001869f0,word,461ece43 // 44810800
-
-
-[No-Interlacing]
-gsinterlacemode=1
-comment=Disable interlacing hack by ElHecht
-
-// disable interlacing
-patch=1,EE,0019e2e8,word,aca00008 // aca60008
-
-

--- a/patches/SLUS-20035_773A8DAB.pnach
+++ b/patches/SLUS-20035_773A8DAB.pnach
@@ -46,12 +46,3 @@ patch=1,EE,00320fcc,word,3fe3d70a
 ; render fix value by No.47
 // patch=1,EE,00320fa8,word,3FCC49BB
 // patch=1,EE,00320fcc,word,3FCC49BB
-; ==========
-
-
-[No-Interlacing]
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-patch=1,EE,20203B9C,word,34030001
-
-

--- a/patches/SLUS-20675_B0859096.pnach
+++ b/patches/SLUS-20675_B0859096.pnach
@@ -28,11 +28,3 @@ patch=1,EE,002c4578,word,3421d70a
 //patch=1,EE,002c82d4,word,3c014288 //alternate render fix value
 patch=1,EE,002c82dc,word,3c013fe3
 patch=1,EE,002c82e0,word,3421d70a
-
-
-[No-Interlacing]
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-patch=1,EE,201EA278,extended,30630000
-
-

--- a/patches/SLUS-20973_4028A55F.pnach
+++ b/patches/SLUS-20973_4028A55F.pnach
@@ -21,11 +21,3 @@ patch=1,EE,002A8914,word,3C013FE2 //3C013FAA
 patch=1,EE,002A8918,word,3421FC95 //34213D70
 patch=1,EE,002A8948,word,3C013FE2 //3C013FAA
 patch=1,EE,002A894C,word,3421FC95 //34213D70
-
-
-[No-Interlacing]
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-patch=1,EE,2019D9D4,extended,ACA00008
-
-


### PR DESCRIPTION
With the new revisions, pcsx2 does an excellent job with interlacing and there are really very few games that require this.
As seen in the images, the interlacing patch prevents the letters from displaying correctly and the sawtooth becomes more noticeable in the graphics, even if we increase the resolution.
On the left side interlaced patch enabled and on the right interlaced patch disabled

![Baldurs gate 1](https://github.com/PCSX2/pcsx2_patches/assets/79443698/a9d3183c-3c6e-47d4-9db4-7ea8ca4ae9b1)
Baldur's Gate - Dark Alliance
![Baldurs gate 2](https://github.com/PCSX2/pcsx2_patches/assets/79443698/89b4d29b-b7da-4d73-bbfd-b22996e8a837)
Baldur's Gate - Dark Alliance 2
![champions return to arm](https://github.com/PCSX2/pcsx2_patches/assets/79443698/c6d15dd4-665e-4394-a769-6ec5cc999f61)
Champions - Return to Arms
![extermination](https://github.com/PCSX2/pcsx2_patches/assets/79443698/91db6bb4-02f5-49fd-a083-0b5daed1683a)
Extermination
![ghost vibration](https://github.com/PCSX2/pcsx2_patches/assets/79443698/0cb95c0f-e232-4fc8-b710-bd7a52dee540)
Ghost Vibration