### PR TITLE
Added Grand Theft Auto III and Vice City 60 FPS Patches for NTSC-U Versions

### DIFF
--- a/patches/SLUS-20062_5E115FB6.pnach
+++ b/patches/SLUS-20062_5E115FB6.pnach
@@ -22,4 +22,7 @@ description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,2011299C,word,00000000
 
-
+[60 FPS]
+author=asasega
+comment=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,2027CEAC,extended,28420001

--- a/patches/SLUS-20552_20B19E49.pnach
+++ b/patches/SLUS-20552_20B19E49.pnach
@@ -15,4 +15,7 @@ patch=1,EE,002434EC,word,0C04C96F // 0c04c970
 patch=1,EE,0026FE1C,word,0C04C972 // 0c04c970
 patch=1,EE,002703F4,word,0C04C972 // 0c04c970
 
-
+[60 FPS]
+author=asasega
+comment=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,20272204,extended,28420001

--- a/patches/SLUS-20552_248E6126.pnach
+++ b/patches/SLUS-20552_248E6126.pnach
@@ -15,6 +15,6 @@ patch=1,EE,0027579c,word,0C04C932 //0c04c930
 patch=1,EE,00275d6c,word,0C04C932 //0c04c930
 
 [60 FPS]
-author=asasega
+author=Snake356
 comment=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
-patch=1,EE,20272204,extended,28420001
+patch=1,EE,20277B8C,extended,28420001

--- a/patches/SLUS-20552_248E6126.pnach
+++ b/patches/SLUS-20552_248E6126.pnach
@@ -14,4 +14,7 @@ patch=1,EE,002485dc,word,0C04C92f //0c04c930
 patch=1,EE,0027579c,word,0C04C932 //0c04c930
 patch=1,EE,00275d6c,word,0C04C932 //0c04c930
 
-
+[60 FPS]
+author=asasega
+comment=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,20272204,extended,28420001

--- a/patches/SLUS-20552_9E312BAF.pnach
+++ b/patches/SLUS-20552_9E312BAF.pnach
@@ -14,4 +14,7 @@ patch=1,EE,0024846c,word,0c04c8cf //0c04c8d0
 patch=1,EE,0027541c,word,0c04c8d2 //0c04c8d0
 patch=1,EE,002759ec,word,0c04c8d2 //0c04c8d0
 
-
+[60 FPS]
+author=Snake356
+comment=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
+patch=1,EE,2027780C,extended,28420001


### PR DESCRIPTION
I have added the NTSC-U 60 FPS for GTA 3 and GTA Vice City v1.40, v2.01 and v3.00! The GTA 3 patch is from the creator “asasega” exactly the same creator for GTA VC v1.40. The versions of GTA VC v2.01 and v.3.00 are from me and were converted from v.1.40 and work without problems with 60 FPS. These 60 FPS patches were missing for the NTSC-U versions.