### PR TITLE
Add 60 FPS Patches for "The Getaway" and "The Getaway Black Monday" NTSC

### DIFF
--- a/patches/SCUS-97133_E21404E2.pnach
+++ b/patches/SCUS-97133_E21404E2.pnach
@@ -1,0 +1,6 @@
+gametitle=Getaway, The [NTSC] SCUS-97133 E21404E2
+
+[60 FPS]
+author=asasega
+comment=Unlocked at 50/60 FPS. Might need enable EE Overclock to be stable.
+patch=1,EE,201F10E8,word,1000000B


### PR DESCRIPTION
60 FPS will be added for “The Getaway” and "The Getaway Black Monday" [NTSC]. Games runs very well in 60 FPS and it is completely playable. I have tested it several times.