### PR TITLE
WS: Disable Jak 2 PAL WS patch

### DIFF
--- a/patches/SCES-51608_2479F4A9.pnach
+++ b/patches/SCES-51608_2479F4A9.pnach
@@ -1,15 +1,13 @@
-gametitle=Jak II - Renegade (PAL-M7) (SCES-51608)
+//gametitle=Jak II - Renegade (PAL-M7) (SCES-51608)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=ElHecht
-comment=Widescreen Hack
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=ElHecht
+//comment=Widescreen Hack. Currently breaks text rendering when switching to 60hz or progressive scan.
 // 16:9
-patch=1,EE,00367be8,word,3c033f1f // 3c033f00 zoom
-patch=1,EE,20826F10,extended,0014A709 // 001479C1 force native 16:9 mode
+//patch=1,EE,00367be8,word,3c033f1f // 3c033f00 zoom
+//patch=1,EE,20826F10,extended,0014A709 // 001479C1 force native 16:9 mode
 
 // menu fix
-patch=1,EE,20B63FE0,extended,43A80000 // 436DE43C
-patch=1,EE,20B665B0,extended,43440000 // 4309CAD8
-
-
+//patch=1,EE,20B63FE0,extended,43A80000 // 436DE43C
+//patch=1,EE,20B665B0,extended,43440000 // 4309CAD8

--- a/patches/SCES-52460_12804727.pnach
+++ b/patches/SCES-52460_12804727.pnach
@@ -3,7 +3,7 @@ gametitle=Jak 3 (PAL-M7) (SCES-52460)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-comment=Widescreen Hack
+comment=Widescreen Hack.
 // 16:9
 patch=1,EE,2030afc8,extended,3c033f1f // 3c033f00 zoom
 patch=1,EE,207d6158,extended,0014877D // 00146171 force native 16:9 mode
@@ -35,5 +35,3 @@ patch=1,EE,20AC3F18,extended,43DF8000 // 43D90000
 patch=1,EE,20AC3F58,extended,43DF8000 // 43D90000
 patch=1,EE,20AC3F98,extended,43DF8000 // 43D90000
 patch=1,EE,20AC3FD8,extended,43DF8000 // 43D90000
-
-


### PR DESCRIPTION
Currently breaks text rendering when switching to 60hz or progressive scan.

![image](https://github.com/PCSX2/pcsx2_patches/assets/80843560/5035a2b5-6210-4246-ad3c-f986b4b24e6f)