### PR TITLE
Obscure: The Aftermath - Disable 60FPS patch

### DIFF
--- a/patches/SLUS-21709_408DFB9C.pnach
+++ b/patches/SLUS-21709_408DFB9C.pnach
@@ -24,12 +24,6 @@ patch=1,EE,00256234,word,3c033f2b
 //resolution fix (upped from 512x448 to 640x448) by nemesis2000
 patch=1,EE,002125b4,word,24020280
 
-//480p
-patch=1,EE,0010cedc,word,3c050000
-patch=1,EE,0010cee4,word,3c060050
-patch=1,EE,0010ceec,word,3c070001
-patch=1,EE,0010d1ac,word,3c090010
-
 //FMV's fix  by nemesis2000
 patch=1,EE,0021114c,word,24020188
 patch=1,EE,00211150,word,14480003
@@ -62,13 +56,15 @@ patch=1,EE,002111b8,word,468000e0
 patch=1,EE,002111bc,word,8c8301e8
 patch=1,EE,002111c0,word,46021043
 
+[480p Mode]
+description=Forces progressive scan mode
+patch=1,EE,0010cedc,word,3c050000
+patch=1,EE,0010cee4,word,3c060050
+patch=1,EE,0010ceec,word,3c070001
+patch=1,EE,0010d1ac,word,3c090010
+
 [Remove Blackbars]
 description=Removes black bars in cutscenes
 patch=1,EE,001f4b58,word,3c020000
 patch=1,EE,001f4a68,word,3c030000
 patch=1,EE,001f4ad8,word,3c020000
-
-[60 FPS]
-author=asasega
-description=Unlocked at 60 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,2013D168,extended,2C420001


### PR DESCRIPTION
Reason: This patch breaks and prevents progress
As discussed on the RA site
![Screenshot_2024-10-04-14-24-02-365_org mozilla firefox-edit](https://github.com/user-attachments/assets/425f0036-084b-4ac7-a7a7-8c37417a2a07)