### PR TITLE
Add "No Fog" to Sly Cooper 1

### DIFF
--- a/patches/SCUS-97198_C77AF2CA.pnach
+++ b/patches/SCUS-97198_C77AF2CA.pnach
@@ -31,4 +31,9 @@ patch=1,EE,201E9C60,extended,0807A71B
 patch=1,EE,2012B838,extended,0804AE17
 patch=1,EE,2015F47C,extended,24060000
 
+[No Fog]
+comment=No Fog by Murugo
+
+//No Fog
+patch=1,EE,201434F0,extended,44800000
 


### PR DESCRIPTION
Added the No Fog patch to disable the fog that surrounds the horizon of the world, which is often colored by the map.

https://slymods.info/wiki/No_Fog