### PR TITLE
SLUS-20831 TXR3 Wanderers fix

### DIFF
--- a/SLUS-20831_0F932D81.pnach
+++ b/SLUS-20831_0F932D81.pnach
@@ -1,4 +1,0 @@
-//Fix for Money Glitch. 
-patch=0,EE,10255c00,extended,B560
-patch=0,EE,10255c04,extended,1430
-patch=0,EE,10255c20,extended,1182

--- a/SLUS-20831_0F932D81.pnach
+++ b/SLUS-20831_0F932D81.pnach
@@ -1,0 +1,4 @@
+//Fix for Money Glitch. 
+patch=0,EE,10255c00,extended,B560
+patch=0,EE,10255c04,extended,1430
+patch=0,EE,10255c20,extended,1182

--- a/patches/SLUS-20831_0F932D81.pnach
+++ b/patches/SLUS-20831_0F932D81.pnach
@@ -12,4 +12,9 @@ description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,20131684,extended,00000000
 
-
+[Wanderers Fix]
+author=Kinglink
+comment=Reduce Exotic Butterfly and Whirlwind Fanfare's Credit(CP) requirements by 100.
+patch=0,EE,10255c00,extended,B560
+patch=0,EE,10255c04,extended,1430
+patch=0,EE,10255c20,extended,1182


### PR DESCRIPTION
There are two Wanderers in Tokyo Xtreme Racer 3 that is unreachable in the American release.  The localization team left these at the Japanese values of 100 million (for Whirlwind Fanfare), and 20 million (For Exotic Butterfly).  They changed the starting cash from 4 million credits to 40 thousand credits.   

This is a fix that reduces the requirements for those two Wanderers to 1 million credits and 200 thousand credits (Which is the reduction by a factor of 100 that all other credit values changed).  

This will make it so Whirlwind Fanfare is reachable for the first time in 20 years with out a cheat device, and make players be able to reach Exotic Butterfly correctly. 

Let me know if there are any issues. 