### PR TITLE
Update Van Helsing to a full widescreen patch

### DIFF
--- a/patches/SLES-51908_8176235A.pnach
+++ b/patches/SLES-51908_8176235A.pnach
@@ -1,10 +1,9 @@
-gametitle=Van Helsing [PAL] (SLES_519.08)
+gametitle=Van Helsing PAL-M SLES-51908 8176235A
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=El_Patas
-
-//Gameplay 16:9
-patch=1,EE,202E88A8,extended,3FE38E38 //3FAAAAAA (Increases hor. axis)
-
-
+author=El_Patas & Gabominated
+description=Widescreen hack
+patch=1,EE,002E88A8,word,3FE38E39 //3FAAAAAA
+patch=1,EE,002E88AC,word,C2D55554 //00000000
+patch=1,EE,002E88B0,word,443AAAAB //44200000

--- a/patches/SLPM-65723_960D74D7.pnach
+++ b/patches/SLPM-65723_960D74D7.pnach
@@ -1,14 +1,9 @@
-gametitle=Van Helsing (J)(SLPM-65723)
+gametitle=Van Helsing NTSC-J SLPM-65723 960D74D7
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Arapapa
-
-//Widescreen hack 16:9
-
-patch=1,EE,002ec1b0,word,3fe38e38 //3faaaaaa
-
-//X-Fov (include 2D)
-//patch=1,EE,0023dfc4,word,3c013ec0 //3c013f00
-
-
+author=Arapapa & Gabominated 
+description=Widescreen hack
+patch=1,EE,002EC1B0,word,3fE38E39 //3fAAAAAA
+patch=1,EE,002EC1B4,word,C2D55554 //00000000
+patch=1,EE,002EC1B8,word,443AAAAB //44200000

--- a/patches/SLUS-20738_901ECEFC.pnach
+++ b/patches/SLUS-20738_901ECEFC.pnach
@@ -1,8 +1,9 @@
-gametitle=Van Helsing (SLUS-20738)
+gametitle=Van Helsing NTSC-U SLUS-20738 901ECEFC
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=paul_met
-patch=1,EE,202E7FA0,extended,3FE38E38 // 3FAAAAAA
-
-
+author=paul_met & Gabominated 
+description=Widescreen hack
+patch=1,EE,002E7FA0,word,3FE38E39 //3FAAAAAA
+patch=1,EE,002E7FA4,word,C2D55554 //00000000
+patch=1,EE,002E7FA8,word,443AAAAB //44200000


### PR DESCRIPTION
Updating to a full widescreen that includes, entire hud, any menu and any font

Older patch
![Van Helsing_SLUS-20738_20240826141313](https://github.com/user-attachments/assets/be98d30f-4f03-4ea1-9c11-a34fee9f4a62)
Updated patch
![Van Helsing_SLUS-20738_20240826141140](https://github.com/user-attachments/assets/da7a2eea-3244-4b05-8d0c-9df3e7ba38c2)
Older patch
![Van Helsing_SLUS-20738_20240826141554](https://github.com/user-attachments/assets/3fe98deb-4f53-414f-9fa8-aaa469cb22a0)
Updated patch
![Van Helsing_SLUS-20738_20240826141608](https://github.com/user-attachments/assets/963bf326-92bd-4cde-aeea-c1254fb64ee8)
Older patch
![Van Helsing_SLUS-20738_20240826141837](https://github.com/user-attachments/assets/aaab7cdf-5e09-4b0b-98bd-e4d7052b7b86)
Updated patch
![Van Helsing_SLUS-20738_20240826141908](https://github.com/user-attachments/assets/0f8fba66-70ca-4a17-9a46-03286c098c8b)
Older patch
![Van Helsing_SLUS-20738_20240826142039](https://github.com/user-attachments/assets/49b14b74-5b63-480c-a7a7-c5758b9113c1)
Updated patch
![Van Helsing_SLUS-20738_20240826142055](https://github.com/user-attachments/assets/3d7b7ef3-ac1d-486d-bea9-408d16620287)
