### PR TITLE
Add patches for Translations and Undubs

### DIFF
--- a/patches/SCUS-97112_087A3C85.pnach
+++ b/patches/SCUS-97112_087A3C85.pnach
@@ -1,0 +1,7 @@
+gametitle=Extermination (NTSC-U) SCUS-97112 087A3C85 (Undub)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+comment=Widescreen Hack
+patch=1,EE,001d2978,extended,3c023f19
+patch=1,EE,001d297c,extended,3442999a

--- a/patches/SLES-53411_B3589D67.pnach
+++ b/patches/SLES-53411_B3589D67.pnach
@@ -1,0 +1,9 @@
+gametitle=Kuon (PAL-M3) SLES-53411 B3589D67 (Spanish Fan Translation)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=ElHecht
+
+// 16:9
+patch=1,EE,001382c4,word,3c023f19  // 3c023f4c hor fov
+patch=1,EE,001382c8,word,3443999a  // 3443999a hor fov

--- a/patches/SLPS-20488_B2486AF4.pnach
+++ b/patches/SLPS-20488_B2486AF4.pnach
@@ -1,0 +1,8 @@
+gametitle=Simple 2000 Series Vol. 113: The Tairyou Jigoku (NTSC-J) SLPS-20488 B2486AF4 (Spanish Fan Translation)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=El_Patas
+
+//Gameplay 16:9
+patch=1,EE,00307D74,word,3C013F40 //3C013F80 (Increases hor. axis)

--- a/patches/SLUS-20893_158FA006.pnach
+++ b/patches/SLUS-20893_158FA006.pnach
@@ -1,0 +1,9 @@
+gametitle= Way Of The Samurai 2 (NTSC-U) SLUS-20893 158FA006 (Undub)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=VIRGIN KLM
+
+//Widescreen - 3D Elements
+patch=1,EE,002F5F20,word,3F400000 // 3F800000
+patch=1,EE,00165b2c,word,3c033fab //3c033f80


### PR DESCRIPTION
This PR adds support for Widescreen

[Kuon Spanish Fan Translation](https://www.romhacking.net/translations/3970/)
Before
![Off Kuon_SLES-53411_20240815183656](https://github.com/user-attachments/assets/db55da75-808e-41fd-8c59-411ea759e45d)
![Off Kuon_SLES-53411_20240815183858](https://github.com/user-attachments/assets/73c125f6-4adf-4fa3-a0aa-c8e140654eac)
After
![On Kuon_SLES-53411_20240815183501](https://github.com/user-attachments/assets/800fb8c2-ecf5-46d8-be7b-7995166730c5)
![On Kuon_SLES-53411_20240815184107](https://github.com/user-attachments/assets/0e0d8177-1495-43b8-b5bf-8ae1efdb667a)
[The Tairyou Jigoku Spanish Fan Translation](https://www.romhacking.net/translations/6317/)
Before
![Off Simple 2000 Series Vol  113 - The Tairyou Jigoku_SLPS-20488_20240815184407](https://github.com/user-attachments/assets/d10bfbb4-e69e-404c-a923-0f3cd6d7ceed)
After
![On Simple 2000 Series Vol  113 - The Tairyou Jigoku_SLPS-20488_20240815184422](https://github.com/user-attachments/assets/e3a0e0c7-843a-4a50-b71d-26b942c02aab)
[Extermination Undub](https://archive.org/download/extermination_undub_patch)
Before
![Off Extermination_SCUS-97112_20240815181853](https://github.com/user-attachments/assets/99293a9f-945f-4b86-b4ed-9128752b7306)
After
![On Extermination_SCUS-97112_20240815181853](https://github.com/user-attachments/assets/85bd3b29-701c-4727-9e2e-c413cd2b8d38)
[Way of the Samurai 2 Undub](https://archive.org/download/way_of_the_samurai_2_undub_patch)
Before
![Off Way of the Samurai 2_SLUS-20893_20240815192600](https://github.com/user-attachments/assets/321d6156-0cd7-44fa-93f5-aa9ead94578d)
After
![On Way of the Samurai 2_SLUS-20893_20240815192612](https://github.com/user-attachments/assets/3cb98c4d-075d-4630-8151-a4e73ad891ad)
