### PR TITLE
Adding widescreen and fps patches

### DIFF
--- a/patches/SLES-50044_55EDA5A0.pnach
+++ b/patches/SLES-50044_55EDA5A0.pnach
@@ -1,36 +1,31 @@
-gametitle=Rayman Revolution (PAL-M5) (SLES-50044)
+gametitle=Rayman Revolution (PAL-M5) (SLES-50044) 55EDA5A0
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hacks by ElHecht & ICUP321
-
+author=ElHecht & ICUP321
+comment=Widescreen Hacks
 // General Widescreen Fixes
 patch=1,EE,0018c6a0,word,4481f000 // 00000000
 patch=1,EE,0018c6a4,word,461e0842 // 00000000
 patch=1,EE,001180ec,word,461e6303 // 00000000 renderfix calculation
-
 // 16:9
 patch=1,EE,0018c690,word,3c013f40 // 00000000 hor fov
 
 // 15:9
 //patch=1,EE,0018c690,word,3c013f50 // 00000000 hor fov
-
 // 16:10
 //patch=1,EE,0018c690,word,3c013f55 // 00000000 hor fov
 //patch=1,EE,0018c694,word,34215555 // 00000000 hor fov
-
 // 21:9
 //patch=1,EE,0018c690,word,3c013f10 // 00000000 hor fov
-
 // 25:16
 //patch=1,EE,0018c690,word,3c013f5a // 00000000 hor fov
 //patch=1,EE,0018c694,word,3421740e // 00000000 hor fov
-
 // 32:9
 //patch=1,EE,0018c690,word,3c013ed5 // 00000000 hor fov
 //patch=1,EE,0018c694,word,3421c28f // 00000000 hor fov
 
-
 [50 FPS]
-description=Patches the game to run at 50 FPS.
-patch=1,EE,2010121C,extended,00000000
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,001011FC,word,24030000 //24030001

--- a/patches/SLES-50069_FD8F4257.pnach
+++ b/patches/SLES-50069_FD8F4257.pnach
@@ -1,0 +1,12 @@
+gametitle=Top Gear Daredevil (PAL-E) SLES-50069 FD8F4257
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,00143DB4,word,3C013EC0 //3C013F00
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0010099C,word,3C012000 //3C014000

--- a/patches/SLES-50074_4A805DF1.pnach
+++ b/patches/SLES-50074_4A805DF1.pnach
@@ -1,0 +1,6 @@
+gametitle=Unreal Tournament (PAL-E) SLES-50074 4A805DF1
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,0012D394,word,28420001 //28420002

--- a/patches/SLES-50955_0CEB8F2F.pnach
+++ b/patches/SLES-50955_0CEB8F2F.pnach
@@ -1,0 +1,6 @@
+gametitle=London Racer 2 (PAL-M) SLES-50955 0CEB8F2F
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,00254824,word,00000000 //1440FFFA

--- a/patches/SLES-51821_83466553.pnach
+++ b/patches/SLES-51821_83466553.pnach
@@ -1,11 +1,14 @@
-gametitle=Alias (Pal-M5)(SLES-51821)
+gametitle=Alias (Pal-M5)(SLES-51821) 83466553
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
-
-// 16:9
+author=ElHecht
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,00248138,word,3c013ec0 // 3c013f00 hor fov
 patch=1,EE,001f3c70,word,3c013f40 // 3c013f80 renderfix
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0024BEAC,word,2C420000 //2C42001E
+patch=1,EE,001DED08,word,3C013F00 //3C013F80

--- a/patches/SLES-52247_36ECD588.pnach
+++ b/patches/SLES-52247_36ECD588.pnach
@@ -1,0 +1,16 @@
+gametitle=The Hobbit (PAL-R) SLES-52247 36ECD588
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,002FA6AC,word,3C013EC0 //3C013F00
+patch=1,EE,0038B168,word,3C013EC0 //3C013F00
+patch=1,EE,0038B27C,word,3C013F40 //3C013F00
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,2040458C,extended,00000001
+patch=1,EE,E0010000,extended,003E9010
+patch=1,EE,2040458C,extended,00000002

