### PR TITLE
Fixes patch formatting for Spongebob The Movie

### DIFF
--- a/patches/SLUS-20904_536FEB77.pnach
+++ b/patches/SLUS-20904_536FEB77.pnach
@@ -1,6 +1,10 @@
+gametitle=Spongebob Squarepants Movie Game (NTSC-U) (SLUS-20904)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Spongebob Squarepants Movie Game (NTSC-U) (SLUS-20904) Widescreen Hack (nemesis2000) (gamemasterplc)
+author=nemesis2000 & gamemasterplc
+comment=Forces the game to run at 16:9 aspect ratio
+
 patch=1,EE,00437714,word,46010083 //Multiply Aspect
 patch=1,EE,00437718,word,E7A20028 //Store Multiplied Aspect
 patch=1,EE,0043771C,word,46010002 //Set Height
@@ -10,5 +14,3 @@ patch=1,EE,00437728,word,DFBF0010 //Restore RA
 patch=1,EE,0043772C,word,7BB00000 //Restore S0
 patch=1,EE,00437730,word,03E00008 //Jump to RA
 patch=1,EE,00437734,word,27BD0030 //Restore Stack (Delay Slot)
-
-


### PR DESCRIPTION
Fixes the broken patch formatting on spongebob the movie game

![Screenshot_20240207_142115](https://github.com/PCSX2/pcsx2_patches/assets/14798312/320b0b21-39ae-40da-8759-1234367ce5bf)
