### PR TITLE
Patches: Various additions and improvements

### DIFF
--- a/patches/SLES-51053_350F7F29.pnach
+++ b/patches/SLES-51053_350F7F29.pnach
@@ -1,0 +1,7 @@
+gametitle=Tom & Jerry's War of the Wiskers (PAL-M)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,20219D3C,word,00000001 //00000000

--- a/patches/SLES-52569_6E51213C.pnach
+++ b/patches/SLES-52569_6E51213C.pnach
@@ -2,8 +2,8 @@ gametitle=Spyro: A Hero's Tail (SLES-52569)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen
-
-//Widescreen + Extra Perspective
-patch=1,EE,003B28C8,extended,3C013F10
-patch=2,EE,003B28DC,extended,3C013F10
+author=CRASHARKI
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
+patch=1,EE,003B2878,extended,3C013F40 //3C013F80 // Fix some 3D HUD elements
+patch=1,EE,003B28C8,extended,3C013F10 //3C013F40
+patch=2,EE,003B28DC,extended,3C013F10 //3C013F40

--- a/patches/SLES-53439_E2FF6D3D.pnach
+++ b/patches/SLES-53439_E2FF6D3D.pnach
@@ -22,3 +22,8 @@ description=SDTV 480p mode at start.
 patch=1,EE,0049529C,word,24110000
 patch=1,EE,004952A0,word,24120050
 patch=1,EE,004952AC,word,24130001
+
+[Unlock PSP Exclusive Content]
+author=CRASHARKI
+description=Unlocks the PSP Exclusive Content (Cars, Battle Arenas and Co-op mode).
+patch=1,EE,209DFB8C,byte,1 //0

--- a/patches/SLES-53657_797ABFFF.pnach
+++ b/patches/SLES-53657_797ABFFF.pnach
@@ -1,0 +1,8 @@
+gametitle=DreamWorks Shrek - SuperSlam (PAL) 797ABFFF
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
+//Original NTSC-U patch by Michael
+patch=1,EE,21C8109C,extended,3FE38E39 // 3FAAAAAB

--- a/patches/SLES-53657_797ABFFF.pnach
+++ b/patches/SLES-53657_797ABFFF.pnach
@@ -4,5 +4,5 @@ gametitle=DreamWorks Shrek - SuperSlam (PAL) 797ABFFF
 gsaspectratio=16:9
 author=CRASHARKI
 description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
-//Original NTSC-U patch by Michael
+//Original NTSC-U patch by xMichael
 patch=1,EE,21C8109C,extended,3FE38E39 // 3FAAAAAB

--- a/patches/SLES-53751_797ABFFF.pnach
+++ b/patches/SLES-53751_797ABFFF.pnach
@@ -1,0 +1,8 @@
+gametitle=DreamWorks Shrek - SuperSlam (PAL) 797ABFFF
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
+//Original NTSC-U patch by Michael
+patch=1,EE,21C8109C,extended,3FE38E39 // 3FAAAAAB

--- a/patches/SLES-53751_797ABFFF.pnach
+++ b/patches/SLES-53751_797ABFFF.pnach
@@ -4,5 +4,5 @@ gametitle=DreamWorks Shrek - SuperSlam (PAL) 797ABFFF
 gsaspectratio=16:9
 author=CRASHARKI
 description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
-//Original NTSC-U patch by Michael
+//Original NTSC-U patch by xMichael
 patch=1,EE,21C8109C,extended,3FE38E39 // 3FAAAAAB

--- a/patches/SLES-53752_797ABFFF.pnach
+++ b/patches/SLES-53752_797ABFFF.pnach
@@ -1,0 +1,8 @@
+gametitle=DreamWorks Shrek - SuperSlam (PAL) 797ABFFF
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
+//Original NTSC-U patch by Michael
+patch=1,EE,21C8109C,extended,3FE38E39 // 3FAAAAAB

--- a/patches/SLES-53752_797ABFFF.pnach
+++ b/patches/SLES-53752_797ABFFF.pnach
@@ -4,5 +4,5 @@ gametitle=DreamWorks Shrek - SuperSlam (PAL) 797ABFFF
 gsaspectratio=16:9
 author=CRASHARKI
 description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
