### PR TITLE
Fixes commented patch & incorrect game title

### DIFF
--- a/patches/SLPM-66211_7EC8A8A3.pnach
+++ b/patches/SLPM-66211_7EC8A8A3.pnach
@@ -1,4 +1,4 @@
-gametitle=eter Jackson's King Kong - The Official Game of the Movie (J)(SLPM-66211)
+gametitle=Peter Jackson's King Kong - The Official Game of the Movie (J)(SLPM-66211)
 
 [Widescreen 16:9]
 gsaspectratio=16:9


### PR DESCRIPTION
### Description:
- Fixes gametitle which had a typo, missing the P in Peter.
- ~~Fixes a commented patch which was the only patch in the pnach file, meaning the widescreen patch did nothing.~~ Removed this change as it is impossible for me to test currently. For anyone interested, [this line is here](https://github.com/PCSX2/pcsx2_patches/blob/955a9d824f8bf898618d582ba0136496102157f6/patches/SCES-50244_71E38F05.pnach#L10).



### Note:
Full credit to @pgert for reporting these in #304. I did not include those in those changes as these were both issues that would be undetected by the CI action so did not want to make it confusing.
