### PR TITLE
Burnout Takedown/Revenge/Dominator formating

### DIFF
--- a/patches/SLUS-21050_BEBF8793.pnach
+++ b/patches/SLUS-21050_BEBF8793.pnach
@@ -1,33 +1,28 @@
+gametitle=Burnout 3: Takedown (U) (SLUS-21050)
+
 [Widescreen 16:9]
-description=Renders the game in 16:9 aspect ratio, instead of 4:3.
-author=Aero_
 gsaspectratio=16:9
-// Burnout 3: Takedown (SLUS-21050)
-// Widescreen Fix (v2.0) by Aero_
-
+author=Aero_
+description=Corrects the aspect ratio of the FOV, HUD, and FMVs for 16:9.
 // FOV (16:9)
-
 patch=1,EE,00665ECD,byte,01 // enables widescreen FOV values
 patch=1,EE,204E0A38,extended,3FAAAAAB // FOV (Single Player) // 16:9 = 1.33333
 patch=1,EE,204E0C70,extended,3FE38E39 // Aspect Ratio (Single Player) // 16:9 = 1.77778
 patch=1,EE,204E0C7C,extended,3FE38E39 // FOV (Multiplayer) // 16:9 = 1.77778
 patch=1,EE,204E0C80,extended,40638E39 // Aspect Ratio (Multiplayer) // 16:9 = 3.55556
-
 // HUD (16:9)
-
 patch=1,EE,204E105C,extended,3A99999A // HUD Width // 16:9 = 0.00117188
-patch=1,EE,206682B0,extended,42A00000 // HUD X Pos // 16:9 = +80
-patch=1,EE,20669B30,extended,42A00000 // HUD X Pos // 16:9 = +80
-patch=1,EE,204B7688,extended,3F98F5C3 // HUD Top Right X Pos // 16:9 = +0.195
-patch=1,EE,204B7678,extended,3F98F5C3 // HUD Bottom Right X Pos // 16:9 = +0.195
-patch=1,EE,204B7658,extended,BE47AE14 // HUD Top Left X Pos // 16:9 = -0.195
-patch=1,EE,204B7668,extended,BE47AE14 // HUD Bottom Left X Pos // 16:9 = -0.195
+patch=1,EE,206682B0,extended,42A00000 // HUD X Pos // 16:9 = +80 (Player 1)
+patch=1,EE,20669B30,extended,42A00000 // HUD X Pos // 16:9 = +80 (Player 2)
+patch=1,EE,204B7688,extended,3F9947AE // HUD Top Right X Pos // 16:9 = +0.1975
+patch=1,EE,204B7678,extended,3F9947AE // HUD Bottom Right X Pos // 16:9 = +0.1975
+patch=1,EE,204B7658,extended,BE4A3D71 // HUD Top Left X Pos // 16:9 = -0.1975
+patch=1,EE,204B7668,extended,BE4A3D71 // HUD Bottom Left X Pos // 16:9 = -0.1975
 patch=1,EE,204CA660,extended,44555555 // Crash Cam Border Width
 patch=1,EE,204CA640,extended,44555555 // Crash Cam Border Width
 patch=1,EE,204CA650,extended,44555555 // Crash Cam Border Width
 patch=1,EE,204CA638,extended,c2d70000 // Crash Cam Border X Pos // 16:9 = -0.107.5
 patch=1,EE,204CA658,extended,c2d70000 // Crash Cam Border X Pos // 16:9 = -0.107.5
-
 patch=1,EE,203D7238,extended,3C024456 // Crash Cam List Backing Width // only change the last four bytes // 16:9 = 854
 patch=1,EE,203D70BC,extended,08121630 // jumps to code cave
 patch=1,EE,204858C0,extended,3C08C2D7 // Crash Cam List Backing X Pos // only change the last four bytes // 16:9 = -0.107.5
@@ -37,9 +32,25 @@ patch=1,EE,203D72F4,extended,08121633 // jumps to code cave
 patch=1,EE,204858CC,extended,3C19C2D7 // Crash Cam List Text X Pos // -0.107.5 for 16:9; only change the last four bytes
 patch=1,EE,204858D0,extended,44991000 // moves new x pos value
 patch=1,EE,204858D4,extended,080F5CBE // jumps back
