### PR TITLE
Black bars patch in separate scenes from widescreen patch and updates

### DIFF
--- a/patches/SCES-50411_91510857.pnach
+++ b/patches/SCES-50411_91510857.pnach
@@ -1,18 +1,15 @@
-gametitle=Vampire Night (PAL-M5) (SCES-50411)
+gametitle=Vampire Night (PAL-M5) (SCES-50411) 91510857
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by ElHecht
-
+author=ElHecht
+description=Widescreen Hack 
 // 16:9
 patch=1,EE,002147e0,word,3c013f40 // 00000000 hor fov
 
 // 16:10
 //patch=1,EE,002147e0,word,3c013f55 // 00000000 hor fov
 //patch=1,EE,00214800,word,34215555 // 00000000 hor fov
-
-// cut-scenes black bar removal
-patch=1,EE,002027a8,word,3c030000 // 3c034420 remove black bars in cut-scenes
 
 // 16:9 and 16:10 main modifications
 // no need to change anything here! all modifications are calculated
@@ -39,4 +36,7 @@ patch=1,EE,001afa50,word,46002103 // 44882000 crosshair/aiming fix unit vector
 patch=1,EE,001afa54,word,461e26c3 // 46002103 crosshair/aiming fix unit vector
 patch=1,EE,001afa58,word,461b0842 // 46040842 crosshair/aiming fix unit vector
 
-
+[Remove Blackbars]
+author=ElHecht
+description=Removes black bars in cutscenes
+patch=1,EE,002027a8,word,3c030000 // 3c034420

--- a/patches/SCES-50500_107B1670.pnach
+++ b/patches/SCES-50500_107B1670.pnach
@@ -1,9 +1,9 @@
-gametitle=Headhunter (PAL-M5) (SCES-50500)
+gametitle=Headhunter (PAL-M5) (SCES-50500) 107B1670
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by ElHecht
-
+author=ElHecht
+description=Widescreen Hack
 // 16:9
 patch=1,EE,001966e4,word,10400007 // 1040000b
 patch=1,EE,001966fc,word,1000fffd // 00000000
@@ -27,8 +27,8 @@ patch=1,EE,0018f0f0,word,e79dbca4 // e784bca4 renderfix
 //patch=1,EE,0018f0bc,word,461e2743 // 4481a000 renderfix
 //patch=1,EE,0018f0f0,word,e79dbca4 // e784bca4 renderfix
 
-//Black bar fix by Arapapa (Get rid of 'Black Bar')
+[Remove Blackbars]
+author=Arapapa
+description=Removes black bars in cutscenes
 //9a99993f 5555553f 5655553e
-patch=1,EE,00585104,word,00000000 /3f99999a
-
-
+patch=1,EE,00585104,word,00000000 //3f99999a

--- a/patches/SCES-50760_5C991F4E.pnach
+++ b/patches/SCES-50760_5C991F4E.pnach
@@ -13,7 +13,9 @@ patch=1,EE,00114de0,word,46181082
 patch=1,EE,001146F4,word,240302ab
 patch=1,EE,0054E478,word,44fa0000
 
-//black borders fix
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
 patch=1,EE,00113450,word,3c010000
 
 

--- a/patches/SCES-50967_F52FB2BE.pnach
+++ b/patches/SCES-50967_F52FB2BE.pnach
@@ -2,7 +2,7 @@ gametitle=Kingdom Hearts (PAL)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen patch
+description=Widescreen patch
 patch=1,EE,001105e4,word,3c0143d6 //render fix
 patch=1,EE,00110ad0,word,3c013f19 //hor value first half
 patch=1,EE,00110ad4,word,3421999a //hor value second half
@@ -11,12 +11,11 @@ patch=1,EE,00110ad4,word,3421999a //hor value second half
 patch=1,EE,002a1308,word,70007000
 patch=1,EE,0010629c,word,3c071900
 
-//black border fix
+[Remove Blackbars]
+description=Removes black bars in cutscenes
 patch=1,EE,0010430c,word,00000000
 patch=1,EE,0010442c,word,00000000
 
 [60 FPS]
 description=Forces the game to run at 60.
 patch=1,EE,002B67CC,extended,00000000
-
-

--- a/patches/SCES-50969_AE3EAA05.pnach
+++ b/patches/SCES-50969_AE3EAA05.pnach
@@ -2,7 +2,8 @@ gametitle=Kingdom Hearts (PAL-G) (SCES-50969)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
+author=ElHecht
+description=Widescreen hack
 
 // 16:9
 patch=1,EE,00110634,word,3c1b3f40 // 00000000 hor fov gameplay
@@ -43,11 +44,11 @@ patch=1,EE,001f9710,word,24030020 // 24030018
 patch=1,EE,0010629c,word,3c071900 // 3c071c08
 patch=1,EE,002a1588,word,70007000 // 74007000
 
-//black border fix
+[Remove Blackbars]
+author=ElHecht
+description=Removes black bars in cutscenes
 patch=1,EE,0010430c,word,00000000 // ac510e48
 patch=1,EE,0010442c,word,00000000 // ac450e48
 
 [60 FPS]
 patch=1,EE,001104d8,word,24820000 // 24820001
-
-

--- a/patches/SCES-51177_E6A57677.pnach
+++ b/patches/SCES-51177_E6A57677.pnach
@@ -1,18 +1,14 @@
-gametitle=Disney's Treasure Planet (E)(SCES-51177)
+gametitle=Disney's Treasure Planet (PAL-M) SCES-51177 E6A57677
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Arapapa
-comment=Widescreen Hack
+author=PeterDelta
+description=Enable native widescreen
+patch=1,EE,E0020000,extended,00382378
+patch=1,EE,002D0EF8,extended,00000002
+patch=1,EE,00382378,extended,00000002
 
-//Widescreen hack 16:9
-
-//X-Fov
-//2044013c 00608144 2d804000
-patch=1,EE,00298e90,word,080b1068
-patch=1,EE,002c41a0,word,3c014455
-patch=1,EE,002c41a4,word,34215555
-patch=1,EE,002c41a8,word,44816000
-patch=1,EE,002c41ac,word,080a63a5
-
-
+[Remove Blackbars]
+author=PeterDelta
+description=Removes black bars in cutscenes
+patch=1,EE,002E8B34,extended,00000000

--- a/patches/SCES-54552_CBB4B383.pnach
+++ b/patches/SCES-54552_CBB4B383.pnach
@@ -1,25 +1,27 @@
-gametitle=Rogue Galaxy [PAL-M5] (SLES_545.52)
+gametitle=Rogue Galaxy [PAL-M5] (SLES_545.52) CBB4B383
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=El_Patas
-comment=Widescreen Hack
+description=Widescreen Hack
 //Gameplay 16:9
 patch=1,EE,001C5E40,word,3C023F10 //3C023F40 (Increases hor. axis)
 
 //Compass
 patch=1,EE,00377F9C,word,3C023F10 //3C023F40
 
-//Black border fix
-patch=1,EE,00261FB4,word,3C020000 //3C023F80
-
 //FMV's fix
 patch=1,EE,001D4E2C,word,24060000 //02C23021 Top
 patch=1,EE,001D4E7C,word,240201C0 //00451021 Bottom
 
+[Remove Blackbars]
+author=El_Patas
+description=Removes black bars in cutscenes
+patch=1,EE,00261FB4,word,3C020000 //3C023F80
+
 [50/60 FPS]
 author=Red-tv
-comment=Unlocked at 50/60 FPS. Might need enable EE Overclock to be stable.
+description=Unlocks internal FPS. Might need EE Overclock at 180%.
 patch=1,EE,004A06D4,byte,01 //60fps
 patch=1,EE,001ce06c,word,00000000 //3c033f80 
 patch=1,EE,001ce088,word,3c033f00 //3c033f80, Breaks Gravity

--- a/patches/SCKA-20039_F088FA5B.pnach
+++ b/patches/SCKA-20039_F088FA5B.pnach
@@ -1,17 +1,15 @@
-gametitle=Tekken Nina Williams In Death By Degree (K)(SCKA-20039)
+gametitle=Tekken Nina Williams In Death By Degree (K)(SCKA-20039) F088FA5B
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack (NTSC-K by Arapapa)
+author=Arapapa
+description=Widescreen hack
 patch=1,EE,00188250,word,3c023fe3
 patch=1,EE,00188258,word,3443bbd6
 patch=1,EE,0018606c,word,3c023fe3
 patch=1,EE,00186070,word,3443bbd6
 patch=1,EE,001f5c88,word,3c023fe3
 patch=1,EE,001f5c90,word,3442bbd6
-
-//black border's fix by nemesis2000
-patch=1,EE,0032b0a8,word,3c023f80
 
 //FMV's fix by nemesis2000
 patch=1,EE,205D9054,extended,3faaaaaa
@@ -20,4 +18,7 @@ patch=1,EE,205D9054,extended,3faaaaaa
 //10 00 02 DE 00 00 C2 FC 18 00 03 DE 00 00 A3 FC
 //patch=1,EE,00102a84,word,34021400
 
-
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,0032b0a8,word,3c023f80

--- a/patches/SCKA-20114_9891B945.pnach
+++ b/patches/SCKA-20114_9891B945.pnach
@@ -20,12 +20,6 @@ patch=1,EE,0042ed64,word,0805ca2e // 00000000 jump back to 00172928
 //00088344 803f023c 00a08244
 patch=1,EE,0025619c,word,3c023fab
 
-
-//black borders fix by nemesis2000
-patch=1,EE,001f4a38,word,3c020000 //3c023f80
-patch=1,EE,001f49c8,word,3c030000 //3c033f80
-patch=1,EE,001f4ab8,word,3c020000 //3c023f80
-
 //FMV's fix by nemesis2000
 patch=1,EE,002110ac,word,24020188 //10200007
 patch=1,EE,002110b0,word,14480003 //e7b40000
@@ -67,4 +61,9 @@ patch=1,EE,0010ceec,word,3c070001 //00073c00
 //patch=1,EE,0010ceec,word,3c070001 //00073c00
 //patch=1,EE,0010d1ac,word,3c090010 //00094c00
 
