### PR TITLE
Dynasty Warriors 5: Xtreme Legends (SLUS-21299) patch updated to include cutscene fix and enable Musou/Free mode

### DIFF
--- a/patches/SLUS-21299_A719D130.pnach
+++ b/patches/SLUS-21299_A719D130.pnach
@@ -5,6 +5,7 @@ gsaspectratio=16:9
 comment=Widescreen hack by nemesis2000 (pnach by nemesis2000 )
 patch=1,EE,00146d7c,word,3c0243d6
 patch=1,EE,0019814c,word,3c023f2b
+patch=1,EE,00146ac4,word,3c023e10 // cutscene zoom (fixes crash)
 
 
 [No-Interlacing]
@@ -14,3 +15,6 @@ patch=1,EE,20112964,word,64420000
 patch=1,EE,201427D0,word,30420000
 
 
+[Load original (Enables Musou and Free modes)]
+comment=Dw5xl contains all files required to play Musou/Free modes, This mod unhides Musou/Free mode. 
+patch=1,EE,001abed4,word,24020001


### PR DESCRIPTION
I updated the patch for Dynasty Warriors 5: Xtreme Legends (SLUS-21299) with the CRC A719D130 to include the cutscene fix drobovik shared. I also included the code to unhide Musou/Free mode as a separate patch. 

This is related to the issue from here: https://github.com/PCSX2/pcsx2_patches/issues/335