### PR TITLE
Disable Spider-man the movie WS patch

### DIFF
--- a/patches/SLES-50812_CB179BA2.pnach
+++ b/patches/SLES-50812_CB179BA2.pnach
@@ -1,15 +1,15 @@
 gametitle=Spider-Man - The Movie (E)(SLES-50812)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//comment=Widescreen Hack by Arapapa
 
 //Widescreen hack 16:9
 
 //Y-Fov
-patch=1,EE,004d1554,word,3fe38e2a //3faaaaab
+//patch=1,EE,004d1554,word,3fe38e2a //3faaaaab
 
 //Zoom
-patch=1,EE,002b5e64,word,3c013c28 //3c013c0e
+//patch=1,EE,002b5e64,word,3c013c28 //3c013c0e
 
-
+//Missing render fix

--- a/patches/SLES-50813_295D2F91.pnach
+++ b/patches/SLES-50813_295D2F91.pnach
@@ -1,14 +1,14 @@
 gametitle=Spider-Man - The Movie (F)(SLES-50813)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=Bigdemon
-comment=Widescreen Hack Conversion
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=Bigdemon
+//comment=Widescreen Hack Conversion
 
 //Y-Fov
-patch=1,EE,004cff54,word,3fe38e2a //3faaaaab
+//patch=1,EE,004cff54,word,3fe38e2a //3faaaaab
 
 //Zoom
-patch=1,EE,002b5e64,word,3c013c28 //3c013c0e
+//patch=1,EE,002b5e64,word,3c013c28 //3c013c0e
 
-
+//Missing render fix

--- a/patches/SLES-50965_CCF57297.pnach
+++ b/patches/SLES-50965_CCF57297.pnach
@@ -1,10 +1,11 @@
 gametitle=Spider-Man - The Movie (S)(SLES-50965) CCF57297
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=Arapapa
-comment=Widescreen Hack
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=Arapapa
+//comment=Widescreen Hack
 //Y-Fov
-patch=1,EE,004d1554,word,3fe38e2a //3faaaaab
+//patch=1,EE,004d1554,word,3fe38e2a //3faaaaab
 //Zoom
-patch=1,EE,002b5e64,word,3c013c28 //3c013c0e
+//patch=1,EE,002b5e64,word,3c013c28 //3c013c0e
+//Missing render fix

--- a/patches/SLUS-20336_015CB6F4.pnach
+++ b/patches/SLUS-20336_015CB6F4.pnach
@@ -1,15 +1,15 @@
 gametitle=Spider-Man - The Movie (U)(SLUS-20336)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-comment=Widescreen Hack by Arapapa
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//comment=Widescreen Hack by Arapapa
 
 //Widescreen hack 16:9
 
 //Y-Fov
-patch=1,EE,004d13d4,word,3fe38e2a //3faaaaab
+//patch=1,EE,004d13d4,word,3fe38e2a //3faaaaab
 
 //Zoom
-patch=1,EE,002b5c64,word,3c013c28 //3c013c0e
+//patch=1,EE,002b5c64,word,3c013c28 //3c013c0e
 
-
+//Missing render fix


### PR DESCRIPTION
It lacks a render fix, when moving around the stage the objects do not appear on the sides.


![Spider-Man_SLES-50965_20240411140301](https://github.com/PCSX2/pcsx2_patches/assets/151682118/bc5fd7d9-6dc7-46a0-a73a-aef5cba285ba)
![Spider-Man_SLES-50965_20240411140317](https://github.com/PCSX2/pcsx2_patches/assets/151682118/55148fda-233f-400f-8a87-087e35b9b87c)