-
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,001f4a38,word,3c020000 //3c023f80
+patch=1,EE,001f49c8,word,3c030000 //3c033f80
+patch=1,EE,001f4ab8,word,3c020000 //3c023f80

--- a/patches/SCPS-11003_B01A4C95.pnach
+++ b/patches/SCPS-11003_B01A4C95.pnach
@@ -14,13 +14,12 @@ patch=1,EE,00114c84,word,46181082 //00000000
 patch=1,EE,00114624,word,240302aB //8f8394cc
 patch=1,EE,00549778,word,44FA0000 //44bb8000
 
-//black borders fix
-patch=1,EE,00113380,word,3c010000 //3c014300
-
 //No interlacing by asasega
 //patch=1,EE,0028D3F8,extended,00000001
 //patch=1,EE,0028D420,extended,00000001
 //patch=1,EE,0028D400,extended,00000040
 //patch=1,EE,0028D428,extended,00000040
 
-
+[Remove Blackbars]
+description=Removes black bars in cutscenes
+patch=1,EE,00113380,word,3c010000 //3c014300

--- a/patches/SCPS-15024_EB4A4786.pnach
+++ b/patches/SCPS-15024_EB4A4786.pnach
@@ -14,12 +14,11 @@ patch=1,EE,00263c5c,word,3c023f40 //3c023f80
 //render fix
 patch=1,EE,0011484c,word,3c033fc0 //3c034000
 
-//black borders fix
-patch=1,EE,001a962c,word,24079400 //24076c00
-
 //dialog portraits fix
 patch=1,EE,0011b150,word,240501b0 //24050190
 patch=1,EE,0011b180,word,240501b0 //24050190
 patch=1,EE,0012ad38,word,25850750 //25850780
 
-
+[Remove Blackbars]
+description=Removes black bars in cutscenes
+patch=1,EE,001a962c,word,24079400 //24076c00

--- a/patches/SCPS-17013_CDEE4B19.pnach
+++ b/patches/SCPS-17013_CDEE4B19.pnach
@@ -10,9 +10,6 @@ patch=1,EE,001c5aa0,word,3c023f10 //403F023C(*) 00608244 FC08050C 2D200002
 //compass
 patch=1,EE,0037413c,word,3c023f10 //F055050C 9004A0E7 A004AFC7 403F023C(*)
 
-//black border fix
-patch=1,EE,00261050,word,3c020000
-
 //FMV's fix
 patch=1,EE,001d4a3c,word,24060000 //top
 patch=1,EE,001D4A8C,word,240201c0 //bottom
@@ -21,4 +18,6 @@ patch=1,EE,001D4A8C,word,240201c0 //bottom
 //patch=1,EE,001d4a2c,word,24030040 //left
 //patch=1,EE,001d4a88,word,240301c0 //right
 
-
+[Remove Blackbars]
+description=Removes black bars in cutscenes
+patch=1,EE,00261050,word,3c020000

--- a/patches/SCPS-56001_2DF2C1EA.pnach
+++ b/patches/SCPS-56001_2DF2C1EA.pnach
@@ -12,8 +12,6 @@ patch=1,EE,00114C80,word,46181082
 //render fix
 patch=1,EE,00114624,word,240302AB
 patch=1,EE,00549578,word,44FA0000
-//black borders fix
-patch=1,EE,00113380,word,3C010000
 
 //No interlacing by asasega
 //patch=1,EE,0028D478,extended,00000001
@@ -21,4 +19,6 @@ patch=1,EE,00113380,word,3C010000
 //patch=1,EE,0028D480,extended,00000040
 //patch=1,EE,0028D4A8,extended,00000040
 
-
+[Remove Blackbars]
+description=Removes black bars in cutscenes
+patch=1,EE,00113380,word,3C010000

--- a/patches/SCUS-97113_6F8545DB.pnach
+++ b/patches/SCUS-97113_6F8545DB.pnach
@@ -1,9 +1,9 @@
-gametitle=ICO (SCUS-97113)
+gametitle=ICO (SCUS-97113) 6F8545DB
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
-
+author=nemesis2000
+description=Widescreen hack
 //widescreen
 patch=1,EE,001146c8,word,3c013f40
 patch=1,EE,001146cc,word,44813800
@@ -14,9 +14,10 @@ patch=1,EE,001146dc,word,c78780dc
 patch=1,EE,001141a4,word,240302ab
 patch=1,EE,00554790,word,44800000 //optional
 
-//black borders fix
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
 patch=1,EE,00113030,word,3c010000
-
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
@@ -25,5 +26,3 @@ patch=1,EE,00274EF8,extended,00000001
 patch=1,EE,00274F20,extended,00000001
 patch=1,EE,00274F00,extended,00000040
 patch=1,EE,00274F28,extended,00000040
-
-

--- a/patches/SCUS-97490_0643F90C.pnach
+++ b/patches/SCUS-97490_0643F90C.pnach
@@ -2,16 +2,14 @@ gametitle=Rogue Galaxy (SCUS-97490)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
+author=nemesis2000
+description=Widescreen hack
 
 //gameplay
 patch=1,EE,001c6a50,word,3c023f10
 
 //compass
 patch=1,EE,0037112c,word,3c023f10
-
-//black border fix
-patch=1,EE,002611D4,word,3c020000
 
 //FMV's fix
 patch=1,EE,001d5a7c,word,24060000 //top
@@ -21,4 +19,7 @@ patch=1,EE,001d5acc,word,240201c0 //bottom
 //patch=1,EE,001d5a6c,word,24030040 //left
 //patch=1,EE,001d5ac8,word,240301c0 /right
 
-
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,002611D4,word,3c020000

--- a/patches/SLES-50196_6D8B4CD1.pnach
+++ b/patches/SLES-50196_6D8B4CD1.pnach
@@ -1,9 +1,9 @@
-gametitle=Legacy of Kain: Soul Reaver 2 (SLES-50196)
+gametitle=Legacy of Kain: Soul Reaver 2 (SLES-50196) 6D8B4CD1
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=nemesis2000
-comment=Widescreen Hack
+description=Widescreen Hack
 //built in widescreen
 patch=1,EE,20240C20,extended,00000001
 patch=1,EE,00170c8c,word,3c013f80
@@ -14,10 +14,6 @@ patch=1,EE,00170cc8,word,00000000
 patch=1,EE,00113f54,word,3c0143c0
 patch=1,EE,00114a70,word,3c0143c0
 
-//cutscenes black border fix
-patch=1,EE,0013e264,word,3c01bf80 //top value
-patch=1,EE,0013e26c,word,3c013f80 //bottom value
-
 //render fix
 patch=1,EE,0011339c,word,3c013f40
 
@@ -25,4 +21,8 @@ patch=1,EE,0011339c,word,3c013f40
 patch=1,EE,001d4610,word,24097560
 patch=1,EE,001d4618,word,240b1550
 
-
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,0013e264,word,3c01bf80 //top value
+patch=1,EE,0013e26c,word,3c013f80 //bottom value

--- a/patches/SLES-50771_06DCCAF4.pnach
+++ b/patches/SLES-50771_06DCCAF4.pnach
@@ -1,18 +1,18 @@
-gametitle=Blood Omen 2: The Legacy of Kain Series (SLES-50771)
+gametitle=Blood Omen 2: The Legacy of Kain Series (SLES-50771) 06DCCAF4
 
 [Widescreen 16:9]
-description=Renders the game in 16:9 aspect ratio, instead of 4:3.
 gsaspectratio=16:9
-
+author=pavachan & nemesis2000
+description=Renders the game in 16:9 aspect ratio, instead of 4:3.
 //gameplay (based on pavachan elf hack)
 patch=1,EE,00310ba0,word,3c013fe3
 patch=1,EE,00310ba4,word,34218e38
-
-//black border fix by nemesis2000
-patch=1,EE,002d24cc,word,00000000
 
 //FMV's fix by nemesis2000
 patch=1,EE,002e9380,word,240575e0
 patch=1,EE,002e9398,word,240a1440
 
-
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,002d24cc,word,00000000

--- a/patches/SLES-50815_1897D0F7.pnach
+++ b/patches/SLES-50815_1897D0F7.pnach
@@ -1,18 +1,18 @@
-gametitle=Blood Omen 2: The Legacy of Kain Series (PAL/G) [SLES-50815]
+gametitle=Blood Omen 2: The Legacy of Kain Series (PAL/G) [SLES-50815] 1897D0F7
 
 [Widescreen 16:9]
-description=Renders the game in 16:9 aspect ratio, instead of 4:3.
 gsaspectratio=16:9
-
+author=pavachan & nemesis2000
+description=Renders the game in 16:9 aspect ratio, instead of 4:3.
 //gameplay (based on pavachan elf hack)
 patch=1,EE,00311810,word,3c013fe3 //3c013faa
 patch=1,EE,00311814,word,34218e38 //3421aaab
-
-//black border fix by nemesis2000
-//patch=1,EE,002d24cc,word,00000000
 
 //FMV's fix by nemesis2000
 patch=1,EE,002e9ff0,word,240575e0 //24057800
 patch=1,EE,002ea008,word,240a1440 //240a1000
 
-
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,002d24cc,word,00000000

--- a/patches/SLES-50877_5CC9BF81.pnach
+++ b/patches/SLES-50877_5CC9BF81.pnach
@@ -1,8 +1,9 @@
-gametitle=TimeSplitters 2 (SLES-50877)
+gametitle=TimeSplitters 2 (SLES-50877) 5CC9BF81
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000 )
+author=nemesis2000
+description=Widescreen hack
 patch=1,EE,005995ac,word,3fe38e38
 patch=1,EE,0059a190,word,3fe38e38
 patch=1,EE,0059a218,word,3fe38e38
@@ -12,10 +13,10 @@ patch=1,EE,0059af98,word,3fe38e38
 patch=1,EE,0059afa8,word,3fe38e38
 patch=1,EE,0059d7dc,word,3fe38e38
 
-//black border's fix
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
 patch=1,EE,003c7714,word,24150000
 patch=1,EE,003c771c,word,24160200
 patch=1,EE,003c7d4c,word,24070000
 patch=1,EE,003c7d5c,word,24050200
