### PR TITLE
Disable Scooby Doo Unmasked WS patches

### DIFF
--- a/patches/SLES-53100_FE0030D6.pnach
+++ b/patches/SLES-53100_FE0030D6.pnach
@@ -1,24 +1,24 @@
 gametitle=Scooby-Doo! Unmasked (U)(SLUS-21091) and (E)(SLES-53100)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//comment=Widescreen hack by Arapapa
 
 //Widescreen hack 16:9
-
+//Disabled as it causes SPS in the intro and the sewer levels (possibly more).
 //Zoom
 //0040023c 00008244 3800a2c7
-patch=1,EE,001daf68,word,3c023fc0
+//patch=1,EE,001daf68,word,3c023fc0
 
 //Y-Fov
 //02100046 0800a0ac
-patch=1,EE,0023af14,word,08030000
+//patch=1,EE,0023af14,word,08030000
 
-patch=1,EE,000c0000,word,46001002
-patch=1,EE,000c0004,word,3c013faa
-patch=1,EE,000c0008,word,3421aaab
-patch=1,EE,000c000c,word,4481f000
-patch=1,EE,000c0010,word,461e0002
-patch=1,EE,000c0014,word,0808ebc6
+//patch=1,EE,000c0000,word,46001002
+//patch=1,EE,000c0004,word,3c013faa
+//patch=1,EE,000c0008,word,3421aaab
+//patch=1,EE,000c000c,word,4481f000
+//patch=1,EE,000c0010,word,461e0002
+//patch=1,EE,000c0014,word,0808ebc6
 
 

--- a/patches/SLUS-21091_FE0030D6.pnach
+++ b/patches/SLUS-21091_FE0030D6.pnach
@@ -1,24 +1,24 @@
 gametitle=Scooby-Doo! Unmasked (U)(SLUS-21091) and (E)(SLES-53100)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-comment=Widescreen hack by Arapapa
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//comment=Widescreen hack by Arapapa
 
 //Widescreen hack 16:9
-
+//Disabled as it causes SPS in the intro and the sewer levels (possibly more).
 //Zoom
 //0040023c 00008244 3800a2c7
-patch=1,EE,001daf68,word,3c023fc0
+//patch=1,EE,001daf68,word,3c023fc0
 
 //Y-Fov
 //02100046 0800a0ac
-patch=1,EE,0023af14,word,08030000
+//patch=1,EE,0023af14,word,08030000
 
-patch=1,EE,000c0000,word,46001002
-patch=1,EE,000c0004,word,3c013faa
-patch=1,EE,000c0008,word,3421aaab
-patch=1,EE,000c000c,word,4481f000
-patch=1,EE,000c0010,word,461e0002
-patch=1,EE,000c0014,word,0808ebc6
+//patch=1,EE,000c0000,word,46001002
+//patch=1,EE,000c0004,word,3c013faa
+//patch=1,EE,000c0008,word,3421aaab
+//patch=1,EE,000c000c,word,4481f000
+//patch=1,EE,000c0010,word,461e0002
+//patch=1,EE,000c0014,word,0808ebc6
 
 


### PR DESCRIPTION
Both versions cause SPS in the intro and sewer levels (that we know of).

Disabling until they can be fixed.