### PR TITLE
WS: Remove 480p code from BFBB patch

### DIFF
--- a/patches/SLES-51970_763D3BF9.pnach
+++ b/patches/SLES-51970_763D3BF9.pnach
@@ -13,12 +13,3 @@ patch=1,EE,0035c680,word,44820800
 patch=1,EE,0035c684,word,27a50028
 patch=1,EE,0035c688,word,46010083
 patch=1,EE,0035c68c,word,e7a20028
-
-//480p
-patch=1,EE,002635fc,word,24050000
-patch=1,EE,00263600,word,24060050
-patch=1,EE,00262948,word,24060050
-patch=1,EE,0026294c,word,24050000
-patch=1,EE,00102254,word,3c090010
-
-


### PR DESCRIPTION
Causes TLB misses on game boot.

![image](https://github.com/PCSX2/pcsx2_patches/assets/80843560/21165abb-e894-4c2b-8efd-fd6f294e467f)
