### PR TITLE
No-Interlacing: Tekken 4 and Tekken tag tournament PAL

### DIFF
--- a/patches/SCES-50001_0DD8941C.pnach
+++ b/patches/SCES-50001_0DD8941C.pnach
@@ -1,4 +1,4 @@
-gametitle=Tekken Tag Tournament (PAL-M5) (SCES-50001) D07E8F35 v2.00 
+gametitle=Tekken Tag Tournament (PAL-M5) (SCES-50001) 0DD8941C v1.00 
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SCES-50878_F48F994A.pnach
+++ b/patches/SCES-50878_F48F994A.pnach
@@ -1,13 +1,20 @@
-gametitle=Tekken 4 (PAL-M5) (SCES-50878)
+gametitle=Tekken 4 (PAL-M5) (SCES-50878) F48F994A
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
 comment=Widescreen ported from NTSC hack by nemesis2000
-// 16:9
 patch=1,EE,002177e0,word,3c013f40  // 3c013f80 hor fov
 patch=1,EE,002015d4,word,3c013f40  // 00000000 renderfix1
 patch=1,EE,002015d8,word,44810000  // 00000000
 patch=1,EE,002015e4,word,46006303  // 00000000
 patch=1,EE,0018d408,word,3c0143d6  // 3c0143a0 renderfix2
 patch=1,EE,001f7028,word,3c013f40  // 3c013f80 partial HUD fix
+
+[No-Interlacing]
+gsinterlacemode=1
+author=felixthecat1970
+comment=Autoboot progressive scan mode
+patch=0,EE,001E2254,extended,24020002
+patch=0,EE,0022B138,extended,24050006
+patch=0,EE,001EDC24,extended,24020009


### PR DESCRIPTION
Add interlacing patches

Tekken Tag: tested all game modes, fmv and scenes
![Tekken Tag Tournament_SCES-50001_20240124225849](https://github.com/PCSX2/pcsx2_patches/assets/79443698/6991649d-9af2-4929-a559-d1ff64f35f38)
before

![Tekken Tag Tournament_SCES-50001_20240124225755](https://github.com/PCSX2/pcsx2_patches/assets/79443698/cd9a3d2c-7e33-4467-a955-66bbf4323c23)
after


Tekken 4: In this pull this interlacing patch is removed because when an fmv was released it changed to PAL. Talking to a friend who works fine for him, I realized that my old save game was corrupted. I deleted the save and completed it again without fmv problem.
https://github.com/PCSX2/pcsx2_patches/pull/247/files#diff-17960fdef464f7674073fab4ba8bfc849df27f2a293dc0cb427c052c6ba2c61e