### PR TITLE
Sound glitch fix patch for Time Crisis 2

### DIFF
--- a/patches/SLUS-20219_D5D560FF.pnach
+++ b/patches/SLUS-20219_D5D560FF.pnach
@@ -5,4 +5,8 @@ gsaspectratio=16:9
 comment=Widescreen Hack
 patch=1,EE,003cd7fc,word,3f400000
 
-
+[Sound Fix for FMV Scenes]
+author=kozarovv
+description=Sound fix for stuttering glitchy audio during FMV/cut-scenes
+patch=1,EE,00154954,extended,10000009
+//Fix code was posted at PCSX2 wiki. Additional info given was "Skip 1200000 cycles loop - fix audio."


### PR DESCRIPTION
Sound fix for stuttering echo-repetition glitchy audio looping during FMV/cut-scenes.  

I confirmed that this code fixes the long-standing audio bug.  The audio stuttering problem is progressively degenerative without this code, and CANNOT be fixed by the commonly offered config changes. 

Username who posted at the wiki is kozarovv, I cited them as author.
https://wiki.pcsx2.net/Time_Crisis_II