### PR TITLE
No-Interlacing: Kaido Racer (Typo fix)

### DIFF
--- a/patches/SLES-53191_F7780E06.pnach
+++ b/patches/SLES-53191_F7780E06.pnach
@@ -8,7 +8,7 @@ comment=Widescreen Hack
 patch=1,EE,20431190,extended,3F400000 //3F800000 (Increases hor. axis)
 
 
-[No Interlacing]
+[No-Interlacing]
 gsinterlacemode=1
 author=val
 description=Attempts to disable interlaced offset rendering.


### PR DESCRIPTION
The lack of dash in `[No Interlacing]` prevents the NI patch from being loaded automatically by **Enable No-Interlacing Patches** option.