### PR TITLE
Add Disable Depth of Field patch to Bully/Canis Canem

### DIFF
--- a/patches/SLES-53561_C78A495D.pnach
+++ b/patches/SLES-53561_C78A495D.pnach
@@ -1,8 +1,9 @@
-gametitle=Canis Canem Edit (SLES-53561)
+gametitle=Canis Canem Edit (Bully) PAL (SLES-53561) CRC C78A495D
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen fix by nemesis2000 (pnach by nemesis2000)
+author=nemesis2000
+description=Widescreen fix
 
 //Widescreen fix
 patch=1,EE,004720d0,word,14640007
@@ -33,23 +34,11 @@ patch=1,EE,2072a3c8,extended,432b0000
 patch=1,EE,e001aaab,extended,005e1638
 patch=1,EE,2072a3cc,extended,432b0000
 
-//patch=1,EE,e001aaab,extended,005e1638
-//patch=1,EE,204720cc,extended,24030000
+[Disable Depth of Field]
+author=refraction
+description=Removes depth of field effect
 
-//patch=1,EE,e001aaab,extended,005e1638
-//patch=1,EE,20222dec,extended,3c01bec0
-
-//patch=1,EE,e001aaab,extended,005e1638
-//patch=1,EE,201d5124,extended,3c023fc0
-
-//patch=1,EE,e0010000,extended,005e1638
-//patch=1,EE,204720cc,extended,90637c9e
-
-//patch=1,EE,e0010000,extended,005e1638
-//patch=1,EE,20222dec,extended,3c01bf00
-
-//patch=1,EE,e0010000,extended,005e1638
-//patch=1,EE,201d5124,extended,3c024000
+patch=1,EE,003DA2D4,word,5000021A //Skips DoF code block.
 
 [50 FPS]
 author=Gabominated

--- a/patches/SLPS-25879_019CFA48.pnach
+++ b/patches/SLPS-25879_019CFA48.pnach
@@ -1,8 +1,9 @@
-gametitle=Bully [NTSC-J] (SLPS-25879)
+gametitle=Bully [NTSC-J] (SLPS-25879) CRC 019CFA48
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa & El_Patas
+author=Arapapa & El_Patas
+description=Widescreen hack
 
 //Gameplay 16:9
 
@@ -24,4 +25,9 @@ patch=1,EE,0020c7cc,word,3c033f40 //3c033f80
 //Render fix
 patch=1,EE,001d52b4,word,3c023fc0 //3c024000
 
+[Disable Depth of Field]
+author=refraction
+description=Removes depth of field effect.
+
+patch=1,EE,003DB104,word,5000021A //Skips DoF code block.
 

--- a/patches/SLUS-21269_28703748.pnach
+++ b/patches/SLUS-21269_28703748.pnach
@@ -1,10 +1,10 @@
-gametitle=Bully (SLUS-21269)
+gametitle=Bully [NTSC-U] (SLUS-21269) CRC 28703748
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen fix by nemesis2000 (pnach by nemesis2000)
+author=nemesis2000
+description=Widescreen fix
 
-//Widescreen fix
 patch=1,EE,00471640,word,14640007
 patch=1,EE,00471644,word,3c030022
 patch=1,EE,00471648,word,2404bec0
@@ -33,27 +33,16 @@ patch=1,EE,20729748,extended,432b0000
 patch=1,EE,e001aaab,extended,005e09b8
 patch=1,EE,2072974c,extended,432b0000
 
-//patch=1,EE,e001aaab,extended,005e09b8
-//patch=1,EE,2047163c,extended,24030000
+[480p Mode]
+author=nemesis2000
+description=Force 480p progressive
 
-//patch=1,EE,e001aaab,extended,005e09b8
-//patch=1,EE,2022280c,extended,3c01bec0
-
-//patch=1,EE,e001aaab,extended,005e09b8
-//patch=1,EE,201d4cf4,extended,3c023fc0
-
-//patch=1,EE,e0010000,extended,005e09b8
-//patch=1,EE,2047163c,extended,9063702e
-
-//patch=1,EE,e0010000,extended,005e09b8
-//patch=1,EE,2022280c,extended,3c01bf00
-
-//patch=1,EE,e0010000,extended,005e09b8
-//patch=1,EE,201d4cf4,extended,3c024000
-
-//480p
 patch=1,EE,0023ea90,word,24060050
 patch=1,EE,0023ea94,word,24050000
 patch=1,EE,0023ea9c,word,23070001
 
+[Disable Depth of Field]
+author=refraction
+description=Removes depth of field effect.
 
+patch=1,EE,003D9AD4,word,50000198 //Skips DoF code block.


### PR DESCRIPTION
Adds depth of field removal to Bully games.

It doesn't upscale well, and users hate it, so now they can turn it off.