### PR TITLE
WS: Disable Cel Damage Overdrive WS patch

### DIFF
--- a/patches/SLES-51554_904B7BA0.pnach
+++ b/patches/SLES-51554_904B7BA0.pnach
@@ -1,12 +1,11 @@
-gametitle=Cell Damage Overdrive (PAL-M5) SLES_515.54
+//gametitle=Cell Damage Overdrive (PAL-M5) SLES_515.54
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=dieSkaarj
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=dieSkaarj.
+//Breaks splitscreen display into one thin grey line.
 
-patch=1,EE,20362ce8,word,3f400000 //3f800000
-patch=1,EE,20362D00,word,3faaaaab //3f800000
+//patch=1,EE,20362ce8,word,3f400000 //3f800000
+//patch=1,EE,20362D00,word,3faaaaab //3f800000
 
 //patch=1,EE,0023f2a0,word,27bdff20 //3c02bf80 HUD scaling?
-
-


### PR DESCRIPTION
Breaks splitscreen multiplayer.