### PR TITLE
WS: Disable CID the Dummy SLUS-21754 WS patch

### DIFF
--- a/patches/SLUS-21754_A06BD445.pnach
+++ b/patches/SLUS-21754_A06BD445.pnach
@@ -1,20 +1,20 @@
-gametitle=CID the Dummy (U)(SLUS-21754)
+//gametitle=CID the Dummy (U)(SLUS-21754)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=Arapapa
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=Arapapa
 
 //Widescreen hack 16:9
 
 //X-Fov
 //06a30046 86050046
-patch=1,EE,00228aa0,word,08030000
+//patch=1,EE,00228aa0,word,08030000
 
-patch=1,EE,000c0000,word,46000586
-patch=1,EE,000c0004,word,3c013faa
-patch=1,EE,000c0008,word,3421aaab
-patch=1,EE,000c000c,word,4481f000
-patch=1,EE,000c0010,word,461eb582
-patch=1,EE,000c0014,word,0808a2a9
+//patch=1,EE,000c0000,word,46000586
+//patch=1,EE,000c0004,word,3c013faa
+//patch=1,EE,000c0008,word,3421aaab
+//patch=1,EE,000c000c,word,4481f000
+//patch=1,EE,000c0010,word,461eb582
+//patch=1,EE,000c0014,word,0808a2a9
 
 


### PR DESCRIPTION
Patch is working (need to be enabled before running the game), but it is creating branch in branch delay slot.
![image](https://github.com/user-attachments/assets/a6f1c541-c693-4c23-aeb7-b9a793fa3e8b)

```
[   48.1423] Enabled patch: Widescreen 16:9
[   48.1431]   1,EE,word,00228aa0,8030000
[   48.1438]   1,EE,word,000c0000,46000586
[   48.1443]   1,EE,word,000c0004,3c013faa
[   48.1447]   1,EE,word,000c0008,3421aaab
[   48.1452]   1,EE,word,000c000c,4481f000
[   48.1456]   1,EE,word,000c0010,461eb582
[   48.1460]   1,EE,word,000c0014,808a2a9
[   48.1467] OSD [LoadPatches]: 1 game patches are active.
[   48.1470] Applying settings...
[   48.1476] Patch: Setting aspect ratio to 16:9 by patch request.
[   48.1481] Updating GS configuration...
[   48.1792] Branch c09317a in delay slot!
[   48.2457] Branch c09317a in delay slot!
```

closes #406