### PR TITLE
New WS patch for Dirge of Cerberus - Final Fantasy VII

### DIFF
--- a/patches/SLUS-21419_44A5FA15.pnach
+++ b/patches/SLUS-21419_44A5FA15.pnach
@@ -1,9 +1,10 @@
-//[Widescreen 16:9]
-//gsaspectratio=16:9
-//comment=Dirge of Cerberus - Final Fantasy VII Widescreen Hack (16:9) (NTSC-U)
+gametitle=Dirge of Cerberus - Final Fantasy VII SLUS-21419 44A5FA15
 
-//patch=1,EE,0040B628,word,3C013FC9
-//patch=1,EE,0040B62C,word,342162D8
-//patch=1,EE,0040C220,word,3C013EC0
-
-// Disable due to causing a black or other colour sphere to appear in the sky or in corridors at certain viewing angles.
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Gabominated
+description=Widescreen hack
+patch=1,EE,004FB248,word,3FC962FC //3F970A3D y-fov
+patch=1,EE,004FB250,word,42b40000 //42930000 zoom
+patch=1,EE,0040c5d4,word,3c013fab //3c013f80 render y-fix
+patch=1,EE,0040c5f4,word,3c013fab //3c013f80 render y-fix


### PR DESCRIPTION
Older patch have render issues as refraction exposed at issues section, I made a new patch that fix that missing of render and correctly scaling, so no more black hole at the sky

![Dirge of Cerberus - Final Fantasy VII_SLUS-21419_20240128174517](https://github.com/PCSX2/pcsx2_patches/assets/154765720/cac40710-976e-4841-a1c2-0743bb2d118d)
![Dirge of Cerberus - Final Fantasy VII_SLUS-21419_20240128183138](https://github.com/PCSX2/pcsx2_patches/assets/154765720/8e456868-62e9-48ad-aea9-b6c7f48141a1)

Fixes #295 