-
-

--- a/patches/SLES-51619_D9FC6310.pnach
+++ b/patches/SLES-51619_D9FC6310.pnach
@@ -1,3 +1,5 @@
+gametitle=Clock Tower 3 (PAL-M) SLES-51619 D9FC6310
+
 [Widescreen 16:9]
 gsaspectratio=16:9
 comment=Clock Tower 3 - Widescreen Hack (16:9) (PAL-E) // strider3871
@@ -12,11 +14,13 @@ patch=1,EE,018bde08,word,34028260 //34028000
 patch=1,EE,018bd788,word,3c026fa0 //3c027200
 patch=1,EE,018bd7d4,word,34028260 //34028000
 
-//black borders fix by nemesis2000
-patch=1,EE,018f4824,word,3c030000 //3c034274
-
 //remove black square near Panic Meter
 patch=1,EE,2041C100,word,00000000
+
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,018f4824,word,3c030000 //3c034274
 
 [50/60 FPS]
 author=Gabominated

--- a/patches/SLES-51766_80EA26DA.pnach
+++ b/patches/SLES-51766_80EA26DA.pnach
@@ -1,11 +1,14 @@
-gametitle=Gladiator - Sword of Vengeance SLES_517.66
+gametitle=Gladiator - Sword of Vengeance (PAL-M) SLES_517.66 80EA26DA
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack
+author=sergx12
+description=Widescreen hack
 patch=1,EE,001c5c98,word,3c013f40 //fov
 patch=1,EE,0020d690,word,3c013fab // vert fov
-patch=1,EE,00284084,word,3c010000 // black bars remove
 patch=1,EE,2078d930,extended,bfab0000 //hud stretch
 
-
+[Remove Blackbars]
+author=sergx12
+description=Removes black bars in cutscenes
+patch=1,EE,00284084,word,3c010000

--- a/patches/SLES-52150_BCAD1E8A.pnach
+++ b/patches/SLES-52150_BCAD1E8A.pnach
@@ -1,24 +1,14 @@
-gametitle=Legacy of Kain - Defiance
+gametitle=Legacy of Kain - Defiance * SLES-52150 * PAL-M5 * BCAD1E8A
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-// ==========
-// pgert@170413
-// http://forums.pcsx2.net/Thread-PCSX2-Widescreen-Game-Patches?pid=240786#pid240786
-// ==========
-
-// ==========
-comment= Legacy of Kain - Defiance * SLES-52150 * PAL-M5 * BCAD1E8A
-comment=- Widescreen hack by nemesis2000.
-// ==========
+author=nemesis2000
+description=Widescreen hack
 // Built in widescreen
 patch=1,EE,0011a644,word,00000000
 patch=1,EE,0028E8C0,word,00000001
 // Sub black background off
 patch=1,EE,0013d458,word,3c013b30
-// Cutscenes black border fix
-patch=1,EE,001522e0,word,3c01bf80 // top value
-patch=1,EE,001522ec,word,3c013f80 // bottom value
 // Cutscenes render fix
 patch=1,EE,00119a34,word,3c01c340 // top value
 patch=1,EE,00119a50,word,3c014340 // bottom value
@@ -31,13 +21,14 @@ patch=1,EE,0013bcfc,word,e4200d6c
 patch=1,EE,0023d668,word,3c013b40 // hor value
 // FMV's fix
 patch=1,EE,00213588,word,24070156 // vertical aspect (int)
-// ==========
 
-// ==========
 // Alternative 16:10 hack by pgert - might not work with all BIOS types & configurations.
 // ==========
 // patch=1,EE,2033EC90,extended,3F400000 // 3F800000 - X-axis
 // patch=1,EE,2033EC94,extended,3F666666 // 3F800000 - Y-axis
-// ==========
 
-
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,001522e0,word,3c01bf80 // top value
+patch=1,EE,001522ec,word,3c013f80 // bottom value

--- a/patches/SLES-52807_5B2962FD.pnach
+++ b/patches/SLES-52807_5B2962FD.pnach
@@ -3,7 +3,7 @@ gametitle=Lemony Snicket's A Series of Unfortunate Events (E)(SLES-52807) 5B2962
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-comment=Renders the game in 16:9 aspect ratio
+description=Renders the game in 16:9 aspect ratio
 //Zoom (Gameplay)
 //003f013c 00608144
 patch=1,EE,0019c130,word,3c013f1b //3c013f00
@@ -18,10 +18,6 @@ patch=1,EE,003ad0a8,word,4481f000
 patch=1,EE,003ad0ac,word,461e1082
 patch=1,EE,003ad0b0,word,08067060
 
-//Black bar fix (Gameplay)
-//803f013c 00008144 34100046 00000000
-patch=1,EE,001c2e10,word,3c013a00 //3c013f80
-
 //X-Fov (Menu, Text and Cutscene)
 //0000acc7 803f013c (2nd)
 patch=1,EE,002ea5c4,word,080eb42d
@@ -33,8 +29,14 @@ patch=1,EE,003ad0c0,word,4481f000
 patch=1,EE,003ad0c4,word,461e6302
 patch=1,EE,003ad0c8,word,080ba972
 
+[Remove Blackbars]
+author=Arapapa
+description=Removes black bars in cutscenes
+//803f013c 00008144 34100046 00000000
+patch=1,EE,001c2e10,word,3c013a00 //3c013f80
+
 [50 FPS]
 author=PeterDelta
-comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+description=Unlocks internal FPS. Might need EE Overclock at 130%.
 patch=1,EE,0047D2C0,word,42C80000 //42480000
 patch=1,EE,0047D2C4,word,3C23D70A //3CA3D70A

--- a/patches/SLES-52877_08C1ED4D.pnach
+++ b/patches/SLES-52877_08C1ED4D.pnach
@@ -2,7 +2,8 @@ gametitle=Haunting Ground (SLES-52877)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000 )
+author=nemesis2000
+description=Widescreen hack
 patch=1,EE,0010e31c,word,3c013f40
 patch=1,EE,0010e320,word,44810000
 patch=1,EE,0010e328,word,4600c602
@@ -11,9 +12,9 @@ patch=1,EE,0010e328,word,4600c602
 patch=1,EE,0028aecc,word,34a98c00
 patch=1,EE,0028aeb4,word,34a67400
 
-//black borders fix
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
 patch=1,EE,0035e628,word,00000000
 patch=1,EE,0035e62c,word,03e00008
 patch=1,EE,0035e630,word,00000000
-
-

--- a/patches/SLES-52931_54D68884.pnach
+++ b/patches/SLES-52931_54D68884.pnach
@@ -1,9 +1,9 @@
-gametitle=Legend of Kay (PAL-M5) (SLES-52931)
+gametitle=Legend of Kay (PAL-M5) (SLES-52931) 54D68884
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-comment=Widescreen Hack
+description=Widescreen Hack
 // 16:9
 patch=1,EE,00392a1c,word,08128980 // 8e040004
 patch=1,EE,00392a20,word,00000000 // 46020003
@@ -13,13 +13,12 @@ patch=1,EE,004a2608,word,8e040004 // 00000000
 patch=1,EE,004a260c,word,46020003 // 00000000
 patch=1,EE,004a2610,word,461e0842 // 00000000
 patch=1,EE,004a2614,word,080e4a88 // 00000000
-
 patch=1,EE,0010579c,word,3c014300 // 3c013e80 render fix
-
 patch=1,EE,002fce20,word,3c013f2e // 00000000 inventory fix
 patch=1,EE,002fce24,word,4481f000 // 00000000
 patch=1,EE,002ff9e4,word,461ea503 // 4600a502
 
-patch=1,EE,003032fc,word,3c0141f0 // 3c014180 remove black bars in cut-scenes
-
-
+[Remove Blackbars]
+author=ElHecht
+description=Removes black bars in cutscenes
+patch=1,EE,003032fc,word,3c0141f0 // 3c014180

--- a/patches/SLES-53025_6419FCC3.pnach
+++ b/patches/SLES-53025_6419FCC3.pnach
@@ -1,9 +1,9 @@
-gametitle=Red Ninja - End of Honor (PAL-E) (SLES-53025)
+gametitle=Red Ninja - End of Honor (PAL-E) (SLES-53025) 6419FCC3
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
-
+author=ElHecht
+description=Widescreen hack
 // 16:9
 patch=1,EE,0036dedc,word,3c013f40 // 3c013f80 hor fov1
 patch=1,EE,0036dee0,word,44817000 // 44816000
@@ -16,7 +16,8 @@ patch=1,EE,004026ec,word,461e0842 // 46020842
 
 patch=1,EE,003625c4,word,3c013f2b // 3c013f00 renderfix enemies
 
-patch=1,EE,0010a694,word,3c01c380 // 3c01c316 remove black bars in cut-scenes
-patch=1,EE,0010a6c8,word,3c014380 // 3c014316 remove black bars in cut-scenes
-
-
+[Remove Blackbars]
+author=ElHecht
+description=Removes black bars in cutscenes
+patch=1,EE,0010a694,word,3c01c380 // 3c01c316
+patch=1,EE,0010a6c8,word,3c014380 // 3c014316

--- a/patches/SLES-53026_2F4D8BA5.pnach
+++ b/patches/SLES-53026_2F4D8BA5.pnach
@@ -1,9 +1,9 @@
-gametitle=Red Ninja - End of Honor (PAL-G) (SLES-53026)
+gametitle=Red Ninja - End of Honor (PAL-G) (SLES-53026) 2F4D8BA5
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
-
+author=ElHecht
+description=Widescreen hack
 // 16:9
 patch=1,EE,0036e0c4,word,3c013f40 // 3c013f80 hor fov1
 patch=1,EE,0036e0c8,word,44817000 // 44816000
@@ -16,7 +16,8 @@ patch=1,EE,004028d4,word,461e0842 // 46020842
 
 patch=1,EE,003627ac,word,3c013f2b // 3c013f00 renderfix enemies
 
