### PR TITLE
Adding Nehalem's falling car parts while driving patch to SLUS-21242_…

### DIFF
--- a/patches/SLUS-21242_D224D348.pnach
+++ b/patches/SLUS-21242_D224D348.pnach
@@ -55,3 +55,9 @@ author=Nahelam
 comment=Change speedometer unit from MPH to KPH
 patch=1,EE,201765E8,extended,0000102D
 patch=1,EE,201767DC,extended,0000102D
+
+[Falling car parts while driving (takedowns & traffic checks)]
+author=Nehalem
+description=Enable falling car parts during takedowns and traffic checks while driving
+patch=0,EE,20210FA8,extended,00000000
+


### PR DESCRIPTION
…D224D348.pnach for Burnout Revenge

Adding Nehalem's falling car parts while driving patch to re-enable detaching car parts when the player is not in a wrecked state. Normally, in Burnout Revenge, car parts wont fall off if the player is not in a wrecked state. Leaving takedowns and traffic checks to look underwhelming as parts falling off is only reserved when the player crashes. The patch forces parts of the cars to fall off even if the player is not wrecked, making takedowns and traffic checks to feel more satisfying. Doesnt seem to affect gameplay aside from this cosmetic change.

Below is a short video for comparison and demonstration of the patch being enabled and disabled https://youtu.be/htn-nQsnEkU?si=QbXaU_wdGdh5PhPt