### PR TITLE
WS: Fatal Frame 2

### DIFF
--- a/patches/SLUS-20766_1C6C1DB6.pnach
+++ b/patches/SLUS-20766_1C6C1DB6.pnach
@@ -1,4 +1,4 @@
-gametitle=Fatal Frame II - Crimson Butterfly (NTSC-U) SLUS-20766 9A51B627
+gametitle=Fatal Frame II - Crimson Butterfly (NTSC-U) SLUS-20766 1C6C1DB6 (Undub)
 
 [Widescreen 16:9]
 gsaspectratio=16:9


### PR DESCRIPTION
Added support for the undub version by wagrenier (https://github.com/wagrenier/Zero2Undub)
Also 2 lines of text were updated in these patches (Standar version&Undub version)

Undub version before
![Fatal Frame II - Crimson Butterfly_SLUS-20766_20240111173041](https://github.com/PCSX2/pcsx2_patches/assets/144561229/0488a8cb-6700-4eb7-aa95-3d03febc9355)
![Fatal Frame II - Crimson Butterfly_SLUS-20766_20240111161051](https://github.com/PCSX2/pcsx2_patches/assets/144561229/f4714303-dd1e-4bb8-8a19-dd7021d494a0)
Undub version after
![Fatal Frame II - Crimson Butterfly_SLUS-20766_20240111173207](https://github.com/PCSX2/pcsx2_patches/assets/144561229/260bae34-6705-4463-8686-fa49a7a6a7f3)
![Fatal Frame II - Crimson Butterfly_SLUS-20766_20240111160831](https://github.com/PCSX2/pcsx2_patches/assets/144561229/99b161fd-d28a-4d8f-86b1-c146daa02330)