-patch=1,EE,0010a694,word,3c01c380 // 3c01c316 remove black bars in cut-scenes
-patch=1,EE,0010a6c8,word,3c014380 // 3c014316 remove black bars in cut-scenes
-
-
+[Remove Blackbars]
+author=ElHecht
+description=Removes black bars in cutscenes
+patch=1,EE,0010a694,word,3c01c380 // 3c01c316
+patch=1,EE,0010a6c8,word,3c014380 // 3c014316

--- a/patches/SLES-53096_DC85FC8F.pnach
+++ b/patches/SLES-53096_DC85FC8F.pnach
@@ -1,11 +1,9 @@
-gametitle=Worms 4 - Mayhem (E)(SLES-53096)
+gametitle=Worms 4 - Mayhem (E)(SLES-53096) DC85FC8F
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
-
-//Widescreen hack 16:9
-
+author=Arapapa
+description=Widescreen Hack by Arapapa
 //X-Fov
 //00000000 c3180b46 a40080ac 00000000 00000000 43080a46
 //403f013c c3180b46 a40080ac 00f08144 43080a46 42081e46
@@ -14,8 +12,8 @@ patch=1,EE,00424484,word,4481f000 //00000000
 patch=1,EE,00424488,word,460a0843 //00000000
 patch=1,EE,0042448c,word,461e0842 //460a0843
 
-//Get rid of 'BLACK BAR'
+[Remove Blackbars]
+author=Arapapa
+description=Removes black bars in cutscenes
 //803f013c 00088144 480003c6
 patch=1,EE,0017a6b4,word,3c010000 //3c013f80
-
-

--- a/patches/SLES-53332_BB70FFB9.pnach
+++ b/patches/SLES-53332_BB70FFB9.pnach
@@ -1,9 +1,20 @@
-gametitle=Medal of Honor: European Assault  (SLES-53332)
+gametitle=Medal of Honor: European Assault (PAL-M) (SLES-53332) BB70FFB9
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
-
+author=nemesis2000
+description=Widescreen hack
 patch=1,EE,0012927c,word,00000000
 
+[50/60 FPS]
+author=asasega
+description=Unlocks internal FPS. Might need EE Overclock at 180%.
+patch=1,EE,20127570,extended,28420001
 
+[480p Mode]
+gsinterlacemode=1
+author=PeterDelta
+description=Forces progressive scan mode 480p at startup.
+patch=1,EE,0044200C,word,24110000
+patch=1,EE,00442010,word,24120050
+patch=1,EE,0044201C,word,24130001

--- a/patches/SLES-53336_BB70FFB9.pnach
+++ b/patches/SLES-53336_BB70FFB9.pnach
@@ -3,10 +3,18 @@ gametitle=Medal of Honor - European Assault (PAL-S) SLES-53336 BB70FFB9
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=nemesis2000
-comment=Renders the game in 16:9 aspect ratio
+description=Renders the game in 16:9 aspect ratio
 patch=1,EE,0012927c,word,00000000
 
-[50 FPS]
+[50/60 FPS]
 author=asasega
-comment=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+description=Unlocks internal FPS. Might need EE Overclock at 180%.
 patch=1,EE,20127570,extended,28420001
+
+[480p Mode]
+gsinterlacemode=1
+author=PeterDelta
+description=Forces progressive scan mode 480p at startup.
+patch=1,EE,0044200C,word,24110000
+patch=1,EE,00442010,word,24120050
+patch=1,EE,0044201C,word,24130001

--- a/patches/SLES-53824_2A79E058.pnach
+++ b/patches/SLES-53824_2A79E058.pnach
@@ -1,9 +1,9 @@
-gametitle=Trapt (PAL-E) (SLES-53824)
+gametitle=Trapt (PAL-E) (SLES-53824) 2A79E058
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
-
+author=ElHecht
+description=Widescreen hack
 // 16:9 vertical fov
 patch=1,EE,00104974,word,3c013f40 // 00000000 ver fov
 patch=1,EE,00104980,word,4481f000 // 00000000
@@ -22,8 +22,8 @@ patch=1,EE,0029ce40,word,3c024415 // 3c0243e0 loading screen ver fov
 // font fix for cut-scenes
 patch=1,EE,001c628c,word,3c024190 // 3c0241c0
 
-// remove black bars in cut-scenes
+[Remove Blackbars]
+author=ElHecht
+description=Removes black bars in cutscenes
 patch=1,EE,001e4e04,word,3c020000 // 3c024420
 patch=1,EE,001e4e50,word,3c020000 // 3c024420
-
-

--- a/patches/SLES-53967_9C5C1478.pnach
+++ b/patches/SLES-53967_9C5C1478.pnach
@@ -1,11 +1,9 @@
-gametitle=The Godfather (PAL)(SLES-53967)
+gametitle=The Godfather (PAL-M) (SLES-53967) 9C5C1478
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
-
-//Widescreen hack 16:9
-
+author=Arapapa
+description=Widescreen Hack
 //Zoom
 //003f013c 00608144
 patch=1,EE,0035f2ac,word,3c013f20 //3c013f00
@@ -14,7 +12,7 @@ patch=1,EE,0035f2ac,word,3c013f20 //3c013f00
 //403f013c 00108144
 patch=1,EE,0036f42c,word,3c013f10 //3c013f40
 
-//Cutscene Bars
+[Remove Blackbars]
+author=Arapapa
+description=Removes black bars in cutscenes
 patch=1,EE,006617B8,word,00000001
-
-

--- a/patches/SLES-54308_38A5588B.pnach
+++ b/patches/SLES-54308_38A5588B.pnach
@@ -1,9 +1,9 @@
-gametitle=Phantasy Star Universe (PAL-M3) (SLES-54308)
+gametitle=Phantasy Star Universe (PAL-M3) (SLES-54308) 38A5588B
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack (16:9) by ElHecht
-
+author=ElHecht
+description=Widescreen Hack
 // 16:9
 patch=1,EE,0085cb30,word,43400000 // 43800000 hor fov
 patch=1,EE,0068f7a4,word,3c093c02 // 00000000
@@ -18,7 +18,7 @@ patch=1,EE,0068f7f4,word,ad493d78 // 00000000
 //patch=1,EE,0068f7f0,word,3c0a0028 // 00000000
 //patch=1,EE,0068f7f4,word,ad493d78 // 00000000
 
-//optional cut-scenes black bar removal
-//patch=1,EE,00767F94,word,40000000
-
-
+[Remove Blackbars]
+author=ElHecht
+description=Removes black bars in cutscenes
+patch=1,EE,00767F94,word,40000000

--- a/patches/SLES-54443_CC03D5AD.pnach
+++ b/patches/SLES-54443_CC03D5AD.pnach
@@ -1,23 +1,24 @@
-gametitle=Made Man (E)(SLES-54443)
+gametitle=Made Man (PAL-M) (SLES-54443) CC03D5AD
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
+author=Arapapa & PeterDelta
+description=Renders the game in 16:9 aspect ratio
+patch=1,EE,00152E68,word,3C013FAB //3C013F80 Y-Fov
+patch=1,EE,00220530,word,3C013F20 //3C013F00 Zoom
+patch=1,EE,001B2D70,word,3C013F04 //3C013F1C Zoom menu fix
+patch=1,EE,00498B28,word,3F700000 //3F800000 Black bars fix
 
-//Widescreen hack 16:9
+[Remove Blackbars]
+author=Arapapa & PeterDelta
+description=Removes black bars in cutscenes
+patch=1,EE,00100B88,word,24040000 //24040001 Upper
+patch=1,EE,00100C88,word,24040000 //24040001 Bottom
 
-//Y-Fov
-patch=1,EE,00152e68,word,3c013fab //3c013f80
-
-//Zoom
-patch=1,EE,00220530,word,3c013f20 //3c013f00
-
-//Black Bar Fix
-patch=1,EE,00100b8c,word,3c010000 //3c014420 Bottom
-patch=1,EE,00100ba0,word,3c010000 //3c014270 Upper
-
-//Black Scene Fix
-//f043013c 00a08144 2d200002
-patch=1,EE,00100e2c,word,3c010000 //3c0143f0
-
-
+[480p Mode]
+gsinterlacemode=1
+author=PeterDelta
+description=Forces progressive scan mode 480p at startup.
+patch=1,EE,001CED74,word,24110000
+patch=1,EE,001CED78,word,24120050
+patch=1,EE,001CED84,word,24130001

--- a/patches/SLES-54837_5F30B426.pnach
+++ b/patches/SLES-54837_5F30B426.pnach
@@ -1,30 +1,35 @@
-gametitle=Disney Princess - Enchanted Journey (E)(SLES-54837)
+gametitle=Disney Princess - Enchanted Journey (PAL-E-G-S) (SLES-54837) 5F30B426
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-comment=Widescreen Hack
-
-//Widescreen hack 16:9
-
+description=Widescreen Hack
 //X-Fov
 patch=1,EE,00265454,word,3c014440 //3c014480
 
 //Render Fix
 patch=1,EE,003f3530,word,40000000 //3eaaaaab
 
-//Black Bar Fix
-patch=1,EE,00188de4,word,00000000 //44810000
-
-
 //Menu.... Character Position (Not Fixed Address)
 //patch=1,EE,206db7d8,extended,39000000 //3d991686
 //patch=1,EE,206db7e0,extended,3e3f0000 //3e4d4fdf
 
+[Remove Blackbars]
+author=Arapapa
+description=Removes black bars in cutscenes
+patch=1,EE,00188de4,word,00000000 //44810000
 
-[50 FPS]
-author=PeterDelta
-comment=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,001002F4,word,10000011 //45000011 bc1f 0x0010033C
-patch=1,EE,E0010001,extended,0185E904 //fixed fmv
+[50/60 FPS]
+author=asasega & PeterDelta
+description=Unlocks internal FPS. Might need EE Overclock at 130%.
+patch=1,EE,201002F4,extended,10000011
+patch=1,EE,E0010000,extended,003A6A38 //fixed fmv
 patch=1,EE,201002F4,extended,45000011
+
+[480p Mode]
+gsinterlacemode=1
+author=PeterDelta
+description=Forces progressive scan mode 480p at startup.
+patch=1,EE,003313DC,word,24110000
+patch=1,EE,003313E0,word,24120050
+patch=1,EE,003313EC,word,24130001

