### PR TITLE
WS: Disable SMT DS 2 WS patch

### DIFF
--- a/patches/SLUS-21845_7FAE77BE.pnach
+++ b/patches/SLUS-21845_7FAE77BE.pnach
@@ -1,15 +1,13 @@
-gametitle=Shin Megami Tensei: Devil Summoner 2: Raidou Kuzunoha vs. King Abaddon (NTSC-U)
+//gametitle=Shin Megami Tensei: Devil Summoner 2: Raidou Kuzunoha vs. King Abaddon (NTSC-U)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-comment=Widescreen pnach (Only works for 3D, not for prerendered backgrounds)
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//comment=Widescreen pnach (Only works for 3D, not for prerendered backgrounds)
 
-patch=1,EE,004278e4,word,3FC6D3A0 //3F951EB8 hor fov
-patch=1,EE,00427c94,word,3FC6D3A0 //3F951EB8 unknown
+//patch=1,EE,004278e4,word,3FC6D3A0 //3F951EB8 hor fov
+//patch=1,EE,00427c94,word,3FC6D3A0 //3F951EB8 unknown
 
 //black borders's fix (optional)
-patch=1,EE,00116928,word,24040000
-patch=1,EE,00106be0,word,a380a213
-patch=1,EE,001069c4,word,2404FF00
-
-
+//patch=1,EE,00116928,word,24040000
+//patch=1,EE,00106be0,word,a380a213
+//patch=1,EE,001069c4,word,2404FF00


### PR DESCRIPTION
Breaks sprite overlap in some scenes.

![image](https://github.com/PCSX2/pcsx2_patches/assets/80843560/9cf196f2-466b-4f38-bf5e-4a2c55b5d022)