-//Original NTSC-U patch by Michael
+//Original NTSC-U patch by xMichael
 patch=1,EE,21C8109C,extended,3FE38E39 // 3FAAAAAB

--- a/patches/SLES-54521_1DF57175.pnach
+++ b/patches/SLES-54521_1DF57175.pnach
@@ -3,9 +3,7 @@ gametitle=SpongeBob and Friends - Battle for Volcano Island (E)(SLES-54521)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-
-//Widescreen hack 16:9
-
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
 //Zoom
 //003f023c 00a08144 f41a0a0c
 patch=1,EE,00286ca0,word,3c013f69 //3c013f00
@@ -18,5 +16,3 @@ patch=1,EE,000c0004,word,4481f000
 patch=1,EE,000c0008,word,461e0f83
 patch=1,EE,000c000c,word,e7be000c
 patch=1,EE,000c0010,word,080a1b33
-
-

--- a/patches/SLES-54841_ECA6BFC5.pnach
+++ b/patches/SLES-54841_ECA6BFC5.pnach
@@ -5,7 +5,7 @@ gsaspectratio=16:9
 author=CRASHARKI
 description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
 patch=1,EE,21BD8268,byte,1 //00000000 //In-game option
-patch=1,EE,21BD82A2,byte,10 //40 //Zoom 1
+patch=1,EE,21BD82A0,extended,3F020000 //3F100000 //Zoom 1
 patch=1,EE,21BD82A8,word,3F000000 //3F2AAAAA //Zoom 2
 
 [50/60 FPS]

--- a/patches/SLES-54842_B4B4E877.pnach
+++ b/patches/SLES-54842_B4B4E877.pnach
@@ -5,7 +5,7 @@ gsaspectratio=16:9
 author=CRASHARKI
 description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
 patch=1,EE,21BD74E8,byte,1 //00000000 //In-game option
-patch=1,EE,21BD7522,byte,10 //40 //Zoom 1
+patch=1,EE,21BD7520,extended,3F020000 //3F100000 //Zoom 1
 patch=1,EE,21BD7528,word,3F000000 //3F2AAAAA //Zoom 2
 
 [50/60 FPS]

--- a/patches/SLES-54843_AEFD7D25.pnach
+++ b/patches/SLES-54843_AEFD7D25.pnach
@@ -5,7 +5,7 @@ gsaspectratio=16:9
 author=CRASHARKI
 description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
 patch=1,EE,21BD81E8,byte,1 //00000000 //In-game option
-patch=1,EE,21BD8222,byte,10 //40 //Zoom 1
+patch=1,EE,21BD8220,extended,3F020000 //3F100000 //Zoom 1
 patch=1,EE,21BD8228,word,3F000000 //3F2AAAAA //Zoom 2
 
 [50/60 FPS]

--- a/patches/SLES-54991_35BD22CA.pnach
+++ b/patches/SLES-54991_35BD22CA.pnach
@@ -3,9 +3,7 @@ gametitle=Nicktoons - Attack of the Toybots (E)(SLES-54991)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-
-//Widescreen hack 16:9
-
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
 //Zoom
 patch=1,EE,0012a828,word,3c013f80 //3c013f40
 
@@ -17,5 +15,3 @@ patch=1,EE,000c0004,word,4481f000
 patch=1,EE,000c0008,word,461e0f83
 patch=1,EE,000c000c,word,e7be000c
 patch=1,EE,000c0010,word,0809dd3d
-
-

--- a/patches/SLES-55204_0F89A154.pnach
+++ b/patches/SLES-55204_0F89A154.pnach
@@ -3,16 +3,15 @@ gametitle=Crash - Mind Over Mutant (PAL)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=CRASHARKI
-comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
 patch=1,EE,21A2A0C8,byte,1 //00000000 //HUD
 patch=1,EE,21A2A102,byte,10 //40 //Zoom 1