--- a/patches/SLES-55147_DC180A6B.pnach
+++ b/patches/SLES-55147_DC180A6B.pnach
@@ -1,10 +1,21 @@
-gametitle=Silent Hill Origins (SLES-55147)
+gametitle=Silent Hill Origins (PAL-M) (SLES-55147) DC180A6B
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen fix by nemesis2000 (pnach by nemesis2000)
+author=nemesis2000
+description=Widescreen fix
+patch=1,EE,001DA9EC,word,3C013FE3
+patch=1,EE,001DA9F0,word,34218E39
+patch=1,EE,001E4938,word,AC40EC80 //noise off
+patch=1,EE,00338F9C,word,43F00000 //43B90000 sub y-pos
+patch=1,EE,00338FA8,word,41A80000 //41600000 sub size
 
-patch=1,EE,001da9ec,word,3c013fe3
-patch=1,EE,001da9f0,word,34218e39
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,001832d4,word,3c010000 //3c014220
 
-
+[50 FPS]
+author=PeterDelta
+description=Unlocks internal FPS. Might need EE Overclock at 130%.
+patch=1,EE,006B3974,extended,04000001 //04000002

--- a/patches/SLES-82026_98D4BC93.pnach
+++ b/patches/SLES-82026_98D4BC93.pnach
@@ -3,7 +3,7 @@ gametitle=Metal Gear Solid 3 - Snake Eater (PAL-S) SLES-82026 98D4BC93
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PeterDelta
-comment=Renders the game in 16:9 aspect ratio
+description=Renders the game in 16:9 aspect ratio
 patch=1,EE,00203FAC,word,3F400000 //3F800000
 patch=1,EE,E00367C8,extended,004B6640
 patch=1,EE,204B6638,extended,3FB00000
@@ -57,13 +57,17 @@ patch=1,EE,E00367C8,extended,0049A7D8
 patch=1,EE,2049A7D0,extended,3FB00000
 patch=1,EE,2049A7D4,extended,3F2F7CEE
 patch=1,EE,2049A7DC,extended,BFB00000
-patch=1,EE,002501DC,extended,00000000 //black bands in scenes
+
+[Remove Blackbars]
+author=PeterDelta
+description=Removes black bars in cutscenes
+patch=1,EE,002501DC,extended,00000000
 patch=1,EE,E0010001,extended,0020B0D4
 patch=1,EE,002501DC,extended,00000001
 
 [50 FPS]
 author=PeterDelta
-comment=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+description=Unlocks internal FPS. Might need EE Overclock at 130%.
 patch=1,EE,001D5E78,word,00000001 //00000002
 patch=1,EE,001D5E7C,word,00000000 //00000001
 patch=1,EE,001D4BA8,word,00000000 //00000040

--- a/patches/SLES-82048_8A5C25A7.pnach
+++ b/patches/SLES-82048_8A5C25A7.pnach
@@ -57,7 +57,11 @@ patch=1,EE,E00367C8,extended,004B04E0
 patch=1,EE,204B04D8,extended,3FB00000
 patch=1,EE,204B04DC,extended,3F43F7CF
 patch=1,EE,204B04E4,extended,BFB00000
-patch=1,EE,0026139C,extended,00000000 //black bands in scenes
+
+[Remove Blackbars]
+author=PeterDelta
+description=Removes black bars in cutscenes
+patch=1,EE,0026139C,extended,00000000
 patch=1,EE,E0010001,extended,0020CE74
 patch=1,EE,0026139C,extended,00000001
 

--- a/patches/SLPM-65945_93DC1B9F.pnach
+++ b/patches/SLPM-65945_93DC1B9F.pnach
@@ -26,10 +26,10 @@ patch=1,EE,00409bc4,word,461e0842 //46020842
 //003f013c 00008144 803d013c
 patch=1,EE,00363ecc,word,3c013f2b //3c013f00 renderfix enemies
 
+[Remove Blackbars]
+description=Removes black bars in cutscenes
 //16c3013c 00688144 (3c7e74c4)
 patch=1,EE,0010ab60,word,3c01c380 //3c01c316 remove black bars in cut-scenes
 
 //1643013c 00688144 3000a427
 patch=1,EE,0010ab94,word,3c014380 //3c014316 remove black bars in cut-scenes
-
-

--- a/patches/SLUS-20011_7BF65F9C.pnach
+++ b/patches/SLUS-20011_7BF65F9C.pnach
@@ -1,10 +1,6 @@
-gametitle=Orphen: Scion of Sorcery [NTSC-U] (SLUS-20011)
+gametitle=Orphen: Scion of Sorcery [NTSC-U] (SLUS-20011) 7BF65F9C
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-comment=Pnach by Little Giant
-
-//black borders's fix (optional)
+[Remove Blackbars]
+author=Little Giant
+description=Removes black bars in cutscenes
 patch=1,EE,0025fdc4,word,24020000 //24020001
-
-

--- a/patches/SLUS-20024_9A8DC7D3.pnach
+++ b/patches/SLUS-20024_9A8DC7D3.pnach
@@ -1,16 +1,18 @@
 gametitle=Blood Omen 2: The Legacy of Kain Series (SLUS-20024)
 
 [Widescreen 16:9]
-description=Renders the game in 16:9 aspect ratio, instead of 4:3.
 gsaspectratio=16:9
-
+author=pavachan & nemesis2000
+description=Renders the game in 16:9 aspect ratio, instead of 4:3.
 //Widescreen
 patch=1,EE,00312b08,word,3C013FE3
 patch=1,EE,00312b0c,word,34218E38
-//Black Borders Fix
-patch=1,EE,002d443c,word,00000000
+
 //FMV Fix
 patch=1,EE,002eb280,word,240575e0 //y-position
 patch=1,EE,002eb298,word,240a1440 //y-scaling
 
-
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,002d443c,word,00000000

--- a/patches/SLUS-20221_7FBCDA34.pnach
+++ b/patches/SLUS-20221_7FBCDA34.pnach
@@ -11,9 +11,6 @@ patch=1,EE,00212358,word,3c013f40 // 00000000 hor fov
 //patch=1,EE,00212358,word,3c013f55 // 00000000 hor fov
 //patch=1,EE,00212388,word,34215555 // 00000000 hor fov
 
-// cut-scenes black bar removal
-patch=1,EE,001ffc38,word,3c030000 // 3c034420 remove black bars in cut-scenes
-
 // 16:9 and 16:10 main modfication
 // no need to change anything here! all modifications are calculated
 // based on the hor fov value in the upper 16:9/16:10 section
@@ -39,4 +36,6 @@ patch=1,EE,001aedc0,word,46002103 // 44882000 crosshair/aiming fix unit vector
 patch=1,EE,001aedc4,word,461e26c3 // 46002103 crosshair/aiming fix unit vector
 patch=1,EE,001aedc8,word,461b0842 // 46040842 crosshair/aiming fix unit vector
 
-
+[Remove Blackbars]
+description=Removes black bars in cutscenes
+patch=1,EE,001ffc38,word,3c030000 // 3c034420

--- a/patches/SLUS-20370_0F6B6315.pnach
+++ b/patches/SLUS-20370_0F6B6315.pnach
@@ -2,7 +2,8 @@ gametitle=Kingdom Hearts (SLUS-20370)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen patch by nemesis2000 (pnach by nemesis2000 )
+author=nemesis2000
+description=Widescreen hack
 patch=1,EE,001103ac,word,3c0143d6 //render fix
 patch=1,EE,00110898,word,3c013f19 //hor value first half
 patch=1,EE,0011089c,word,3421999a //hor value second half
@@ -10,10 +11,6 @@ patch=1,EE,0011089c,word,3421999a //hor value second half
 //FMV's fix
 patch=1,EE,002a0d88,word,70007000
 patch=1,EE,001061f4,word,3c071900
-
-//black border fix
-patch=1,EE,00104264,word,00000000
-patch=1,EE,00104384,word,00000000
 
 // matrix (affects menu characters, textboxes, world map, gummi ship)
 patch=1,EE,0026202c,word,3c013f40 //00000000
@@ -27,4 +24,8 @@ patch=1,EE,2048E550,word,3FAAAAAB //3f800000 (width)
 //position fix weapon select
 patch=1,EE,00207498,word,3c0144fa // 3c014500
 
-
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,00104264,word,00000000
+patch=1,EE,00104384,word,00000000

--- a/patches/SLUS-20416_6B64AB86.pnach
+++ b/patches/SLUS-20416_6B64AB86.pnach
@@ -1,9 +1,9 @@
-gametitle=Headhunter (NTSC-U) (SLUS-20416)
+gametitle=Headhunter (NTSC-U) (SLUS-20416) 6B64AB86
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by ElHecht
-
+author=ElHecht
+description=Widescreen Hack
 // 16:9
 patch=1,EE,00196fd4,word,10400007 // 1040000b
 patch=1,EE,00196fec,word,1000fffd // 00000000
@@ -27,8 +27,8 @@ patch=1,EE,0018f9e0,word,e79dbcb4 // e784bcb4 renderfix
 //patch=1,EE,0018f9ac,word,461e2743 // 4481a000 renderfix
 //patch=1,EE,0018f9e0,word,e79dbcb4 // e784bcb4 renderfix
 
-//Black bar fix by Arapapa (Get rid of 'Black Bar')
+[Remove Blackbars]
+author=Arapapa
+description=Removes black bars in cutscenes
 //9a99993f 5555553f 5655553e
-patch=1,EE,00586d04,word,00000000 /3f99999a
-
-
+patch=1,EE,00586d04,word,00000000 //3f99999a

--- a/patches/SLUS-20633_274E5444.pnach
+++ b/patches/SLUS-20633_274E5444.pnach
@@ -12,9 +12,6 @@ patch=1,EE,018bd5b8,word,34028260
 patch=1,EE,018bcf38,word,3c026fa0
 patch=1,EE,018bcf84,word,34028260
 
-//black borders fix by nemesis2000
-patch=1,EE,018f37e4,word,3c030000
-
 //remove black square near Panic Meter
 patch=1,EE,2041C240,word,00000000
 
