### PR TITLE
Fix hanging up after mission levels

### DIFF
--- a/patches/SLPS-25338_26D1C561.pnach
+++ b/patches/SLPS-25338_26D1C561.pnach
@@ -12,7 +12,7 @@ patch=1,EE,01E15D18,extended,00000040 // 3C023F80 hor fov menu
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-patch=1,EE,0023C2DC,extended,00000000
+patch=1,EE,2023C2DC,extended,34020001 //30420001
 
 [Remove Blur]
 author=001 & Berylskid

--- a/patches/SLPS-25339_26D1C561.pnach
+++ b/patches/SLPS-25339_26D1C561.pnach
@@ -12,7 +12,7 @@ patch=1,EE,01E15D18,extended,00000040 // 3C023F80 hor fov menu
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-patch=1,EE,0023C2DC,extended,00000000
+patch=1,EE,2023C2DC,extended,34020001 //30420001
 
 [Remove Blur]
 author=001 & Berylskid


### PR DESCRIPTION
- Rewrote `[No-interlacing]` patch to fix hanging up after some missions.
- This change is only for NTSC-J Armored Core Nexus (Both discs).