--- a/patches/SLES-52729_59A5C81C.pnach
+++ b/patches/SLES-52729_59A5C81C.pnach
@@ -10,6 +10,6 @@ patch=1,EE,203018E0,extended,3F891A2A //3fb6cb8f
 [50 FPS]
 author=asasega and PeterDelta
 comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
-patch=1,EE,20343668,extended,00000002
-patch=1,EE,E0010001,extended,002DA2D8
-patch=1,EE,20343668,extended,00000001
+patch=1,EE,00343668,extended,00000001
+patch=1,EE,E0010000,extended,002DCE80
+patch=1,EE,00343668,extended,00000002

--- a/patches/SLES-52857_38351989.pnach
+++ b/patches/SLES-52857_38351989.pnach
@@ -1,0 +1,6 @@
+gametitle=Fairly OddParents, The - Shadow Showdown (PAL-M) SLES-52857 38351989
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,004D1414,word,42700000 //41F00000

--- a/patches/SLES-53575_82CA3505.pnach
+++ b/patches/SLES-53575_82CA3505.pnach
@@ -1,0 +1,19 @@
+gametitle=Bratz - Rock Angelz (PAL-S) SLES-53575 82CA3505
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,002FAF64,word,3C013F40
+patch=1,EE,002FAF68,word,4481F000
+patch=1,EE,002FAF70,word,461EB582
+patch=1,EE,0035BFD4,word,3C013F2B
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0031C7D4,extended,03E00004
+patch=1,EE,0034C5B4,extended,3C013F00
+patch=1,EE,E0020001,extended,003E3F50
+patch=1,EE,0031C7D4,extended,03E00008
+patch=1,EE,0034C5B4,extended,3C013F80 

--- a/patches/SLES-53654_2E66AAEA.pnach
+++ b/patches/SLES-53654_2E66AAEA.pnach
@@ -1,0 +1,6 @@
+gametitle=London Racer - Destruction Madness (PAL-M) SLES-53654 2E66AAEA
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0021C828,word,44020000 //44820800

--- a/patches/SLES-54343_A90A973D.pnach
+++ b/patches/SLES-54343_A90A973D.pnach
@@ -1,14 +1,14 @@
-gametitle=Bratz: Forever Diamondz [PAL-M3] (SLES_543.43)
+gametitle=Bratz: Forever Diamondz [PAL-M3] (SLES_543.43) A90A973D
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by El_Patas
-
-//Gameplay 16:9
+author=El_Patas
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,0031F5D8,word,3C013F1E //3C013F00 Zoom
 patch=1,EE,00300934,word,3C013ED3 //3C013F00 Y-FOV
+patch=1,EE,00300848,word,3C013F2B //3C013F00 Render fix
 
-//Render fix
-patch=1,EE,00300848,word,3C013F2B //3C013F00
-
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,01FAFD9C,word,00000000 //00000001

--- a/patches/SLES-54473_8B0725D5.pnach
+++ b/patches/SLES-54473_8B0725D5.pnach
@@ -1,24 +1,21 @@
-gametitle=The Flintstones - Bedrock Racing (E)(SLES-54473)
+gametitle=The Flintstones - Bedrock Racing (E)(SLES-54473) 8B0725D5
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen hack 16:9
-
-//Zoom
-//003f013c 00008144 3800b7e7
-patch=1,EE,00180684,word,3c013f21 //3c013f00
-
-//Y-Fov
-//c2051546 2d200002
-patch=1,EE,001806d4,word,08087fb8
-
+author=Arapapa and PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,00180684,word,3c013f21 //3c013f00 Zoom
+patch=1,EE,001806d4,word,08087fb8 //Y-Fov
 patch=1,EE,0021fee0,word,461505c2
 patch=1,EE,0021fee4,word,3c013f40
 patch=1,EE,0021fee8,word,00000000
 patch=1,EE,0021feec,word,4481f000
 patch=1,EE,0021fef0,word,461ebdc2
 patch=1,EE,0021fef4,word,080601b6