-
+patch=1,EE,201A176C,short,4456 // HUD Render Width (Player 1) // 16:9 = 854
+patch=1,EE,201A17D0,short,4456 // HUD Render Width (Player 2) // 16:9 = 854
+patch=1,EE,201A1774,extended,08121672 // jumps to code cave
+patch=1,EE,204859C8,extended,AfA200A0 // saves width value
+patch=1,EE,204859CC,extended,3C02C2D7 // HUD Render X Pos (Player 1) // only change the last four bytes // 16:9 = -0.107.5
+patch=1,EE,204859D0,extended,AFA200A8 // saves new x pos value
+patch=1,EE,204859D4,extended,080685DE // jumps back
+patch=1,EE,201A17D8,extended,08121676 // jumps to code cave
+patch=1,EE,204859D8,extended,AFA20090 // saves width value
+patch=1,EE,204859DC,extended,3C02C2D7 // HUD Render X Pos (Player 2) // only change the last four bytes // 16:9 = -0.107.5
+patch=1,EE,204859E0,extended,AFA20098 // saves new x pos value
+patch=1,EE,204859E4,extended,080685F7 // jumps back
+patch=1,EE,20134F2C,short,4456 // "Get Ready! GO" Width // 16:9 = 854
+patch=1,EE,20134F74,extended,0812166E // jumps to code cave
+patch=1,EE,204859B8,extended,AFA20174 // saves y pos value
+patch=1,EE,204859BC,extended,3C023EC0 //  "Get Ready! GO" X Pos // only change the last four bytes // 16:9 = 0.375
+patch=1,EE,204859C0,extended,AFA20168 // saves new x pos value
+patch=1,EE,204859C4,extended,0804D3DE // jumps back
 // Menus (16:9)
-
 patch=1,EE,2030D7E4,short,43F0 // Menu Width // 16:9 = 480
 patch=1,EE,2030D834,extended,08121636 // jumps to code cave
 patch=1,EE,204858D8,extended,E4830008 // saves width value
@@ -47,10 +58,8 @@ patch=1,EE,204858DC,extended,3C1942A0 // Menu X Pos // only change the last four
 patch=1,EE,204858E0,extended,44991800 // moves new x pos value
 patch=1,EE,204858E4,extended,E4830000 // saves new x pos value
 patch=1,EE,204858E8,extended,080C360E // jumps back
-
 patch=1,EE,204D1570,extended,44555555 // Car Select Overlay Width  // 16:9 = 853.3
 patch=1,EE,204D1568,extended,C2D70000 // Car Select Overlay X Pos  // 16:9 = -107.5
-
 patch=1,EE,2031B180,short,4456 // Top Border Width // 16:9 = 854
 patch=1,EE,2031B1F4,extended,0812163B // jumps to code cave
 patch=1,EE,204858EC,extended,3C190000 // Top Border X Pos // only change the last four bytes // 16:9 = 0 (4:3 = 80)
@@ -58,7 +67,6 @@ patch=1,EE,204858F0,extended,44993800 // moves new x pos value
 patch=1,EE,204858F4,extended,E4870000 // saves new x pos value
 patch=1,EE,204858F8,extended,C4850004 // original code
 patch=1,EE,204858FC,extended,080C6C7E // jumps back
-
 patch=1,EE,2038AE00,short,4456 // Bottom Border Width // 16:9 = 854
 patch=1,EE,2038AE38,short,4456 // Bottom Border Width // 16:9 = 854
 patch=1,EE,2038AE4C,extended,08121640 // jumps to code cave
@@ -69,7 +77,6 @@ patch=1,EE,2038AE04,extended,08121643 // jumps to code cave
 patch=1,EE,2048590C,extended,3C193E00 // Bottom Border X Pos // only change the last four bytes // 16:9 = 0.125
 patch=1,EE,20485910,extended,AFB90078 // saves new x pos value
 patch=1,EE,20485914,extended,080E2B82 // jumps back
-
 patch=1,EE,2031D6E4,short,4456 // Checkerboard Width // 16:9 = 854
 patch=1,EE,2031D73C,short,4456 // Checkerboard Width // 16:9 = 854
 patch=1,EE,2031D7E8,short,4456 // Checkerboard Width // 16:9 = 854
@@ -95,41 +102,48 @@ patch=1,EE,2031D854,extended,08121652 // jumps to code cave
 patch=1,EE,20485948,extended,3C193E00 // Bottom Middle Checkerboard X Pos // only change the last four bytes // 16:9 = 0.125
 patch=1,EE,2048594C,extended,AFB900B0 // saves new x pos value
 patch=1,EE,20485950,extended,080C7616 // jumps back
