### PR TITLE
No Interlacing Patch for Extermination [SCUS-97112]

### DIFF
--- a/patches/SCUS-97112_0AE679AF.pnach
+++ b/patches/SCUS-97112_0AE679AF.pnach
@@ -5,3 +5,9 @@ gsaspectratio=16:9
 comment=Widescreen Hack
 patch=1,EE,001d2978,extended,3c023f19
 patch=1,EE,001d297c,extended,3442999a
+
+[No Interlacing]
+author=asasega
+comment=No Interlacing
+patch=1,EE,20101614,word,00000000
+patch=1,EE,2010187C,word,00000000


### PR DESCRIPTION
Added No Interlacing Patch from asasega for Extermination. The game shakes a lot without no interlacing, that's why I added the patch from asasega, because it hasn't been added to the patches yet. Also works without any problems.