### PR TITLE
Ratchet UYA, Deadlocked: Add 60 FPS split-screen patch

### DIFF
--- a/patches/SCUS-97353_49536F3F.pnach
+++ b/patches/SCUS-97353_49536F3F.pnach
@@ -1,5 +1,10 @@
 gametitle=Ratchet & Clank - Up Your Arsenal
 
+[60 FPS split-screen]
+author=SuperSamus
+comment=Makes all split-screen modes render at 60 FPS. Needs enable 180% EE Overclock to be stable.
+dpatch=0,4,5,48,24022D00,4C,0044180B,50,00A3182A,60,0000202D,0,00000000,78,00000000,F0,00000000,5C,00000000,B4,24032470
+
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PsxFan107

--- a/patches/SCUS-97465_9BFBCD42.pnach
+++ b/patches/SCUS-97465_9BFBCD42.pnach
@@ -1,5 +1,10 @@
 gametitle=Ratchet - Deadlocked
 
+[60 FPS split-screen]
+author=SuperSamus
+comment=Makes all split-screen modes render at 60 FPS. Needs enable 180% EE Overclock to be stable.
+dpatch=0,4,4,54,A2B01680,68,A2A01680,6C,3C030022,70,8C63DDA4,0,00000000,4C,00000000,30,00000000,90,24032470
+
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PsxFan107


### PR DESCRIPTION
These patches allow "Ratchet & Clank: Up Your Arsenal" and "Ratchet: Deadlocked" to play at 60 FPS during any split-screen modes, instead of the regular 30 FPS.
In reality, the game achieves 30 FPS by doing two logic steps per frame: thus, the game logic was still running at 60 FPS. 
Basically, the simplified split-screen loop is (values taken from Deadlocked):
```c
REG_RCNT1_COUNT = 0;
startRendering();
logicStep(); /* This is `nop`ed. Note that it doesn't process some things like the reticle, unlike the second one. */
if (REG_RCNT1_COUNT < 0x251c) /* Its regular purpose is to make the game run "as fast as it can" if the CPU can't keep up. */
  vsync(); /* This is `nop`ed */
logicStep();
if (REG_RCNT1_COUNT < 0x4b00) /* Changed to 0x2470 */
  logicStep(); /* Used for frame skipping */
vsync();
```

The patch simply removes a logic step and a Vsync in the loop, so that every logic step is rendered, instead of only half of them.

#### Usage notes
- Requires a lot of EE overclock, preferably 180%. Unfortunately, 300% corrupts the graphics.
- Frame skipping is supported, if the emulated CPU can't keep up.
  - However, if it can't handle 30 FPS either, the game will slow down.
    - At 180%, this is going to be an issue only on Endzone (which is a lag fest even normally).

#### Testing done
- Deadlocked's campaign has been thoroughly tested, start to finish
- In the PvP modes, the only testing I did is that they work
  - 3/4 players in particular needs more testing (see the documentation)

#### For reviewers
- The frameskip, just like normally, is based on whether the value of `REG_RCNT1_COUNT` reaches a certain threshold. I only lowered its threshold because the regular one was too high. The value I inserted was obtained through trial and error: I don't know if I could use math to get a better value.
- This only supports the NTSC versions of the games.
  - If you want to port it, good news! The code touched by the patch is in the "outermost" function executed during the splitscreen loop, so you can easily get there through the debugger (Step Out), then find which function does the logic step, and which one does the Vsync, through trial and error. Follow the comments for the rest.
    - For the PAL version, being 50 FPS instead, the last replacement will likely need to have a different (higher) value.

(Original post on https://forums.pcsx2.net/Thread-60-fps-codes?pid=640315#pid640315, but I can't update it anymore)

<details>
<summary>Documentation</summary>

#### Up Your Arsenal
```
+  dynaPatches:
+    - pattern:
+        - { offset: 0x48, value: 0x24022D00 }
+        - { offset: 0x4C, value: 0x0044180B }
+        - { offset: 0x50, value: 0x00A3182A }
+        - { offset: 0x60, value: 0x0000202D }
+      replacement:
+        - { offset: 0x0, value: 0x00000000 } # Remove the first logic step (not the second one: it does things like drawing the aiming reticle)
+        - { offset: 0x78, value: 0x00000000 } # Always take the "not 3/4 players" branch (I don't know what it's actually for, but without this, 3/4 players is broken)
+        - { offset: 0xF0, value: 0x00000000 } # Same, but for the frameskip branch (only useful if starting the match underclocked)
+        - { offset: 0x5C, value: 0x00000000 } # Remove the first VSync (leaving the one that is never skipped)
+        # Feel free to tweak the last 4 digits of the value.
+        # If too low: the game will frameskip when it doesn't need to.
+        # If too high: the game may not realize that it needs to frameskip, and run at half speed. Avoid!
+        - { offset: 0xB4, value: 0x24032470 } # Reduce the time required to do another framestep (so that the game will frameskip if it can't keep up)
```

#### Deadlocked
```
+    - pattern:
+        - { offset: 0x54, value: 0xA2B01680 }
+        - { offset: 0x68, value: 0xA2A01680 }
+        - { offset: 0x6C, value: 0x3C030022 }
+        - { offset: 0x70, value: 0x8C63DDA4 }
+      replacement:
+        - { offset: 0x0, value: 0x00000000 } # Remove the first logic step (not the second one: it does things like drawing the aiming reticle)
+        - { offset: 0x4C, value: 0x00000000 } # Always take the "not 3/4 players" branch (I don't know what it's actually for, but without this, 3/4 players is broken)
+        - { offset: 0x30, value: 0x00000000 } # Remove the first VSync (leaving the one that is never skipped)
+        # Feel free to tweak the last 4 digits of the value.
+        # If too low: the game will frameskip when it doesn't need to.
+        # If too high: the game may not realize that it needs to frameskip, and run at half speed. Avoid!
+        - { offset: 0x90, value: 0x24032470 } # Reduce the time required to do another framestep (so that the game will frameskip if it can't keep up)
```
</details>