-patch=1,EE,21A2A108,extended,3F000000 //3F2AAAAA //Zoom without Progressive Scan
-patch=1,EE,E0010001,extended,01A2A0A8 //Check if Progressive Scan is on
-patch=1,EE,21A2A108,extended,3F066666 //3F333333 //Zoom with Progressive Scan
+patch=1,EE,21A2A108,extended,3F100000 //3F000000 | 3F066666 //Y-Axis
+patch=1,EE,21A2A104,extended,3F7FA68A //3F65A68A | 3F63F7CD //X-Axis
 
 [Progressive Scan]
 author=CRASHARKI
-comment=Run the game with Progressive Scan enabled from the start.
+description=Run the game with Progressive Scan enabled from the start.
 patch=1,EE,20715330,byte,1 //00000000 //Progressive Scan\60 FPS from the beginning
 
 [50/60 FPS]

--- a/patches/SLES-55205_0F89A154.pnach
+++ b/patches/SLES-55205_0F89A154.pnach
@@ -3,16 +3,15 @@ gametitle=Crash - Mind Over Mutant (PAL)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=CRASHARKI
-comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
 patch=1,EE,21A2A0C8,byte,1 //00000000 //HUD
 patch=1,EE,21A2A102,byte,10 //40 //Zoom 1
-patch=1,EE,21A2A108,extended,3F000000 //3F2AAAAA //Zoom without Progressive Scan
-patch=1,EE,E0010001,extended,01A2A0A8 //Check if Progressive Scan is on
-patch=1,EE,21A2A108,extended,3F066666 //3F333333 //Zoom with Progressive Scan
+patch=1,EE,21A2A108,extended,3F100000 //3F000000 | 3F066666 //Y-Axis
+patch=1,EE,21A2A104,extended,3F7FA68A //3F65A68A | 3F63F7CD //X-Axis
 
 [Progressive Scan]
 author=CRASHARKI
-comment=Run the game with Progressive Scan enabled from the start.
+description=Run the game with Progressive Scan enabled from the start.
 patch=1,EE,20715330,byte,1 //00000000 //Progressive Scan\60 FPS from the beginning
 
 [50/60 FPS]

--- a/patches/SLES-55206_0F89A154.pnach
+++ b/patches/SLES-55206_0F89A154.pnach
@@ -3,16 +3,15 @@ gametitle=Crash - Mind Over Mutant (PAL)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=CRASHARKI
-comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
 patch=1,EE,21A2A0C8,byte,1 //00000000 //HUD
 patch=1,EE,21A2A102,byte,10 //40 //Zoom 1
-patch=1,EE,21A2A108,extended,3F000000 //3F2AAAAA //Zoom without Progressive Scan
-patch=1,EE,E0010001,extended,01A2A0A8 //Check if Progressive Scan is on
-patch=1,EE,21A2A108,extended,3F066666 //3F333333 //Zoom with Progressive Scan
+patch=1,EE,21A2A108,extended,3F100000 //3F000000 | 3F066666 //Y-Axis
+patch=1,EE,21A2A104,extended,3F7FA68A //3F65A68A | 3F63F7CD //X-Axis
 
 [Progressive Scan]
 author=CRASHARKI
-comment=Run the game with Progressive Scan enabled from the start.
+description=Run the game with Progressive Scan enabled from the start.
 patch=1,EE,20715330,byte,1 //00000000 //Progressive Scan\60 FPS from the beginning
 
 [50/60 FPS]

--- a/patches/SLES-55271_A9060667.pnach
+++ b/patches/SLES-55271_A9060667.pnach
@@ -1,0 +1,8 @@
+gametitle=Spongebob SquarePants Featuring Nicktoons - Globs of Doom (PAL-E)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,204142B4,extended,3FB60B60 //3F888888
+patch=1,EE,204B4C84,extended,00000001 //00000000

--- a/patches/SLES-55272_8EB42610.pnach
+++ b/patches/SLES-55272_8EB42610.pnach
@@ -1,0 +1,8 @@
+gametitle=Spongebob SquarePants Featuring Nicktoons - Globs of Doom (PAL-M)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,204142B4,extended,3FB60B60 //3F888888
+patch=1,EE,204B4C84,extended,00000001 //00000000