+patch=1,EE,001286E4,word,3C013F40 //3C013F80 hud
+patch=1,EE,00128F78,word,3C013F40 //3C013F80 hud
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,005AEDE0,word,00000001 //00000002

--- a/patches/SLES-54527_4CB5D96E.pnach
+++ b/patches/SLES-54527_4CB5D96E.pnach
@@ -1,11 +1,14 @@
-gametitle=Flushed Away [PAL-M5] (SLES_545.27)
+gametitle=Flushed Away [PAL-M5] (SLES_545.27) 4CB5D96E
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by El_Patas
-
-//Gameplay 16:9
+author=El_Patas
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,0027CD34,word,3C013CAD //3C013C8E Zoom
 patch=1,EE,001C8334,word,3C013C6E //3C013C8E Y-FOV
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,002AE4A4,word,00000000 //00031A38
+patch=1,EE,003537A4,word,2405003C //2405001E

--- a/patches/SLES-54952_1712E9F9.pnach
+++ b/patches/SLES-54952_1712E9F9.pnach
@@ -1,11 +1,14 @@
-gametitle=Ben 10: Protector of Earth [PAL-M5] (SLES_549.52)
+gametitle=Ben 10: Protector of Earth [PAL-M5] (SLES_549.52) 1712E9F9
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by El_Patas
-
-//Gameplay 16:9
+author=El_Patas
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,0011940C,word,3C013F4D //3C013F89
 patch=1,EE,00119410,word,3421B6E0 //34212493
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,00268658,word,00000001 //00000002
+patch=1,EE,001637AC,word,3C013F30

--- a/patches/SLES-54989_FD4FE026.pnach
+++ b/patches/SLES-54989_FD4FE026.pnach
@@ -1,0 +1,17 @@
+gametitle=Bratz - The Movie (PAL-S-I) SLES-54989 FD4FE026
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,003DDD24,word,3C013F40
+patch=1,EE,003DDD28,word,4481F000
+patch=1,EE,003DDD30,word,461EB582
+patch=1,EE,003BD070,word,3C013F2B
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,003F4324,extended,46010003
+patch=1,EE,E0010000,extended,004C0850
+patch=1,EE,003F4324,extended,46010001

--- a/patches/SLES-55016_9D6AA1B8.pnach
+++ b/patches/SLES-55016_9D6AA1B8.pnach
@@ -1,19 +1,15 @@
-gametitle=Bee Movie Game (E)(SLES-55016)
+gametitle=Bee Movie Game (E)(SLES-55016) 9D6AA1B8
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
-
-//Widescreen hack 16:9
-
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
 //Zoom
 //003f023c 1c0101c6
 patch=1,EE,001864b0,word,3c023f1a //3c023f00
-
 //Y-Fov
 //03081546 9400a0e7
 patch=1,EE,0018652c,word,0808bad8
-
 patch=1,EE,0022eb60,word,46150803
 patch=1,EE,0022eb64,word,3c013faa
 patch=1,EE,0022eb68,word,3421aaab
@@ -21,4 +17,7 @@ patch=1,EE,0022eb6c,word,4481f000
 patch=1,EE,0022eb70,word,461e0002
 patch=1,EE,0022eb74,word,0806194c
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,00209798,word,28420001 //28420002

--- a/patches/SLES-55357_26847412.pnach
+++ b/patches/SLES-55357_26847412.pnach
@@ -1,12 +1,9 @@
-gametitle=Bratz - Girlz Really Rock (E)(SLES-55357)
+gametitle=Bratz - Girlz Really Rock (E)(SLES-55357) 26847412
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
-
-//Widescreen hack 16:9
-
-
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
 //X-Fov
 //00000000 00000000 83ad0046 00000000
 //403f013c 00f08144 83ad0046 82b51e46
