### PR TITLE
Project Snowblind PAL. CRCs Fixed 

### DIFF
--- a/patches/SLES-53124_821A0C40.pnach
+++ b/patches/SLES-53124_821A0C40.pnach
@@ -1,0 +1,13 @@
+gametitle=Project - Snowblind (PAL-M4) SLES-53124 821A0C40 (BO3GM.ELF) single-player
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=ElHecht
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,20332BB8,extended,3C013FE3 //3C013FAA hor fov
+patch=1,EE,20332BBC,extended,34218E39 //3421AAAB hor fov
+
+[50/60 FPS]
+author=PeterDelta
+comment=Unlocked at 50/60 FPS. Might need enable 130% EE Overclock to be stable.
+patch=1,EE,002D4D94,word,2C620000 //0062102B

--- a/patches/SLES-53124_CD9DAA4C.pnach
+++ b/patches/SLES-53124_CD9DAA4C.pnach
@@ -1,0 +1,8 @@
+gametitle=Project - Snowblind (PAL-M4) SLES-53124 CD9DAA4C (BO3NETGM.ELF) LAN/multi-player
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=ElHecht
+comment=Renders the game in 16:9 aspect ratio
+patch=1,EE,20418700,extended,3C013FE3 //3C013FAA hor fov
+patch=1,EE,20418704,extended,34218E39 //3421AAAB hor fov

--- a/patches/SLES-53124_F00CA82B.pnach
+++ b/patches/SLES-53124_F00CA82B.pnach
@@ -1,22 +1,13 @@
-gametitle=Project - Snowblind (PAL-M4) (SLES-53124)
+gametitle=Project - Snowblind (PAL-M4) (SLES-53124) F00CA82B
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
 comment=Widescreen Hack
-// 16:9 intro (SLES_531.24)
-patch=1,EE,e0023faa,extended,001d98a0 // check 001d98a0 matches value 00003faa
-patch=1,EE,201d98a0,extended,3c013fe3 // 3c013faa hor fov
-patch=1,EE,201d98a4,extended,34218e39 // 3421aaab hor fov
+patch=1,EE,201D98A0,extended,3C013FE3 //3C013FAA hor fov
+patch=1,EE,201D98A4,extended,34218E39 //3421AAAB hor fov
 
-// 16:9 single-player (BO3GM.ELF)
-patch=1,EE,e0023faa,extended,00332bb8 // check 00332bb8 matches value 00003faa
-patch=1,EE,20332bb8,extended,3c013fe3 // 3c013faa hor fov
-patch=1,EE,20332bbc,extended,34218e39 // 3421aaab hor fov
-
-// 16:9 lan/internet multi-player (BO3NETGM.ELF)
-patch=1,EE,e0023faa,extended,00418700 // check 00418700 matches value 00003faa
-patch=1,EE,20418700,extended,3c013fe3 // 3c013faa hor fov
-patch=1,EE,20418704,extended,34218e39 // 3421aaab hor fov
-
-
+[50/60 FPS]
+author=PeterDelta
+comment=Unlocked at 50/60 FPS. Might need enable 130% EE Overclock to be stable.
+//Used to activate crc 821A0C40 BO3GM.ELF for single player.


### PR DESCRIPTION
This game runs 3 .elf and with the new pnach system it does not work correctly. It does not require conditionals because the widescreen addresses change every time an .elf is executed and there is no conflict. The only thing I haven't been able to test is LAN/Internet Multiplayer because I don't have the Ethernet Network Adapter configured, but I have made sure the addresses match the values when "BO3NETGM.ELF" is run. I guess ElHecht tested it when he made the patch.