--- a/patches/SLES-55402_CABE6FFD.pnach
+++ b/patches/SLES-55402_CABE6FFD.pnach
@@ -1,0 +1,8 @@
+gametitle=Spongebob SquarePants Featuring Nicktoons - Globs of Doom (PAL-A)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,204140B4,extended,3FB60B60 //3F888888
+patch=1,EE,204B4A84,extended,00000001 //00000000

--- a/patches/SLPM-66090_1E65175B.pnach
+++ b/patches/SLPM-66090_1E65175B.pnach
@@ -3,9 +3,9 @@ gametitle=Crash Bandicoot Gacchanko World (J)(SLPM-66090)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
 
 //Widescreen 16:9
-
 
 //X-Fov
 //803f013c 00608144 7c00458e
@@ -14,4 +14,7 @@ patch=1,EE,002da76c,word,3c013fab //3c013f80
 //Render fix
 patch=1,EE,002da790,word,3c013fab //3c013f80
 
-
+[Unlock PSP Exclusive Content]
+author=CRASHARKI
+description=Unlocks the PSP Exclusive Content (Cars, Battle Arenas and Co-op mode).
+patch=1,EE,209EF50C,byte,1 //0

--- a/patches/SLUS-20355_F243A4C9.pnach
+++ b/patches/SLUS-20355_F243A4C9.pnach
@@ -1,0 +1,7 @@
+gametitle=Tom & Jerry's War of the Wiskers (NTSC-U)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,2021CF4C,word,00000001 //00000000

--- a/patches/SLUS-20884_94C56923.pnach
+++ b/patches/SLUS-20884_94C56923.pnach
@@ -2,10 +2,8 @@ gametitle=Spyro: A Hero's Tail (SLUS-20884)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Widescreen
-
-//Widescreen + Extra Perspective
-patch=1,EE,203B1B70,extended,3C013F10
-patch=2,EE,203B1B84,extended,3C013F10
-
-
+author=Brandondorf9999 & CRASHARKI
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
+patch=1,EE,003B1B20,extended,3C013F40 //3C013F80 // Fix some 3D HUD elements
+patch=1,EE,003B1B70,extended,3C013F10 //3C013F40
+patch=2,EE,003B1B84,extended,3C013F10 //3C013F40

--- a/patches/SLUS-21191_AA525269.pnach
+++ b/patches/SLUS-21191_AA525269.pnach
@@ -15,3 +15,8 @@ patch=1,EE,002D9AD0,word,00000000 //0040F809
 author=asasega
 description=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
 patch=1,EE,207A9E5C,extended,00000001 //00000002
+
+[Unlock PSP Exclusive Content]
+author=CRASHARKI
+description=Unlocks the PSP Exclusive Content (Cars, Battle Arenas and Co-op mode).
+patch=1,EE,209D488C,byte,1 //0

--- a/patches/SLUS-21197_C09CB530.pnach
+++ b/patches/SLUS-21197_C09CB530.pnach
@@ -1,0 +1,7 @@
+gametitle=DreamWorks Shrek - SuperSlam (NTSC-U) C09CB530
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Michael
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
+patch=1,EE,21C8111C,extended,3FE38E39 // 3FAAAAAB

--- a/patches/SLUS-21197_C09CB530.pnach
+++ b/patches/SLUS-21197_C09CB530.pnach
@@ -2,6 +2,6 @@ gametitle=DreamWorks Shrek - SuperSlam (NTSC-U) C09CB530
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Michael
+author=xMichael
 description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
 patch=1,EE,21C8111C,extended,3FE38E39 // 3FAAAAAB

--- a/patches/SLUS-21469_CAF1432F.pnach
+++ b/patches/SLUS-21469_CAF1432F.pnach
@@ -3,9 +3,7 @@ gametitle=Nicktoons - Battle for Volcano Island (U)(SLUS-21469)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-
-//Widescreen hack 16:9
-
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
 //Zoom
 //00000000 003f013c 00a08144
 patch=1,EE,00286148,word,3c013f68 //3c013f00
@@ -13,12 +11,9 @@ patch=1,EE,00286148,word,3c013f68 //3c013f00
 //Y-Fov
 //00000000 0c00a1c7 42080046
 patch=1,EE,00286194,word,0806f684 //46000842