@@ -14,4 +11,9 @@ patch=1,EE,003baf8c,word,3c013f40
 patch=1,EE,003baf90,word,4481f000
 patch=1,EE,003baf98,word,461eb582
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,003F4324,extended,46010003
+patch=1,EE,E0010000,extended,004AD52C
+patch=1,EE,003D189C,extended,46010001

--- a/patches/SLES-55374_76B70CCE.pnach
+++ b/patches/SLES-55374_76B70CCE.pnach
@@ -1,12 +1,16 @@
-gametitle=DreamWorks Madagascar 2 - Escape 2 Africa (E)(SLES-55374)
+gametitle=DreamWorks Madagascar 2 - Escape 2 Africa (E)(SLES-55374) 76B70CCE
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
-
-//Widescreen hack 16:9
-
-//X-Fov
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,001ff07c,word,3c023f1e //3c023f00
 
-
+[60 FPS]
+author=PeterDelta
+comment=Forces progressive scan mode at 60 fps
+patch=1,EE,00465124,word,3C050000
+patch=1,EE,0046512C,word,3C060052
+patch=1,EE,00465134,word,3C070001
+patch=1,EE,007B5C58,word,02058290
+patch=1,EE,007B5C60,word,02058290

--- a/patches/SLES-55486_084CC895.pnach
+++ b/patches/SLES-55486_084CC895.pnach
@@ -1,0 +1,12 @@
+gametitle=DreamWorks Monsters vs. Aliens (PAL-M) SLES-55486 084CC895
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,00179ED0,word,3C023FAB //3C023F80
+
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,0023391C,word,28420001 //28420002

--- a/patches/SLES-55592_35C84D80.pnach
+++ b/patches/SLES-55592_35C84D80.pnach
@@ -1,10 +1,14 @@
-gametitle=Ben 10: Alien Force Vilgax Attacks [PAL-M5] (SLES_555.92)
+gametitle=Ben 10: Alien Force Vilgax Attacks [PAL-M5] (SLES_555.92) 35C84D80
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by El_Patas
-
-//Gameplay 16:9
+author=El_Patas
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,2073DD54,extended,3FE38E38 //3FAAAAAB (Increases hor. axis)
 
-
+[50 FPS]
+author=asasega and PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,201002F4,extended,10000011
+patch=1,EE,E0010001,extended,004D114C
+patch=1,EE,201002F4,extended,45000011

--- a/patches/SLES-55625_5ED15549.pnach
+++ b/patches/SLES-55625_5ED15549.pnach
@@ -1,15 +1,16 @@
-gametitle=Despicable Me - The Game (E)(SLES-55625)
+gametitle=Despicable Me - The Game (E)(SLES-55625) 5ED15549
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
-
-//Widescreen hack 16:9
-
-//X-Fov
-
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
 patch=1,EE,00119874,word,00000000 //46140034
 patch=1,EE,001198bc,word,3c014235 //3c014265
 patch=1,EE,001198c0,word,3421e327 //34212ee1
 
-
+[Mode 480p]
+author=PeterDelta
+comment=Forces progressive scan mode 480p at startup
+patch=1,EE,004006E4,word,3C050000
+patch=1,EE,004006EC,word,3C060050
+patch=1,EE,004006F4,word,3C070001

--- a/patches/SLPM-67519_D2F77DF2.pnach
+++ b/patches/SLPM-67519_D2F77DF2.pnach
@@ -30,7 +30,7 @@ patch=1,EE,0011811c,word,461e6303 // 00000000 renderfix calculation
 //patch=1,EE,0018c7d0,word,3c013ed5 // 00000000 hor fov
 //patch=1,EE,0018c7d4,word,3421c28f // 00000000 hor fov
 
