### PR TITLE
X-Men Legends (PAL & NTSC) Widescreen Patches Updates

### DIFF
--- a/patches/SLES-52624_69094734.pnach
+++ b/patches/SLES-52624_69094734.pnach
@@ -1,18 +1,26 @@
-gametitle=X-Men Legends (PAL-E) (SLES-52624)
+gametitle=X-Men Legends (PAL-E) (SLES-52624) v1.02
 
-[Widescreen 16:9]
+[16:9 Widescreen Support]
 gsaspectratio=16:9
-author=XxGaMiNGK3LLERxX
-comment=Widescreen Hack
-patch=1,EE,20D86690,word,3F666666 // HUD Height
-patch=1,EE,207214D4,word,3FA00000 // HUD & Menu Width
+comment=16:9 Widescreen for X-Men Legends (PAL-E) (SLES-52624) (Game Version: v1.02). Requires "Show Overscan" to be enabled for the best widescreen support. Highlight HUD does not scale and is kind of broken.
+author=NomNom
+
+patch=1,EE,20D86690,word,3F733333 // HUD Height
 patch=1,EE,20D86678,word,3F59999A // HUD Width
-patch=1,EE,207214CC,word,3F100000 // font width
-patch=1,EE,207214D0,word,3F100000 // font height
-patch=1,EE,207214A0,word,3FE00000 // Gameplay screen fix 16:9
+patch=1,EE,207214D4,word,3FA00000 // HUD & Menu Width
+patch=1,EE,207214D8,word,3f90a3d7 // HUD & Menu Height
+patch=1,EE,207214CC,word,3ecccccd // Font width
+patch=1,EE,207214D0,word,3eeb851f // Font height
+patch=1,EE,207214A0,word,3FE147AE // In-Game FoV [Affects HUD]
 
-//patch=1,EE,20D866B4,word,3F733333
-//patch=1,EE,30231920,word,3F333333
-//patch=1,EE,206A81EC,word,3F7AE148 //character skill highlight beta fix - causes ring health to bug when applied
+[16:10 Widescreen Support]
+comment=16:10 Widescreen for X-Men Legends (PAL-E) (SLES-52624) (Game Version: v1.02). Requires "Show Overscan" to be enabled, and Aspect Ratio set to "Fit to Window / Fullscreen" for the best widescreen support. Highlight HUD does not scale and is kind of broken.
+author=NomNom
 
-
+patch=1,EE,20D86690,word,3f4ccccd // HUD Height
+patch=1,EE,20D86678,word,3F59999A // HUD Width
+patch=1,EE,207214D4,word,3FA00000 // HUD & Menu Width
+patch=1,EE,207214D8,word,3f9d70a4 // HUD & Menu Height
+patch=1,EE,207214CC,word,3ecccccd // Font width
+patch=1,EE,207214D0,word,3eeb851f // Font height
+patch=1,EE,207214A0,word,3FE147AE // In-Game FoV [Affects HUD]

--- a/patches/SLUS-20656_CE6A63BF.pnach
+++ b/patches/SLUS-20656_CE6A63BF.pnach
@@ -1,18 +1,27 @@
-gametitle=X-Men Legends SLUS_206.56
+gametitle=X-Men Legends (NTSC-U) (SLUS-20656) v1.01
 
-[Widescreen 16:9]
+[16:9 Widescreen Support]
 gsaspectratio=16:9
-comment=Widescreen Hack
+comment=Widescreen 16:9 Support for X-Men Legends (NTSC-U) (SLUS-20656) (Game Version: v1.01). Requires "Show Overscan" to be enabled for the best 16:9 support. Highlight HUD does not scale and is kind of broken.
+author=NomNom
+
 //patch=1,EE,005cc888,word,3c023f34
-patch=1,EE,20720920,word,3FE147AE  //In-game width widescreen 16:9
-patch=1,EE,2072094c,word,3F000000  //Fonts Width
-patch=1,EE,20720950,word,3F000000  //Fonts Height
-patch=1,EE,20720958,word,3F8CCCCD  //HUD & Menu Height
-patch=1,EE,20720954,word,3FA00000  //HUD & Menu Width
-patch=1,EE,20D85448,word,3F666666  //HUD Height
-patch=1,EE,20D85430,word,3F59999A  //HUD Width
+patch=1,EE,20720920,word,3FE147AE  // In-Game FoV
+patch=1,EE,2072094c,word,3ecccccd  // Fonts Width
+patch=1,EE,20720950,word,3eeb851f  // Fonts Height
+patch=1,EE,20720958,word,3f90a3d7  // HUD & Menu Height
+patch=1,EE,20720954,word,3FA00000  // HUD & Menu Width
+patch=1,EE,20D85448,word,3F733333  // HUD Height
+patch=1,EE,20D85430,word,3F59999A  // HUD Width
 
-//20D85448 //HUD Height
-//206625A8 //HUD Resize
+[16:10 Widescreen Support]
+comment=Widescreen 16:9 Support for X-Men Legends (NTSC-U) (SLUS-20656) (Game Version: v1.01). Requires "Show Overscan" to be enabled for the best 16:10 support. Highlight HUD does not scale and is kind of broken.
+author=NomNom
 
-
+patch=1,EE,20720920,word,3FE147AE  // In-Game FoV
+patch=1,EE,2072094c,word,3ecccccd  // Fonts Width
+patch=1,EE,20720950,word,3eeb851f  // Fonts Height
+patch=1,EE,20720958,word,3f9d70a4  // HUD & Menu Height
+patch=1,EE,20720954,word,3FA00000  // HUD & Menu Width
+patch=1,EE,20D85448,word,3f4ccccd  // HUD Height
+patch=1,EE,20D85430,word,3F59999A  // HUD Width


### PR DESCRIPTION
Updated existing patches for better 16:9 widescreen support, and optionally supports 16:10. Updates both PAL and NTSC patches to be more consistent with each other, whereas before, they were obvious discrepancies between them.

_Please note; I have changed the author name within the patch, as I am the original author of the patch under a different alias._

**Preview screenshots of 16:9 Widescreen with the patch:**
_First three screenshots, did not have Show Overscan enabled, which would have vertically squeezed the UI a bit._
![image](https://github.com/PCSX2/pcsx2_patches/assets/97398234/68bf5aa6-ba2a-4498-8b4b-4896aee45846)
![image](https://github.com/PCSX2/pcsx2_patches/assets/97398234/d1dff89c-218b-451e-b5f5-4f34eefa1d9f)
![image](https://github.com/PCSX2/pcsx2_patches/assets/97398234/20a6919b-1b42-4589-b248-f89575dd5bb7)
![image](https://github.com/PCSX2/pcsx2_patches/assets/97398234/90e9ec68-fbe2-4d63-a0c8-38ca0783b684)
![image](https://github.com/PCSX2/pcsx2_patches/assets/97398234/b9c886b3-8df9-40d5-ba7b-ed4897e30359)
![image](https://github.com/PCSX2/pcsx2_patches/assets/97398234/4a6c3a31-705d-4604-bc45-e4c47b211db2)