-
 patch=1,EE,001bda10,word,46000842
 patch=1,EE,001bda14,word,3c013faa
 patch=1,EE,001bda18,word,3421aaab
 patch=1,EE,001bda1c,word,4481f000
 patch=1,EE,001bda20,word,461e0842
 patch=1,EE,001bda24,word,080a1866
-
-

--- a/patches/SLUS-21583_C6E85EF0.pnach
+++ b/patches/SLUS-21583_C6E85EF0.pnach
@@ -3,9 +3,9 @@ gametitle=Crash of the Titans (NTSC-U)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=CRASHARKI
-comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
 patch=1,EE,21BD4F68,byte,1 //00000000 //In-game option
-patch=1,EE,21BD4FA2,byte,10 //40 //Zoom 1
+patch=1,EE,21BD4FA0,extended,3F020000 //3F100000 //Zoom 1
 patch=1,EE,21BD4FA8,word,3F066666 //3F333333 //Zoom 2
 
 [60 FPS]

--- a/patches/SLUS-21605_910FDAA4.pnach
+++ b/patches/SLUS-21605_910FDAA4.pnach
@@ -3,9 +3,7 @@ gametitle=Nicktoons - Attack of the Toybots (U)(SLUS-21605)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-
-//Widescreen hack 16:9
-
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
 //Zoom
 //403f013c 00608144 a8a80c0c
 patch=1,EE,0012a818,word,3c013f80 //3c013f40
@@ -17,5 +15,3 @@ patch=1,EE,000c0004,word,4481f000
 patch=1,EE,000c0008,word,461e0f83
 patch=1,EE,000c000c,word,e7be000c
 patch=1,EE,000c0010,word,0809dbfd
-
-

--- a/patches/SLUS-21728_6A8448BA.pnach
+++ b/patches/SLUS-21728_6A8448BA.pnach
@@ -3,14 +3,15 @@ gametitle=Crash - Mind Over Mutant (NTSC-U)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=CRASHARKI
-comment=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
 patch=1,EE,21A2A3B8,byte,1 //00000000 //HUD
 patch=1,EE,21A2A3F2,byte,10 //40 //Zoom 1
-patch=1,EE,21A2A3F8,word,3F066666 //3F333333 //Zoom 2
+patch=1,EE,21A2A3F8,extended,3F100000 //3F066666 //Y-Axis
+patch=1,EE,21A2A3F4,extended,3F7FA68A //3F63F7CD //X-Axis
 
 [Progressive Scan]
 author=CRASHARKI
-comment=Run the game with Progressive Scan enabled from the start.
+description=Run the game with Progressive Scan enabled from the start.
 patch=1,EE,207155B0,byte,1 //00000000 //Progressive Scan from the beginning
 
 [60 FPS]

--- a/patches/SLUS-21818_A1DB02D9.pnach
+++ b/patches/SLUS-21818_A1DB02D9.pnach
@@ -1,0 +1,8 @@
+gametitle=Spongebob SquarePants Featuring Nicktoons - Globs of Doom (NTSC-U)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,20413CB4,extended,3F9F49F4 //3F6EEEEE
+patch=1,EE,204B4684,extended,00000001 //00000000


### PR DESCRIPTION
Changes:

- Add Widescreen patches to Tom & Jerry's War of the Wiskers to run the game at 16:9 Widescreen Aspect Ratio from the start.
- Improve Widescreen patches to Spyro A Hero's Tail (Improved HUD).
- Add Widescreen patches to Shrek SuperSlam to run the game at 16:9 Widescreen Aspect Ratio.
- Add patches to circumvent the PSP Connection (not supported on PCSX2) of Crash Tag Team Racing.
- Add Widescreen patches to Nicktoons Globs of Doom to run the game at 16:9 Widescreen Aspect Ratio from the start.
- Improve Widescreen patches to Crash of the Titans (Improved HUD).
- Improve Widescreen patches to Crash Mind Over Mutant (Improved HUD).
- Tidy up.

All of the patches have been tested for all versions of the games, and relevant comments have been added.