### PR TITLE
Remove unnecessary No-Interlacing patches

### DIFF
--- a/patches/SCES-50294_B590CE04.pnach
+++ b/patches/SCES-50294_B590CE04.pnach
@@ -1,14 +1,14 @@
 gametitle=Gran Turismo 3 - A-Spec (PAL-M) SCES-50294 B590CE04
 
 [No-Interlacing]
-author=junfurano
-description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-patch=1,EE,2025B4E8,extended,34020001
+author=PeterDelta
+description=Enable progressive interlacing.
+patch=1,EE,0028F81C,word,3C050000
 
 [60 FPS]
 author=PeterDelta
-comment=Forces progressive scan and run at 60 fps
+description=Forces progressive scan and run at 60 fps
 patch=1,EE,2028F840,extended,24120052
 patch=1,EE,2035163C,extended,3C888889 //speed flags 
 patch=1,EE,20351F1C,extended,3C888889 //speed cars

--- a/patches/SLES-50330_021396FD.pnach
+++ b/patches/SLES-50330_021396FD.pnach
@@ -17,10 +17,6 @@ patch=1,EE,00253C1C,word,0C061282
 patch=1,EE,0027B9B4,word,0C061282
 patch=1,EE,0027BE8C,word,0C061282
 
-[No-Interlacing]
-gsinterlacemode=1
-patch=1,EE,2011299C,extended,00000000
-
 [50 FPS]
 author=Snake356
 comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).

--- a/patches/SLES-50330_581954FC.pnach
+++ b/patches/SLES-50330_581954FC.pnach
@@ -17,12 +17,6 @@ patch=1,EE,00253D6C,word,0C061296
 patch=1,EE,0027BB34,word,0C061296
 patch=1,EE,0027C00C,word,0C061296
 
-[No-Interlacing]
-gsinterlacemode=1
-author=Mensa
-comment=Attempts to disable interlaced offset rendering.
-patch=1,EE,2011299C,extended,00000000
-
 [50 FPS]
 author=Snake356
 comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).

--- a/patches/SLES-51061_26954C46.pnach
+++ b/patches/SLES-51061_26954C46.pnach
@@ -16,10 +16,6 @@ patch=1,EE,002485dc,word,0C04C92F
 patch=1,EE,002764AC,word,0C04C932
 patch=1,EE,00276A7C,word,0C04C932
 
-[No-Interlacing]
-gsinterlacemode=1
-patch=1,EE,20112444,extended,00000000
-
 [50 FPS]
 author=Snake356
 comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).

--- a/patches/SLES-51061_C498A04F.pnach
+++ b/patches/SLES-51061_C498A04F.pnach
@@ -16,12 +16,6 @@ patch=1,EE,002434EC,word,0C04C96F
 patch=1,EE,0027088C,word,0C04C972
 patch=1,EE,00270E64,word,0C04C972
 
-[No-Interlacing]
-gsinterlacemode=1
-author=Mensa
-comment=Attempts to disable interlaced offset rendering.
-patch=1,EE,20112B24,extended,00000000
-
 [50 FPS]
 author=Snake356
 comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).

--- a/patches/SLES-51061_CFCB0D20.pnach
+++ b/patches/SLES-51061_CFCB0D20.pnach
@@ -16,10 +16,6 @@ patch=1,EE,0024335C,word,0C04C8EB
 patch=1,EE,002706DC,word,0C04C8EE
 patch=1,EE,00270CB4,word,0C04C8EE
 
-[No-Interlacing]
-gsinterlacemode=1
-patch=1,EE,201123C4,extended,00000000
-
 [50 FPS]
 author=Snake356
 comment=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).

--- a/patches/SLES-52541_A1B3F232.pnach
+++ b/patches/SLES-52541_A1B3F232.pnach
@@ -15,12 +15,6 @@ patch=1,EE,001130CC,word,E78C9A90
 patch=1,EE,0021DF84,word,0C044C2F
 patch=1,EE,00242D54,word,0C044C32
 
-[No-Interlacing]
-gsinterlacemode=1
-author=Mensa
-comment=Attempts to disable interlaced offset rendering.
-patch=1,EE,2054996C,extended,00000000
-
 [Remove Radiosity Filter]
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
 patch=1,EE,2051A0C8,extended,00000000

--- a/patches/SLES-52541_B440A8FE.pnach
+++ b/patches/SLES-52541_B440A8FE.pnach
@@ -15,10 +15,6 @@ patch=1,EE,001130CC,word,E78C9A90
 patch=1,EE,0021DFE4,word,0C044C2F //0C044C30
 patch=1,EE,00242DB4,word,0C044C32 //0C044C30
 
-[No-Interlacing]
-gsinterlacemode=1
-patch=1,EE,2054A06C,extended,00000000
-
 [Remove Radiosity Filter]
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
 patch=1,EE,2051A7C8,extended,00000000


### PR DESCRIPTION
 As of this version: https://github.com/PCSX2/pcsx2/pull/10821 Patches can no longer be disabled per game. These types of patches that are only limited to eliminating the sceGsSetHalfOffset routine were a good fix in old versions but now they have become obsolete, do not improve anything and do worsen the textures and letters, so to keep the games with the least alteration I remove. following that I have verified are no longer necessary.

In Gran Turismo 3 we see that in automatic and the default interlacing modes of pcsx2 they do not act correctly so a patch would be needed.
![Gran Turismo 3 automatic](https://github.com/PCSX2/pcsx2_patches/assets/151682118/80c98702-4fc8-4c99-8808-1c2492a249db)

Old patch that eliminates the routine sceGsSetHalfOffset 
![Gran Turismo 3 routine interlacing](https://github.com/PCSX2/pcsx2_patches/assets/151682118/f26fcdd7-d63c-4f53-a985-2ea79a465181)

New patch enables progressive interlacing, keeps the sceGsSetHalfOffset routine unchanged, the image does not shake and the scrolling of the letters looks correct. The difference is minimal but it is there.
![Gran Turismo 3 progressive](https://github.com/PCSX2/pcsx2_patches/assets/151682118/b56291f6-ef30-4ef1-8dc4-1ecfbaa9a195)