-
 patch=1,EE,2031DA20,short,4456 // Loading Background Width // 16:9 = 854
 patch=1,EE,2031DA40,extended,08121655 // jumps to code cave
 patch=1,EE,20485954,extended,3C19C2D7 // Loading Background X Pos // only change the last four bytes // 16:9 = -107.5
 patch=1,EE,20485958,extended,AFB901D8 // saves new x pos value
 patch=1,EE,2048595C,extended,080C7691 // jumps back
+patch=1,EE,203A6984,short,4456 // Replay Top Bar Width // 16:9 = 854
+patch=1,EE,203A6998,extended,08121668 // jumps to code cave
+patch=1,EE,204859A0,extended,3C19C2D7 // Replay Top Bar X Pos // only change the last four bytes // 16:9 = -107.5
+patch=1,EE,204859A4,extended,AFB90078 // saves new x pos value
+patch=1,EE,204859A8,extended,080E9A67 // jumps back
+patch=1,EE,203A69C8,short,4456 // Replay Bottom Bar Width // 16:9 = 854
+patch=1,EE,203A69DC,extended,0812166B // jumps to code cave
+patch=1,EE,204859AC,extended,3C19C2D7 // Replay Bottom Bar X Pos // only change the last four bytes // 16:9 = -107.5
+patch=1,EE,204859B0,extended,AFB90060 // saves new x pos value
+patch=1,EE,204859B4,extended,080E9A78 // jumps back
+patch=1,EE,204E0C3C,extended,3FE38E39 // Globe Aspect Ratio // 16:9 = 1.777777791
+patch=1,EE,204E0A94,extended,3FB8E38F // Globe Glow Aspect Ratio // 16:9 = 1.444444537
 
 [60 FPS for Menus]
-description=Menus will render at 60 FPS
 author=Nehalem
-
-patch=1,EE,201D3F2C,extended,1000000A
-patch=1,EE,20130DD8,extended,C7958074
-patch=1,EE,20130DDC,extended,3C084000
-patch=1,EE,20130DE0,extended,4488A000
-patch=1,EE,20130DE4,extended,4614AD03
-patch=1,EE,20130DE8,extended,00000000
+description=Menus will render at 60 FPS
+// 60 FPS in menus only
+patch=0,EE,201D3F2C,extended,1000000A
+// Fix FMVs playback speed while using 60 FPS patches
+patch=0,EE,20130DD8,extended,C7958074
+patch=0,EE,20130DDC,extended,3C084000
+patch=0,EE,20130DE0,extended,4488A000
+patch=0,EE,20130DE4,extended,4614AD03
+patch=0,EE,20130DE8,extended,00000000
 
 [60 FPS for Crashes]
-description=Crashes will render at 60 FPS
-author=Unknown
-
-patch=1,EE,204E17DC,extended,01800001 // Frame Rate
-patch=1,EE,2051BAC4,byte,01 // Game Speed
-patch=1,EE,00132F64,extended,00000000
+author=Nehalem
+description=Enable 60 FPS in crashes
+patch=0,EE,201320D8,extended,1000004B
 
 [Progressive Scan]
-description=Always ask for 480p mode during boot
 author=Nehalem
-
-patch=1,EE,20437758,extended,100000F1
+description=Always ask for 480p mode during boot
+patch=0,EE,20437758,extended,100000F1
 
 [MPH to KPH]
-description=Change speedometer unit from MPH to KPH
 author=Nehalem
-
-patch=1,EE,101A3BA0,extended,000082F0
-patch=1,EE,101A3D78,extended,000007D7
+description=Change speedometer unit from MPH to KPH
+patch=0,EE,101A3BA0,extended,000082F0
+patch=0,EE,101A3D78,extended,000007D7

--- a/patches/SLUS-21242_D224D348.pnach
+++ b/patches/SLUS-21242_D224D348.pnach
@@ -1,9 +1,9 @@
-gametitle=Burnout Revenge (U)(SLUS-21242)
+gametitle=Burnout Revenge (U) (SLUS-21242)
 
 [Widescreen 16:9]
+gsaspectratio=16:9
 author=SuperType1/remco
 description=Fixes the game and the HUD to run in a 16:9 Scale (only enable one and not both of them).
-gsaspectratio=16:9
 patch=1,EE,201398C0,extended,00000000
 patch=1,EE,2016BCA8,extended,3C013A9D
 patch=1,EE,21C02438,extended,3FAA3D71
@@ -17,9 +17,9 @@ patch=1,EE,21C02108,extended,43C30000
 patch=1,EE,2032677C,extended,3C013C9A
 
 [Widescreen 21:9]
