### PR TITLE
Minor Typo fix

### DIFF
--- a/patches/SLES-53502_EFC63B51.pnach
+++ b/patches/SLES-53502_EFC63B51.pnach
@@ -1,4 +1,4 @@
-gametitle=Star Wars: Battlefront 2 (F)(SLES-53505)
+gametitle=Star Wars: Battlefront 2 (F)(SLES-53502)
 
 [Widescreen 16:9]
 gsaspectratio=16:9


### PR DESCRIPTION
This disc has SLES-53502 as serial-code, not SLES-53505.
SLES-53505 is "Beat Down - Fists of Vengeance",
 both according to GameIndex and redump.

http://redump.org/disc/24233/
http://redump.org/disc/520/
