### PR TITLE
Patches: Various fixes

### DIFF
--- a/patches/SCES-52004_6624A78C.pnach
+++ b/patches/SCES-52004_6624A78C.pnach
@@ -1,7 +1,7 @@
 gametitle=Killzone [PAL-M] SCES-52004 6624A78C
 
-[50/60 FPS]
-author=PeterDelta
-comment=Unlocked at 50/60 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,00152014,word,24420002 //24420001
-patch=1,EE,005DB004,word,3F000000 //3F800000 speed general
+//[50/60 FPS]
+//author=PeterDelta. Disabled due to causing double speed in menu and game FMVs and other game breaking issues.
+//comment=Unlocked at 50/60 FPS. Might need enable EE Overclock to be stable.
+//patch=1,EE,00152014,word,24420002 //24420001
+//patch=1,EE,005DB004,word,3F000000 //3F800000 speed general

--- a/patches/SCUS-97328_77E61C8A.pnach
+++ b/patches/SCUS-97328_77E61C8A.pnach
@@ -100,18 +100,6 @@ author=Aero_
 patch=1,EE,2039CE80,extended,1000000D
 patch=1,EE,2039CEB8,extended,24020001
 
-[32-Bit Color Depth]
-comment=Color depth will remain 32-bit while using 480p.
-author=Aero_
-patch=1,EE,1043668C,extended,0001 // Color Depth Mode
-patch=1,EE,10436698,extended,0280 // Resolution X
-patch=1,EE,104366A0,extended,0168 // Resolution Y
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-patch=1,EE,203E1500,extended,10400002 // beq v0,zero,0x003E150C : Jumps if Widescreen Mode is Disabled
-patch=1,EE,203E1504,extended,3C013F40 // lui at,0x3F40 : License Trophy Aspect Ratio Float Value (4:3)
-patch=1,EE,203E1508,extended,3C013F80 // lui at,0x3F80 : License Trophy Aspect Ratio Float Value (16:9)
-patch=1,EE,203E150C,extended,34210000 // ori at,at,0x0000
-
 [Full Trigger Sensitivity]
 comment=Allows the full range of the triggers (L2 & R2) to be used for throttle and brake inputs.
 author=Silent & Aero_
@@ -136,10 +124,8 @@ author=Aero_
 patch=1,EE,2039DA54,extended,00000000 // GET READY TO DRIVE
 patch=1,EE,2039D77C,extended,00000000 // Penalty Timer
 
-[No-Interlacing]
 [Autoboot in 480p]
 comment=The game will always start in 480p instead of 480i.
-gsinterlacemode=1
 author=Silent
 patch=1,EE,204364A8,extended,AE0516B0
 patch=1,EE,10436598,extended,10E8

--- a/patches/SCUS-97402_CAAEC49C.pnach
+++ b/patches/SCUS-97402_CAAEC49C.pnach
@@ -1,7 +1,7 @@
 gametitle=Killzone (NTSC-U) SCUS-97402 CAAEC49C
 
-[60 FPS]
-author=asasega
-comment=Unlocked at 60 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,00152014,word,24420002 //fps
-patch=1,EE,005DB004,word,3F000000 //speed
+//[60 FPS]
+//author=asasega. Disabled due to causing double speed in menu and game FMVs and other game breaking issues.
+//comment=Unlocked at 60 FPS. Might need enable EE Overclock to be stable.
+//patch=1,EE,00152014,word,24420002 //fps
+//patch=1,EE,005DB004,word,3F000000 //speed

--- a/patches/SLUS-20910_5D0244D3.pnach
+++ b/patches/SLUS-20910_5D0244D3.pnach
@@ -85,3 +85,28 @@ patch=1,EE,203DD658,extended,3F100000
 patch=1,EE,204A807C,extended,00000001 //Aspect Ratio Option (0 = 4:3, 1 = 16:9)
 patch=1,EE,202A419C,extended,00000000 //Right Button
 patch=1,EE,202A41C0,extended,00000000 //Left Button
+
+[Shoulders control mapping]
+description=Modify Type 2 controls to use analog triggers for throttle/brake
+author=Silent
+
+patch=0,EE,202AA84C,extended,26460808 // Joy DY- - throttle
+patch=0,EE,202AA85C,extended,26460810 // Joy DX- - braking
+patch=0,EE,102AA8D4,extended,5F28 // Button 7 - dig_braking
+patch=0,EE,102AA8EC,extended,5F00 // Button 8 - dig_throttle
+patch=0,EE,102AA904,extended,5EE8 // Button 6 - view
+patch=0,EE,102AA924,extended,5D48 // Button 5 - horn
+
+// Patch the control scheme in menu
+patch=0,EE,102AB748,extended,0038 // L2
+patch=0,EE,102AB760,extended,0034 // R1
+patch=0,EE,102AB76C,extended,003C // R2
+patch=0,EE,102AB778,extended,0030 // L1
+
+// Enable analog throttle and analog brake by default
+patch=0,EE,202AAE58,extended,AE000000
+patch=0,EE,202AAE5C,extended,AE000004
+
+// Do not load digital_throttle and digital_braking from the memory card
+patch=0,EE,202A8FD8,extended,00000000
+patch=0,EE,202A8FEC,extended,00000000

--- a/patches/SLUS-21355_60A42FF5.pnach
+++ b/patches/SLUS-21355_60A42FF5.pnach
@@ -10,17 +10,17 @@ patch=1,EE,00527e18,word,34218e34
 patch=0,EE,00527e14,word,3c013fe3
 patch=0,EE,00527e18,word,34218e34
 
-[Widescreen 16:9 HUD]
-author=SuperType1
-description=Fixes HUD scaling when using Widescreen hack (Requires HW Renderer)
-patch=1,EE,001D6DB0,byte,1e0 //480p geometry centering 
-patch=1,EE,001D6DB0,byte,280 //480p geometry centering 
-patch=1,EE,001C8310,byte,280 //480p post fx centering
-patch=1,EE,001C8314,byte,1e0 //480p post fx centering
-patch=1,EE,001C829C,word,0000000 //disable "hdr" glow cut off
-patch=1,EE,001C82AC,word,0000000 //disable "hdr" glow cut off
-patch=1,EE,001C828C,word,241E0280 //"hdr" glow offset
-patch=0,EE,204BF458,byte,01 //enable 480p
+//[Widescreen 16:9 HUD]
+//author=SuperType1. Appears to cause extreme FPS issues when used.
+//description=Fixes HUD scaling when using Widescreen hack (Requires HW Renderer)
+//patch=1,EE,001D6DB0,byte,1e0 //480p geometry centering 
+//patch=1,EE,001D6DB0,byte,280 //480p geometry centering 
+//patch=1,EE,001C8310,byte,280 //480p post fx centering
+//patch=1,EE,001C8314,byte,1e0 //480p post fx centering
+//patch=1,EE,001C829C,word,0000000 //disable "hdr" glow cut off
+//patch=1,EE,001C82AC,word,0000000 //disable "hdr" glow cut off
+//patch=1,EE,001C828C,word,241E0280 //"hdr" glow offset
+//patch=0,EE,204BF458,byte,01 //enable 480p
 
 [Disable motion blur]
 description= removes motion blur 


### PR DESCRIPTION
Cleans up a mistake I made bringing over some GT4 patches and removes the 32 bit color depth patch as it causes the blue rectangle of death on the left hand side of the screen also removes the Midnight Club 3 Dub Remix 16:9 HUD fix as it apparently causes FPS issues and doesn't actually function correctly and brings over Silents Test Drive Eve of Destruction shoulders control mapping patch.