### PR TITLE
Disable Lego Island Xtreme Stunts patches

### DIFF
--- a/patches/SLES-51153_1A957202.pnach
+++ b/patches/SLES-51153_1A957202.pnach
@@ -1,16 +1,16 @@
-gametitle=Island Xtreme Stunts (E)(SLES-51153)
+//gametitle=Island Xtreme Stunts (E)(SLES-51153)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-comment=Widescreen hack by by Arapapa
-
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//comment=Widescreen hack by by Arapapa
+//Disabled as it causes SPS.
 //Widescreen hack 16:9
 
-patch=1,EE,0021eef4,word,3c013f40 //00000000
-patch=1,EE,0021eef8,word,44810000 //00000000
-patch=1,EE,0021ef00,word,4600c602 //00000000
+//patch=1,EE,0021eef4,word,3c013f40 //00000000
+//patch=1,EE,0021eef8,word,44810000 //00000000
+//patch=1,EE,0021ef00,word,4600c602 //00000000
 
 //Render Fix
-patch=1,EE,00220f70,word,3c013fab //3c013f80
+//patch=1,EE,00220f70,word,3c013fab //3c013f80
 
 

--- a/patches/SLUS-20575_BC910F04.pnach
+++ b/patches/SLUS-20575_BC910F04.pnach
@@ -1,17 +1,17 @@
-gametitle=Island Xtreme Stunts (U)(SLUS-20575)
+//gametitle=Island Xtreme Stunts (U)(SLUS-20575)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-comment=Widescreen hack by by Arapapa
-
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//comment=Widescreen hack by by Arapapa
+//Disabled as it causes SPS.
 //Widescreen hack 16:9
 
-patch=1,EE,0021eec4,word,3c013f40 //00000000
-patch=1,EE,0021eec8,word,44810000 //00000000
-patch=1,EE,0021eed0,word,4600c602 //00000000
+//patch=1,EE,0021eec4,word,3c013f40 //00000000
+//patch=1,EE,0021eec8,word,44810000 //00000000
+//patch=1,EE,0021eed0,word,4600c602 //00000000
 
 //Render Fix
 //803f013c 00088144 01b91646
-patch=1,EE,00220f40,word,3c013fab //3c013f80
+//patch=1,EE,00220f40,word,3c013fab //3c013f80
 
 


### PR DESCRIPTION
Disables patches for LEGO Island Xtreme Stunts.

These cause SPS.

This is the second set by Arapapa I've had to disable this week for SPS, can we PLEASE make sure these patches work before you submit them, you didn't even have to test far with this one, literally the main menu is broken.