@@ -26,4 +23,7 @@ patch=1,EE,2041C240,word,00000000
 //patch=1,EE,20419E00,word,00000000 //Shatter 3
 //patch=1,EE,20419E24,word,00000000 //Shatter 4
 
-
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,018f37e4,word,3c030000

--- a/patches/SLUS-20714_6B0F338D.pnach
+++ b/patches/SLUS-20714_6B0F338D.pnach
@@ -16,8 +16,10 @@ patch=1,EE,003fdcac,word,461e0842 // 46020002
 
 patch=1,EE,0035dcc4,word,3c013f2b // 3c013f00 renderfix enemies
 
-patch=1,EE,00109e90,word,3c01c380 // 3c01c316 remove black bars in cut-scenes
-patch=1,EE,00109ec4,word,3c014380 // 3c014316 remove black bars in cut-scenes
+[Remove Blackbars]
+description=Removes black bars in cutscenes
+patch=1,EE,00109e90,word,3c01c380 // 3c01c316
+patch=1,EE,00109ec4,word,3c014380 // 3c014316
 
 [60 FPS]
 author=Gabominated

--- a/patches/SLUS-20773_728AB07C.pnach
+++ b/patches/SLUS-20773_728AB07C.pnach
@@ -2,18 +2,14 @@ gametitle=Legacy of Kain: Defiance (SLUS-20773)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
-
+author=nemesis2000
+description=Widescreen hack
 //built in widescreen
 patch=1,EE,0011a33c,word,00000000
 patch=1,EE,0028cfe0,word,00000001
 
 //sub black background off
 patch=1,EE,0013d108,word,3c013b30
-
-//cutscenes black border fix
-patch=1,EE,00151ef8,word,3c01bf80 //top value
-patch=1,EE,00151f04,word,3c013f80 //bottom value
 
 //cutscenes render fix
 patch=1,EE,0011972c,word,3c01c340 //top value
@@ -31,10 +27,13 @@ patch=1,EE,0023be84,word,3c013b40 //hor value
 //FMV's fix
 patch=1,EE,00212f2c,word,24070140
 
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,00151ef8,word,3c01bf80 //top value
+patch=1,EE,00151f04,word,3c013f80 //bottom value
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,201C3070,word,30420000
-
-

--- a/patches/SLUS-20793_C5DAD771.pnach
+++ b/patches/SLUS-20793_C5DAD771.pnach
@@ -2,10 +2,11 @@ gametitle=Gladiator - Sword of Vengeance NTSC-U
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack
+description=Widescreen hack
 patch=1,EE,001c6240,word,3c013f40 //fov
 patch=1,EE,0020dc38,word,3c013fab // vert fov
-patch=1,EE,0028462c,word,3c010000 // black bars remove
 patch=1,EE,20799D30,extended,bfab0000 //hud stretch
 
-
+[Remove Blackbars]
+description=Removes black bars in cutscenes
+patch=1,EE,0028462c,word,3c010000

--- a/patches/SLUS-20804_A9C82AB9.pnach
+++ b/patches/SLUS-20804_A9C82AB9.pnach
@@ -3,7 +3,7 @@ gametitle=Demon Stone (SLUS-20804)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=nemesis2000
-comment=Widescreen hack
+description=Widescreen hack
 
 patch=1,EE,001a4fb0,word,3c013f40
 patch=1,EE,001a4fb4,word,44810000
@@ -12,7 +12,9 @@ patch=1,EE,001a4fbc,word,46006b43
 patch=1,EE,0015629c,word,3c023fe3
 patch=1,EE,001562a0,word,34438e38
 
-//black borders fix
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
 patch=1,EE,001d8330,word,24040001
 
 [60 FPS]

--- a/patches/SLUS-20934_E1D6F85E.pnach
+++ b/patches/SLUS-20934_E1D6F85E.pnach
@@ -15,13 +15,12 @@ patch=1,EE,001f5c90,word,3442bbd6
 //FMV's fix by nemesis2000
 patch=1,EE,205D9054,extended,3faaaaaa
 
-//black border's fix by nemesis2000
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
 patch=1,EE,0032b0a8,word,3c023f80
-
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,20102A84,extended,34021400
-
-

--- a/patches/SLUS-21005_DA0535FD.pnach
+++ b/patches/SLUS-21005_DA0535FD.pnach
@@ -29,22 +29,21 @@ patch=1,EE,2037ae44,word,3F400000 // 3F800000
 patch=1,EE,2037ae48,word,3F400000 // 3F800000
 patch=1,EE,2037ae4c,word,3F400000 // 3F800000
 
-//black bar fix
+//lower subtitles
+patch=1,EE,001aae88,word,240a0190
+
+[Remove Blackbars]
+description=Removes black bars in cutscenes
 patch=1,EE,0014aaf0,word,24050000
 patch=1,EE,0014ab18,word,24050000
 patch=1,EE,0014ab40,word,24050000
 patch=1,EE,0014ab70,word,24050000
-
-//lower subtitles
-patch=1,EE,001aae88,word,240a0190
-
-//subtitles off
-//patch=1,EE,002274cc,word,11e00019
-
 
 [60 FPS]
 description=Forces the game to run at 60.
 //60 FPS
 patch=1,EE,00356F4C,extended,00000000
 
-
+[Subtitles off]
+description=Disable subtitles during scenes
+patch=1,EE,002274cc,word,11e00019

--- a/patches/SLUS-21041_F3BDB2E6.pnach
+++ b/patches/SLUS-21041_F3BDB2E6.pnach
@@ -3,11 +3,6 @@ gametitle=Shadow Hearts Covenant SLUS_210.41
 [Widescreen 16:9]
 gsaspectratio=16:9
 comment=Widescreen Hack
-
-//black borders fix (optional)
-// (c843033c 803f023c to c843033c 0000023c)
-patch=1,EE,00402f24,word,3c020000 //3c023f80
-
 // 16:9
 patch=1,EE,00202c94,word,3c013f40
 patch=1,EE,00202c98,word,44810000
@@ -16,7 +11,6 @@ patch=1,EE,00202ca0,word,4600c602
 // Render-Fix
 patch=1,EE,0022531c,word,3c033fc0
 
-
 //16:9 Text box
 //Remove "//" before patch to activate
 //Side Effect -  subtitles during cutscenes will be on the left side of the screen
@@ -24,4 +18,7 @@ patch=1,EE,0022531c,word,3c033fc0
 //patch=1,EE,0027cf78,word,3c023f19 //3c023f4c
 //patch=1,EE,0026eabc,word,3c023eB0 //3c023f00
 
-
+[Remove Blackbars]
+description=Removes black bars in cutscenes
+// (c843033c 803f023c to c843033c 0000023c)
+patch=1,EE,00402f24,word,3c020000 //3c023f80

--- a/patches/SLUS-21044_F3BDB2E6.pnach
+++ b/patches/SLUS-21044_F3BDB2E6.pnach
@@ -3,11 +3,6 @@ gametitle=Shadow Hearts Covenant SLUS_210.41
 [Widescreen 16:9]
 gsaspectratio=16:9
 comment=Widescreen Hack
-
-//black borders fix (optional)
-// (c843033c 803f023c to c843033c 0000023c)
-patch=1,EE,00402f24,word,3c020000 //3c023f80
-
 // 16:9
 patch=1,EE,00202c94,word,3c013f40
 patch=1,EE,00202c98,word,44810000
@@ -16,7 +11,6 @@ patch=1,EE,00202ca0,word,4600c602
 // Render-Fix
 patch=1,EE,0022531c,word,3c033fc0
 
-
 //16:9 Text box
 //Remove "//" before patch to activate
 //Side Effect -  subtitles during cutscenes will be on the left side of the screen
@@ -24,4 +18,7 @@ patch=1,EE,0022531c,word,3c033fc0
 //patch=1,EE,0027cf78,word,3c023f19 //3c023f4c
 //patch=1,EE,0026eabc,word,3c023eB0 //3c023f00
 
-
+[Remove Blackbars]
+description=Removes black bars in cutscenes
+// (c843033c 803f023c to c843033c 0000023c)
+patch=1,EE,00402f24,word,3c020000 //3c023f80

--- a/patches/SLUS-21075_901AAC09.pnach
+++ b/patches/SLUS-21075_901AAC09.pnach
@@ -2,7 +2,8 @@ gametitle=Haunting Ground (SLUS-21075)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000 )
+author=nemesis2000
+description=Widescreen hack
 patch=1,EE,0010e31c,word,3c013f40
 patch=1,EE,0010e320,word,44810000
 patch=1,EE,0010e328,word,4600c602
@@ -10,11 +11,6 @@ patch=1,EE,0010e328,word,4600c602
 //cutscenes fix
 patch=1,EE,002ba3ec,word,34a98c00
 patch=1,EE,002ba3d4,word,34a67400
-
-//black borders fix
-patch=1,EE,002c9ea8,word,00000000
-patch=1,EE,002c9eac,word,03e00008
-patch=1,EE,002c9eb0,word,00000000
 
 //dynamic zoom
 //patch=1,EE,2045FD40,word,3F800000
@@ -25,4 +21,9 @@ patch=1,EE,002c9eb0,word,00000000
 //zoom in
 //patch=1,EE,0010e340,word,3c013f60 //3c013f80
 
-
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,002c9ea8,word,00000000
+patch=1,EE,002c9eac,word,03e00008
+patch=1,EE,002c9eb0,word,00000000

--- a/patches/SLUS-21078_4835F048.pnach
+++ b/patches/SLUS-21078_4835F048.pnach
@@ -3,7 +3,7 @@ gametitle=Lemony Snicket's A Series of Unfortunate Events (U)(SLUS-21078) 4835F0
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-comment=Widescreen hack
+description=Widescreen hack
 //Zoom (Gameplay)
 //003f013c 00608144
 patch=1,EE,0018cd58,word,3c013f1b //3c013f00
@@ -18,10 +18,6 @@ patch=1,EE,0037b9b8,word,4481f000
 patch=1,EE,0037b9bc,word,461e1082
 patch=1,EE,0037b9c0,word,0806336a
 