-
 [60 FPS]
-description=Patches the game to run at 60 FPS.
-patch=1,EE,2010121C,extended,00000000
+author=PeterDelta
+description=Unlocked at 60 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,001011FC,word,24030000 //24030001

--- a/patches/SLUS-20138_D2F77DF2.pnach
+++ b/patches/SLUS-20138_D2F77DF2.pnach
@@ -30,7 +30,7 @@ patch=1,EE,0011811c,word,461e6303 // 00000000 renderfix calculation
 //patch=1,EE,0018c7d0,word,3c013ed5 // 00000000 hor fov
 //patch=1,EE,0018c7d4,word,3421c28f // 00000000 hor fov
 
-
 [60 FPS]
-description=Patches the game to run at 60 FPS.
-patch=1,EE,2010121C,extended,00000000
+author=PeterDelta
+description=Unlocked at 60 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,001011FC,word,24030000 //24030001

--- a/patches/SLUS-21015_09052A4D.pnach
+++ b/patches/SLUS-21015_09052A4D.pnach
@@ -20,4 +20,4 @@ patch=1,EE,00117290,word,080a2073
 author=PeterDelta
 comment=Unlocked at 60 FPS. Might need enable 130% EE Overclock to be stable.
 patch=1,EE,004B0304,byte,01
-patch=1,EE,003469C4,byte,78
+patch=1,EE,003469C4,byte,77

--- a/patches/SLUS-21622_07717046.pnach
+++ b/patches/SLUS-21622_07717046.pnach
@@ -1,19 +1,15 @@
-gametitle=Bee Movie Game (U)(SLUS-21622)
+gametitle=Bee Movie Game (U)(SLUS-21622) 07717046
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
-
-//Widescreen hack 16:9
-
+author=Arapapa
+comment=Renders the game in 16:9 aspect ratio
 //Zoom
 //003f023c 1c0101c6
 patch=1,EE,001864b0,word,3c023f1a //3c023f00
-
 //Y-Fov
 //03081546 9400a0e7
 patch=1,EE,0018652c,word,0808bac4
-
 patch=1,EE,0022eb10,word,46150803
 patch=1,EE,0022eb14,word,3c013faa
 patch=1,EE,0022eb18,word,3421aaab
@@ -21,4 +17,7 @@ patch=1,EE,0022eb1c,word,4481f000
 patch=1,EE,0022eb20,word,461e0002
 patch=1,EE,0022eb24,word,0806194c
 
-
+[60 FPS]
+author=PeterDelta
+comment=Unlocked at 60 FPS. Might need enable 180% EE Overclock to be stable.
+patch=1,EE,00209798,word,28420001 //28420002

--- a/patches/SLUS-21870_D3C84C28.pnach
+++ b/patches/SLUS-21870_D3C84C28.pnach
@@ -35,4 +35,7 @@ patch=1,EE,00281ba8,word,4481f000
 patch=1,EE,00281bac,word,461ebdc2
 patch=1,EE,00281bb0,word,0808cdd0
 
-
+[50 FPS]
+author=PeterDelta
+comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,002338EC,word,28420001 //28420002


### PR DESCRIPTION
The patches are tested and work correctly.

Changes in Rayman 2 - Revolution. The previous patch maintains 50fps at all times and makes some scenes play twice as fast. Some examples of these scenes:

![rayman old](https://github.com/PCSX2/pcsx2_patches/assets/151682118/31203b7f-b902-4db3-84b5-b5ee63bd04d2)
Previous patch running at double speed

![rayman new](https://github.com/PCSX2/pcsx2_patches/assets/151682118/06c21e19-0235-4863-a4b5-55ced5092009)
New patch fixed

![rayman new usa](https://github.com/PCSX2/pcsx2_patches/assets/151682118/6bc14857-fcba-473a-a2d3-b4aaa9f9e3f8)

It works the same in ntsc-u version, in gameplay it changes automatically