### PR TITLE
Update SLES-51058_54854C71.pnach for proper PAL Progressive scan

### DIFF
--- a/patches/SLES-51058_54854C71.pnach
+++ b/patches/SLES-51058_54854C71.pnach
@@ -12,8 +12,6 @@ comment=Progressive scan
 
 //Override SetGsCrt syscall arguments.
 patch=1,EE,202000c0,extended,24040000
-patch=1,EE,202000c4,extended,24050002
+// The next line activates 60 NTSC Progressive format but brings a slew of issues like immediate FMV desync and the game being out of frame unless using the overscan option
+// patch=1,EE,202000c4,extended,24050002 
 patch=1,EE,202000c8,extended,24060001
-
-
-


### PR DESCRIPTION
PAL Progressive scan instead of NTSC Progressive Scan forcing 60 FPS on the user and having the consequence of de-syncing all Maken Shao cutscenes to end faster than they should.

It should resolve #380 