-//Black bar fix (Gameplay)
-//803f013c 00008144 34100046 00000000
-patch=1,EE,001af498,word,3c013a00 //3c013f80
-
 //X-Fov (Menu,Text and Cutscene)
 //0000acc7 803f013c (2nd)
 patch=1,EE,002bbf24,word,080dee74
@@ -32,6 +28,12 @@ patch=1,EE,0037b9d8,word,3421aaab
 patch=1,EE,0037b9dc,word,4481f000
 patch=1,EE,0037b9e0,word,461e6302
 patch=1,EE,0037b9e4,word,080aefca
+
+[Remove Blackbars]
+author=Arapapa
+description=Removes black bars in cutscenes
+//803f013c 00008144 34100046 00000000
+patch=1,EE,001af498,word,3c013a00 //3c013f80
 
 [60 FPS]
 author=asasega

--- a/patches/SLUS-21145_2545CA71.pnach
+++ b/patches/SLUS-21145_2545CA71.pnach
@@ -2,10 +2,8 @@ gametitle=Full Spectrum Warrior (U)(SLUS-21145)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
-
-//Widescreen hack 16:9
-
+author=Arapapa
+description=Widescreen hack
 //X-Fov
 //803f013c 00a88144 80001026
 patch=1,EE,00402c28,word,3c013fab //3c013f80
@@ -26,13 +24,13 @@ patch=1,EE,0042b41c,word,461e2102 //46001103 Left
 patch=1,EE,0042b428,word,4600a143 //00000000
 patch=1,EE,0042b42c,word,461e2942 //4600a143 Right
 
-//Black Bar Fix(Get rid of Black Bar)
-//4842013c 00a08144 80730e46
-patch=1,EE,002ea0f0,word,3c010000 //3c014248
-
 //Get rid of fading effect (Black Scene)
 patch=1,EE,002ea018,word,3c010000 //3c013f80
 patch=1,EE,002ea4a0,word,3c010000 //3c013f80
 patch=1,EE,002ea5ec,word,3c010000 //3c01437f
 
-
+[Remove Blackbars]
+author=Arapapa
+description=Removes black bars in cutscenes
+//4842013c 00a08144 80730e46
+patch=1,EE,002ea0f0,word,3c010000 //3c014248

--- a/patches/SLUS-21156_15948AA5.pnach
+++ b/patches/SLUS-21156_15948AA5.pnach
@@ -2,8 +2,8 @@ gametitle=Without Warning (SLUS)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
-
+author=nemesis2000
+description=Widescreen hack
 patch=1,EE,001486fc,word,3c013f40
 patch=1,EE,00148700,word,44810800
 patch=1,EE,00148704,word,27bdffe0
@@ -17,7 +17,7 @@ patch=1,EE,00148368,word,0c0521bf
 patch=1,EE,00197ddc,word,0c0521bf
 patch=1,EE,00197df8,word,0c0521bf
 
-//black borders fix
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
 patch=1,EE,0017f75c,word,3c013f80
-
-

--- a/patches/SLUS-21199_BB70FFB9.pnach
+++ b/patches/SLUS-21199_BB70FFB9.pnach
@@ -1,9 +1,20 @@
-gametitle=Medal of Honor: European Assault  (SLUS-21199) / Medal of Honor: European Assault  (SLES-53332)
+gametitle=Medal of Honor: European Assault (NTSC-U) (SLUS-21199) BB70FFB9
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
-
+author=nemesis2000
+description=Widescreen hack
 patch=1,EE,0012927c,word,00000000
 
+[60 FPS]
+author=asasega
+description=Unlocks internal FPS. Might need EE Overclock at 180%.
+patch=1,EE,20127570,extended,28420001
 
+[480p Mode]
+gsinterlacemode=1
+author=PeterDelta
+description=Forces progressive scan mode 480p at startup.
+patch=1,EE,0044200C,word,24110000
+patch=1,EE,00442010,word,24120050
+patch=1,EE,0044201C,word,24130001

--- a/patches/SLUS-21248_F4807B40.pnach
+++ b/patches/SLUS-21248_F4807B40.pnach
@@ -2,11 +2,13 @@ gametitle=Legend of Kay (SLUS_21248)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by No.47
+author=No.47
+description=Widescreen hack
 patch=1,EE,2063D9C0,word,3FAE8BA3
 patch=1,EE,2063D9C4,word,401B26CA
 patch=1,EE,206E6814,word,3FBBBBBB
 
-patch=1,EE,003047a4,word,3c0141f0 // 3c014180 remove black bars in cut-scenes
-
-
+[Remove Blackbars]
+author=No.47
+description=Removes black bars in cutscenes
+patch=1,EE,003047a4,word,3c0141f0 // 3c014180

--- a/patches/SLUS-21255_DCFBB290.pnach
+++ b/patches/SLUS-21255_DCFBB290.pnach
@@ -2,8 +2,8 @@ gametitle=Trapt (NTSC-U)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
-
+author=ElHecht
+description=Widescreen hack
 // 16:9 vertical fov
 patch=1,EE,00104954,word,3c013f40 // 00000000 ver fov
 patch=1,EE,00104960,word,4481f000 // 00000000
@@ -22,14 +22,13 @@ patch=1,EE,0029a930,word,3c024415 // 3c0243e0 loading screen ver fov
 // font fix for cut-scenes
 patch=1,EE,001c5a4c,word,3c024190 // 3c0241c0
 
-// remove black bars in cut-scenes
+[Remove Blackbars]
+author=ElHecht
+description=Removes black bars in cutscenes
 patch=1,EE,001e4654,word,3c020000 // 3c024420
 patch=1,EE,001e46a0,word,3c020000 // 3c024420
-
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,00120e14,word,00000000 //64420008
-
-

--- a/patches/SLUS-21326_C3D28EB9.pnach
+++ b/patches/SLUS-21326_C3D28EB9.pnach
@@ -3,11 +3,6 @@ gametitle=Shadow Hearts - From the New World  SLUS_213.26
 [Widescreen 16:9]
 gsaspectratio=16:9
 comment=Widescreen Hack
-
-//black borders fix (optional)
-// (c843033c 803f023c to c843033c 0000023c)
-patch=1,EE,002f75c4,word,3c020000 //3c023f80
-
 // 16:9
 patch=1,EE,00202d4c,word,3c013f40
 patch=1,EE,00202d50,word,44810000
@@ -16,4 +11,7 @@ patch=1,EE,00202d58,word,4600c602
 // Render-Fix
 patch=1,EE,002282cc,word,3c033fc0
 
-
+[Remove Blackbars]
+description=Removes black bars in cutscenes
+// (c843033c 803f023c to c843033c 0000023c)
+patch=1,EE,002f75c4,word,3c020000 //3c023f80

--- a/patches/SLUS-21359_053D2239.pnach
+++ b/patches/SLUS-21359_053D2239.pnach
@@ -3,7 +3,7 @@ gametitle=Metal Gear Solid 3 - Subsistence (SLUS_21359) 053D2239
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PeterDelta and No.47
-comment=Renders the game in 16:9 aspect ratio
+description=Renders the game in 16:9 aspect ratio
 patch=1,EE,202050AC,word,3F400000
 patch=1,EE,E00367C8,extended,004CCD48
 patch=1,EE,204CCD40,extended,3FB00000
@@ -57,7 +57,11 @@ patch=1,EE,E00367C8,extended,004AD5E0
 patch=1,EE,204AD5D8,extended,3FB00000
 patch=1,EE,204AD5DC,extended,3F2F7CEE
 patch=1,EE,204AD5E4,extended,BFB00000
-patch=1,EE,0025E69C,extended,00000000 //black bands in scenes
+
+[Remove Blackbars]
+author=PeterDelta
+description=Removes black bars in cutscenes
+patch=1,EE,0025E69C,extended,00000000
 patch=1,EE,E0010001,extended,0020C174
 patch=1,EE,0025E69C,extended,00000001
 

--- a/patches/SLUS-21373_1648E3C9.pnach
+++ b/patches/SLUS-21373_1648E3C9.pnach
@@ -2,8 +2,8 @@ gametitle=Drakengard 2 (NTSC-U)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by ElHecht
-
+author=ElHecht
+description=Widescreen hack
 patch=1,EE,204cf458,extended,3FE38E32 // 3Faaaaaa
 patch=1,EE,20560f94,extended,44550000 // 44200000
 
@@ -14,7 +14,7 @@ patch=1,EE,20560f94,extended,44550000 // 44200000
 //patch=1,EE,002a1674,word,461e18c3 // c783c51c
 //patch=1,EE,002d2b0c,word,3c014456 // 3c014420 renderfix
 
-// black border fix
+[Remove Blackbars]
+author=ElHecht
+description=Removes black bars in cutscenes
 patch=1,EE,003323dc,word,3c010000 // 3c014300
-
-

--- a/patches/SLUS-21389_2088950A.pnach
+++ b/patches/SLUS-21389_2088950A.pnach
@@ -2,8 +2,8 @@ gametitle=Xenosaga Episode III: Also sprach Zarathustra (Disc 1) (SLUS-21389) / 
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
-
+author=nemesis2000
+description=Widescreen hack
 //gameplay
 patch=1,EE,2054FF20,extended,3fc1f080 //original value 3f91745d
 
@@ -16,10 +16,6 @@ patch=1,EE,203e4360,extended,00000174
 patch=1,EE,0019adf8,word,24020001
 patch=1,EE,0019adfc,word,a2020081
 
-//black borders's fix (optional)
-patch=1,EE,00244d90,word,24060000
-patch=1,EE,00244da4,word,24c801c0
-
 //black border removal for bosses
 //(CAUSES ISSUES WITH HAKOX - characters not loading in tutorials)
 //patch=1,EE,00a9e5d8,word,24060000
@@ -27,4 +23,8 @@ patch=1,EE,00244da4,word,24c801c0
 
 //zoom value = 2054E200
 
-
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,00244d90,word,24060000
+patch=1,EE,00244da4,word,24c801c0

--- a/patches/SLUS-21417_2088950A.pnach
+++ b/patches/SLUS-21417_2088950A.pnach
@@ -2,8 +2,8 @@ gametitle=Xenosaga Episode III: Also sprach Zarathustra (Disc 1) (SLUS-21389) / 
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen hack by nemesis2000 (pnach by nemesis2000)
-
+author=nemesis2000
+description=Widescreen hack
 //gameplay
 patch=1,EE,2054FF20,extended,3fc1f080 //original value 3f91745d
 
