### PR TITLE
SLUS-20831 Tokyo Xtreme Racing 3 Money Glitch Fix

### DIFF
--- a/SLUS-20831_0F932D81.pnach
+++ b/SLUS-20831_0F932D81.pnach
@@ -1,0 +1,4 @@
+//Fix for Money Glitch. 
+patch=0,EE,10255c00,extended,B560
+patch=0,EE,10255c04,extended,1430
+patch=0,EE,10255c20,extended,1182


### PR DESCRIPTION
Made it so that Tokyo Xtreme Racer 3 is now able to be won with out any cheat codes.  This changes the requirements to meet two wanderers (lowers the requirements by 100x, which is what the developers likely intended but did not do).  

With out the changes Whirlwind Fanfare was impossible to get as the requirement was 1 more than the highest possible money, and Exotic Butterfly is more money than the player would earn on an entire playthrough of the game. 