### PR TITLE
WS: Disable Jak 3 NTSC WS patch

### DIFF
--- a/patches/SCUS-97330_644CFD03.pnach
+++ b/patches/SCUS-97330_644CFD03.pnach
@@ -1,43 +1,41 @@
-gametitle=Jak 3 (U)(SCUS-97330)
+//gametitle=Jak 3 (U)(SCUS-97330)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-comment=Widescreen Hack by ElHecht (NTSC-U by Arapapa)
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//comment=Widescreen Hack by ElHecht (NTSC-U by Arapapa). Disabled due to causing black texture flickering in desert areas.
 
 // 16:9
 //003f033c 00008344 00088744
-patch=1,EE,2030aec8,extended,3c033f1f // 3c033f00 zoom
+//patch=1,EE,2030aec8,extended,3c033f1f // 3c033f00 zoom
 
 //71601400 014c1400 054c1400
-patch=1,EE,207D5F68,extended,0014867D // 00146071 force native 16:9 mode
+//patch=1,EE,207D5F68,extended,0014867D // 00146071 force native 16:9 mode
 
 //menu fix
-patch=1,EE,20C15680,extended,43A90000 // 436E33F5
-patch=1,EE,20C178C0,extended,43420000 // 43082F0F
+//patch=1,EE,20C15680,extended,43A90000 // 436E33F5
+//patch=1,EE,20C178C0,extended,43420000 // 43082F0F
 
 
-patch=1,EE,20AC3B60,extended,42860000 // 429E0000
-patch=1,EE,20AC3BA0,extended,42860000 // 429E0000
-patch=1,EE,20AC3BE0,extended,42860000 // 429E0000
-patch=1,EE,20AC3C20,extended,42860000 // 429E0000
-patch=1,EE,20AC3C60,extended,42860000 // 429E0000
-patch=1,EE,20AC3CA0,extended,42860000 // 429E0000
-patch=1,EE,20AC3CE0,extended,42860000 // 429E0000
-patch=1,EE,20AC3D20,extended,42860000 // 429E0000
-patch=1,EE,20AC3D60,extended,42860000 // 429E0000
-patch=1,EE,20AC3DA0,extended,42860000 // 429E0000
-patch=1,EE,20AC3DE0,extended,42860000 // 429E0000
+//patch=1,EE,20AC3B60,extended,42860000 // 429E0000
+//patch=1,EE,20AC3BA0,extended,42860000 // 429E0000
+//patch=1,EE,20AC3BE0,extended,42860000 // 429E0000
+//patch=1,EE,20AC3C20,extended,42860000 // 429E0000
+//patch=1,EE,20AC3C60,extended,42860000 // 429E0000
+//patch=1,EE,20AC3CA0,extended,42860000 // 429E0000
+//patch=1,EE,20AC3CE0,extended,42860000 // 429E0000
+//patch=1,EE,20AC3D20,extended,42860000 // 429E0000
+//patch=1,EE,20AC3D60,extended,42860000 // 429E0000
+//patch=1,EE,20AC3DA0,extended,42860000 // 429E0000
+//patch=1,EE,20AC3DE0,extended,42860000 // 429E0000
 
-patch=1,EE,20AC3B68,extended,43DF8000 // 43D90000
-patch=1,EE,20AC3BA8,extended,43DF8000 // 43D90000
-patch=1,EE,20AC3BE8,extended,43DF8000 // 43D90000
-patch=1,EE,20AC3C28,extended,43DF8000 // 43D90000
-patch=1,EE,20AC3C68,extended,43DF8000 // 43D90000
-patch=1,EE,20AC3CA8,extended,43DF8000 // 43D90000
-patch=1,EE,20AC3CE8,extended,43DF8000 // 43D90000
-patch=1,EE,20AC3D28,extended,43DF8000 // 43D90000
-patch=1,EE,20AC3D68,extended,43DF8000 // 43D90000
-patch=1,EE,20AC3DA8,extended,43DF8000 // 43D90000
-patch=1,EE,20AC3DE8,extended,43DF8000 // 43D90000
-
-
+//patch=1,EE,20AC3B68,extended,43DF8000 // 43D90000
+//patch=1,EE,20AC3BA8,extended,43DF8000 // 43D90000
+//patch=1,EE,20AC3BE8,extended,43DF8000 // 43D90000
+//patch=1,EE,20AC3C28,extended,43DF8000 // 43D90000
+//patch=1,EE,20AC3C68,extended,43DF8000 // 43D90000
+//patch=1,EE,20AC3CA8,extended,43DF8000 // 43D90000
+//patch=1,EE,20AC3CE8,extended,43DF8000 // 43D90000
+//patch=1,EE,20AC3D28,extended,43DF8000 // 43D90000
+//patch=1,EE,20AC3D68,extended,43DF8000 // 43D90000
+//patch=1,EE,20AC3DA8,extended,43DF8000 // 43D90000
+//patch=1,EE,20AC3DE8,extended,43DF8000 // 43D90000


### PR DESCRIPTION
Causes black texture flicker in desert areas.

Closes #391 