### PR TITLE
Patches: Fix Tourist Trophy no interlacing patch.

### DIFF
--- a/patches/SCUS-97502_FF9C0E93.pnach
+++ b/patches/SCUS-97502_FF9C0E93.pnach
@@ -1,8 +1,7 @@
 gametitle=Tourist Trophy [SCUS-97502] (USA)
 
-[No-Interlacing]
-gsinterlacemode=1
-comment=Autoboot in 480p
+[Autoboot in 480p]
+comment=The game will always start races in 480p instead of 480i.
 author=Blackbird+Silent
 patch=1,EE,20829248,extended,00000001
 


### PR DESCRIPTION
The patch only enables 480p in races. Menus are still 480i so disabling interlace handling causes issues in these screens.