+gsaspectratio=Stretch
 author=SuperType1/remco
 description=Fixes the game and the HUD to run in a 21:9 Scale (only enable one and not both of them).
-gsaspectratio=Stretch
 patch=1,EE,201398C0,extended,00000000
 patch=1,EE,201398C8,extended,3C014017
 patch=1,EE,2016BCA8,extended,3C013A83
@@ -46,18 +46,17 @@ description=Makes the Crashes & Crash Mode run in 60 FPS.
 patch=1,EE,20104B9C,extended,90850608
 
 [Progressive Scan]
-author=Nahelam
-comment=Always ask for 480p mode during boot
-patch=1,EE,2019778C,extended,10A2001C
+author=Nehalem
+description=Always ask for 480p mode during boot
+patch=0,EE,2019778C,extended,10A2001C
 
 [MPH to KPH]
-author=Nahelam
-comment=Change speedometer unit from MPH to KPH
-patch=1,EE,201765E8,extended,0000102D
-patch=1,EE,201767DC,extended,0000102D
+author=Nehalem
+description=Change speedometer unit from MPH to KPH
+patch=0,EE,201765E8,extended,0000102D
+patch=0,EE,201767DC,extended,0000102D
 
 [Falling car parts while driving (takedowns & traffic checks)]
 author=Nehalem
 description=Enable falling car parts during takedowns and traffic checks while driving
 patch=0,EE,20210FA8,extended,00000000
-

--- a/patches/SLUS-21596_8C9576A1.pnach
+++ b/patches/SLUS-21596_8C9576A1.pnach
@@ -1,9 +1,9 @@
-gametitle=Burnout - Dominator (U)(SLUS-21596)
+gametitle=Burnout Dominator (U) (SLUS-21596)
 
 [Widescreen 16:9]
+gsaspectratio=16:9
 author=SuperType1/remco
 description=Fixes the game and the HUD to run in a 16:9 Scale (only enable one and not both of them).
-gsaspectratio=16:9
 
 //Force 16:9
 patch=1,EE,001A2798,word,00000000
@@ -32,9 +32,9 @@ patch=1,EE,21C91F60,extended,C4430000//crashbreaker text offset
 patch=1,EE,20441078,extended,438C0000//ea trax pop up width
 
 [Widescreen 21:9]
+gsaspectratio=Stretch
 author=SuperType1/remco
 description=Fixes the game and the HUD to run in a 21:9 Scale (only enable one and not both of them).
-gsaspectratio=Stretch
 
 //Force 21:9
 patch=1,EE,001A2798,word,00000000
@@ -68,9 +68,14 @@ patch=1,EE,20441078,extended,43340000//ea trax width
 
 [60 FPS Menus and Crashes]
 author=SuperType1/remco
-comment=Makes the entire game run in 60 FPS.
+description=Makes the entire game run in 60 FPS.
 //60 FPS Front End
 patch=1,EE,202159AC,extended,24040001
 patch=1,EE,202159A4,extended,00108002
 //60 FPS Crashes
 patch=1,EE,20209070,word,908523E8
+
+[Progressive Scan]
+author=Nehalem
+description=Always ask for 480p mode during boot
+patch=0,EE,20183F1C,extended,10000015


### PR DESCRIPTION
Burnout 3 Takedown
- The file was missing its `gametitle=`
- The widescreen patch was incomplete, now it has been taken from its [original repository](https://github.com/AeroWidescreen/PCSX2-Cheats/blob/main/Burnout%203%20Takedown/SLUS-21050/Widescreen%20Fix/SLUS-21050_BEBF8793_widescreen.pnach) and completed.
- [60 FPS menus] now specify what each line of the patch does
- [60 FPS crashes] replaced that old patch with a newer and simpler one.
- Nehalem patches used to be `patch=1` now they are changed to `patch=0`, so that they match their [original repository](https://github.com/Nahelam/PS2-Game-Mods/tree/main/Burnout%203%20Takedown) (this does not bring any negative change as they were always `patch=0`).

Burnout Revenge
- The author's name has been corrected from Nahelam to Nehalem.
- Nehalem patches used to be `patch=1` now they are changed to `patch=0`, so that they match their [original repository](https://github.com/Nahelam/PS2-Game-Mods/tree/main/Burnout%20Revenge) (this does not bring any negative change as they were always `patch=0`).

Burnout Dominator
- Added [Progressive Scan]