### PR TITLE
Update The Simpsons - Road Rage SLES-50628

### DIFF
--- a/patches/SLES-50628_063CED6E.pnach
+++ b/patches/SLES-50628_063CED6E.pnach
@@ -1,10 +1,9 @@
-gametitle=The Simpsons - Road Rage (PAL-M5) (SLES-50628)
+gametitle=The Simpsons - Road Rage (PAL-M5) (SLES-50628) 063CED6E
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-
-// 16:9
+description=Renders the game in 16:9 aspect ratio
 patch=1,EE,001a1914,word,3c013fc0 // 3c013f9c 1-player zoom
 patch=1,EE,001a1918,word,34214000 // 342161ab 1-player zoom
 patch=1,EE,001a1924,word,3c013fe3 // 3c013faa 1-player ver fov
@@ -14,8 +13,3 @@ patch=1,EE,001a18e0,word,3c013fbb // 3c013f97 2-players zoom
 patch=1,EE,001a18e4,word,34218000 // 3421e9d9 2-players zoom
 patch=1,EE,001588ec,word,3c014063 // 3c01402a 2-players ver fov
 patch=1,EE,001588f0,word,34218e39 // 3421aaab 2-players ver fov
-
-// removes black texture glitches in hardware emulation, but brightens screen
-patch=1,EE,001c16e4,word,3c013f7f // 3c013f80
-
-


### PR DESCRIPTION
It seems that in previous versions of pcsx2 there were glitches with the hardware renderer, now it runs perfectly and you can now see the shadows of the vehicles

![Simpsons Road Rage_SLES-50628_20240826164406](https://github.com/user-attachments/assets/988db2a7-0c68-466e-9bfd-d3860cad3932)
4:3 original

![Simpsons Road Rage_SLES-50628_20240826164517](https://github.com/user-attachments/assets/9eb90151-2585-426f-b8e4-14b163d4d5c7)
Current patch

![Simpsons Road Rage_SLES-50628_20240826164716](https://github.com/user-attachments/assets/d381086d-b125-40d7-b369-37816ef1a9f5)
Update