@@ -16,10 +16,6 @@ patch=1,EE,203e4360,extended,00000174
 patch=1,EE,0019adf8,word,24020001
 patch=1,EE,0019adfc,word,a2020081
 
-//black borders's fix (optional)
-patch=1,EE,00244d90,word,24060000
-patch=1,EE,00244da4,word,24c801c0
-
 //black border removal for bosses
 //(CAUSES ISSUES WITH HAKOX - characters not loading in tutorials)
 //patch=1,EE,00a9e5d8,word,24060000
@@ -27,4 +23,8 @@ patch=1,EE,00244da4,word,24c801c0
 
 //zoom value = 2054E200
 
-
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
+patch=1,EE,00244d90,word,24060000
+patch=1,EE,00244da4,word,24c801c0

--- a/patches/SLUS-21448_F3FD313E.pnach
+++ b/patches/SLUS-21448_F3FD313E.pnach
@@ -2,7 +2,7 @@ gametitle= Rule of Rose SLUS 214.48
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack
+description=Widescreen Hack
 patch=1,EE,0013bd54,extended,3c013f12
 patch=1,EE,0013bd7c,extended,3c013f10
 
@@ -24,9 +24,8 @@ patch=1,EE,2073D6A0,extended,00000000
 //noise off (alternate address)
 //patch=1,EE,001c9cec,word,e43f1fa0 //e4211fa0
 
-//black borders's fix
-patch=1,EE,00190e58,word,24050000
-
 //Camera distance = 203035B0
 
-
+[Remove Blackbars]
+description=Removes black bars in cutscenes
+patch=1,EE,00190e58,word,24050000

--- a/patches/SLUS-21587_C339BD7D.pnach
+++ b/patches/SLUS-21587_C339BD7D.pnach
@@ -1,29 +1,16 @@
-gametitle=Made Man - Confessions of the Family Blood (U)(SLUS-21587)
+gametitle=Made Man - Confessions of the Family Blood (U)(SLUS-21587) C339BD7D
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
+author=Arapapa & PeterDelta
+description=Renders the game in 16:9 aspect ratio
+patch=1,EE,00152DD0,word,3C013FAB //3C013F80 Y-Fov
+patch=1,EE,002205D8,word,3C013F20 //3C013F00 Zoom
+patch=1,EE,001B2E10,word,3C013F04 //3C013F1C Zoom menu fix
+patch=1,EE,00498B28,word,3F700000 //3F800000 Black bars fix
 
-//Widescreen hack 16:9
-//Y-Fov
-//803f013c 00a88144 30001126
-patch=1,EE,00152dd0,word,3c013fab //3c013f80
-
-//Zoom
-//003f013c 00608144 0000a67f (2nd)
-patch=1,EE,002205d8,word,3c013f20 //3c013f00
-
-//Black Bar Fix
-//2044013c 00c08144
-patch=1,EE,00100b8c,word,3c010000 //3c014420 Bottom
-patch=1,EE,00100ba0,word,3c010000 //3c014270 Upper
-
-//Black Scene Fix
-//f043013c 00a08144 2d200002
-patch=1,EE,00100e2c,word,3c010000 //3c0143f0
-
-//Zoom (Event, Menu)  3F508228
-//patch=1,EE,001b2e10,word,3c013f50 //3c013f1c
-//patch=1,EE,001b2e14,word,34218228 //342161ab
-
-
+[Remove Blackbars]
+author=Arapapa & PeterDelta
+description=Removes black bars in cutscenes
+patch=1,EE,00100B88,word,24040000 //24040001 Upper
+patch=1,EE,00100C88,word,24040000 //24040001 Bottom

--- a/patches/SLUS-21660_56790A28.pnach
+++ b/patches/SLUS-21660_56790A28.pnach
@@ -2,21 +2,26 @@ gametitle=Disney Princess - Enchanted Journey (U)(SLUS-21660)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
-
-//Widescreen hack 16:9
-
+author=Arapapa
+description=Widescreen Hack
 //X-Fov
 patch=1,EE,002652c4,word,3c014440 //3c014480
 
 //Render fix
 patch=1,EE,003f2490,word,40000000 //3eaaaaab
 
-//Black Bar fix
-patch=1,EE,00188978,word,00000000 //44810000
-
 //Menu.... Character Position (Not Fixed Address)
 //patch=1,EE,206db7d8,extended,39000000 //3d991686
 //patch=1,EE,206db7e0,extended,3e3f0000 //3e4d4fdf
 
+[Remove Blackbars]
+author=Arapapa
+description=Removes black bars in cutscenes
+patch=1,EE,00188978,word,00000000 //44810000
 
+[60 FPS]
+author=asasega & PeterDelta
+description=Unlocks internal FPS. Might need EE Overclock at 130%.
+patch=1,EE,201002F4,extended,10000011
+patch=1,EE,E0010000,extended,003A67B0 //fixed fmv
+patch=1,EE,201002F4,extended,45000011

--- a/patches/SLUS-21709_408DFB9C.pnach
+++ b/patches/SLUS-21709_408DFB9C.pnach
@@ -21,11 +21,6 @@ patch=1,EE,00211be8,word,1000ffdf
 //rfix by ElHecht
 patch=1,EE,00256234,word,3c033f2b
 
-//black borders fix
-patch=1,EE,001f4b58,word,3c020000
-patch=1,EE,001f4a68,word,3c030000
-patch=1,EE,001f4ad8,word,3c020000
-
 //resolution fix (upped from 512x448 to 640x448) by nemesis2000
 patch=1,EE,002125b4,word,24020280
 
@@ -67,4 +62,8 @@ patch=1,EE,002111b8,word,468000e0
 patch=1,EE,002111bc,word,8c8301e8
 patch=1,EE,002111c0,word,46021043
 
-
+[Remove Blackbars]
+description=Removes black bars in cutscenes
+patch=1,EE,001f4b58,word,3c020000
+patch=1,EE,001f4a68,word,3c030000
+patch=1,EE,001f4ad8,word,3c020000

--- a/patches/SLUS-21731_A8D83239.pnach
+++ b/patches/SLUS-21731_A8D83239.pnach
@@ -2,20 +2,20 @@ gametitle=Silent Hill Origins (SLUS-21731)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen fix by nemesis2000 (pnach by nemesis2000)
-
+author=nemesis2000
+description=Widescreen fix
 patch=1,EE,001da9b4,word,3c013fe3
 patch=1,EE,001da9b8,word,34218e39
 
-//black borders's fix (optional)
+[Remove Blackbars]
+author=nemesis2000
+description=Removes black bars in cutscenes
 patch=1,EE,00183548,word,24020000 //24020001
-
 
 [No-Interlacing]
 gsinterlacemode=1
-comment=Enhacement by felixthecat1970
-
-//Progressive
+author=felixthecat1970
+description=Forces progressive scan mode 480p at startup.
 patch=0,EE,2029445C,extended,3C050000
 patch=0,EE,20294464,extended,3C060050
 patch=0,EE,2029446C,extended,3C070001

--- a/patches/SLUS-21845_7FAE77BE.pnach
+++ b/patches/SLUS-21845_7FAE77BE.pnach
@@ -1,15 +1,13 @@
-gametitle=Shin Megami Tensei: Devil Summoner 2: Raidou Kuzunoha vs. King Abaddon (NTSC-U)
+//gametitle=Shin Megami Tensei: Devil Summoner 2: Raidou Kuzunoha vs. King Abaddon (NTSC-U)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-comment=Widescreen pnach (Only works for 3D, not for prerendered backgrounds)
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//comment=Widescreen pnach (Only works for 3D, not for prerendered backgrounds)
 
-patch=1,EE,004278e4,word,3FC6D3A0 //3F951EB8 hor fov
-patch=1,EE,00427c94,word,3FC6D3A0 //3F951EB8 unknown
+//patch=1,EE,004278e4,word,3FC6D3A0 //3F951EB8 hor fov
+//patch=1,EE,00427c94,word,3FC6D3A0 //3F951EB8 unknown
 
 //black borders's fix (optional)
-patch=1,EE,00116928,word,24040000
-patch=1,EE,00106be0,word,a380a213
-patch=1,EE,001069c4,word,2404FF00
-
-
+//patch=1,EE,00116928,word,24040000
+//patch=1,EE,00106be0,word,a380a213
+//patch=1,EE,001069c4,word,2404FF00

--- a/patches/SLUS-21854_64ABECC8.pnach
+++ b/patches/SLUS-21854_64ABECC8.pnach
@@ -7,7 +7,8 @@ patch=1,EE,001a65f0,word,3c013c2e //r fix
 patch=1,EE,002644ec,word,3c014440 // hor fov
 //patch=1,EE,00267dd0,word,3C013F40 //hud zoom in
 
-//Get rid of black bar
+[Remove Blackbars]
+description=Removes black bars in cutscenes
 //8642013c 67662134
 patch=1,EE,00225ffc,word,3c014000 //3c014286
 patch=1,EE,00226000,word,00000000 //34216667


### PR DESCRIPTION
In order for the repository to be as clean and tidy as possible, I separate the patches that eliminate black bars/black bands in cut scenes so that the user can decide if they want to use them or not.

Updated widescreen patches:
 - Made Man:  Arapapa patch fixed. The main and pause menu now fit the image.
 - Disney's Treasure Planet: The previous patch worked fine if you had the 4:3 menu option set, but saving the 16:9 menu option to the memory card or selecting it in the menu makes the image too narrow. Having native widescreen, with the new patch 16:9 is enabled from the beginning and you can also choose the other 16:9 widescreen option called "letter box" while maintaining the original look

![Made Man_SLES-54443_20240331201253](https://github.com/PCSX2/pcsx2_patches/assets/151682118/1d7776b7-789c-4025-830c-ccbb34fea156)

![Made Man_SLES-54443_20240331201140](https://github.com/PCSX2/pcsx2_patches/assets/151682118/31fc0ad6-670b-4b29-aac5-87b156767b33)
