### PR TITLE
Add guncon flash removal patch for Time Crisis: Crisis Zone

### DIFF
--- a/patches/SLUS-20927_E0D4421A.pnach
+++ b/patches/SLUS-20927_E0D4421A.pnach
@@ -5,4 +5,12 @@ gsaspectratio=16:9
 comment=Widescreen Hack
 patch=1,EE,00100658,word,3c033f40
 
-
+[No Guncon Flash]
+author=Souzooka
+description=Removes the flash and fog effect when firing with the Guncon controller.
+// Sudden white flash
+patch=0,EE,20126EF0,extended,03E00008
+patch=0,EE,20126EF4,extended,00000000
+// Full-auto fog effect
+patch=0,EE,20126FB0,extended,03E00008
+patch=0,EE,20126FB4,extended,00000000


### PR DESCRIPTION
This removes the flash/fog effect when firing weapons in Time Crisis: Crisis Zone using the Guncon. 

Before:
https://cdn.discordapp.com/attachments/453242743292952578/1190917518408290324/2023-12-31_02-20-04.mp4?ex=65a38b5e&is=6591165e&hm=a0f5596a37ddb029fd20cbf27f3aefddc0e136a22769adce83c0dcb77ce55ba1&

After:
https://cdn.discordapp.com/attachments/1185062307571695636/1190948508941946890/2023-12-31_04-16-22.mp4?ex=65a3a83b&is=6591333b&hm=3d49fbc979f9869afb73721236a874989a7a7d4a34d8178208bd413334d11e35&

Wasn't particularly sure of the exact syntax/meaning (for comments and the text in brackets and such) so let me know if anything needs to be changed.