### PR TITLE
Fatal Frame 2 Undub - Patches update

### DIFF
--- a/patches/SLUS-20766_1C6C1B71.pnach
+++ b/patches/SLUS-20766_1C6C1B71.pnach
@@ -1,4 +1,4 @@
-gametitle=Fatal Frame II: Crimson Butterfly (Undub) * SLUS-20766 * NTSC-U * 1C6C1DB6
+gametitle=Fatal Frame II: Crimson Butterfly (Undub v1.0.2) * SLUS-20766 * NTSC-U * 1C6C1B71
 // same serial-code as 9A51B627 - the regular version.
 // Project Zero II: Crimson Butterfly
 // Zero2Undub: https://github.com/wagrenier/Zero2Undub
@@ -120,12 +120,6 @@ patch=1,EE,0019EDD4,word,10000012 // 54400012
 author=pgert
 description=Puts the Y-axis value to that of 50 Hz-mode (PAL).
 patch=1,EE,00337610,word,3F800000 // 3F600000 - Y-axis of GamePlay (including Cutscenes).
-
-[60 FPS]
-author=asasega
-comment=Everything is double speed - Might need EE overclocking to be stable.
-patch=1,EE,2021B7E4,word,10000007
-patch=1,EE,201F798C,word,2C42003C // gametime fix
 
 // ==========
 // Patches by pgert

--- a/patches/SLUS-20766_1C6C1B71.pnach
+++ b/patches/SLUS-20766_1C6C1B71.pnach
@@ -121,6 +121,13 @@ author=pgert
 description=Puts the Y-axis value to that of 50 Hz-mode (PAL).
 patch=1,EE,00337610,word,3F800000 // 3F600000 - Y-axis of GamePlay (including Cutscenes).
 
+// [60 FPS]
+// author=asasega
+// comment=Everything is double speed - Might need EE overclocking to be stable.
+// Patch disabled due to doubling the game speed
+// patch=1,EE,2021B7E4,word,10000007
+// patch=1,EE,201F798C,word,2C42003C // gametime fix
+
 // ==========
 // Patches by pgert
 // ==========


### PR DESCRIPTION
- The undub patch was updated a few months ago and with that update the CRC changed again, so this PR adds support for this new Undub v1.0.2 (1C6C1B71) ~~basically using the same patches as Undub v1.0.1 (1C6C1DB6).~~
- So the support for the old v1.0.1 is removed, in order not to fill this repository with unnecessary CRC's, leaving only the support for the most recent version of this romhack.
- as well as this PR serves as a follow up of #424
since that PR forgot to disable the broken 60fps patch for the Undub patch

~~i would also like to have the opinion of a moderator~~

~~1. I should remove support for the old undub patch v1.0.1 (1C6C1DB6) from Nov 1, 2022 and only support for the latest undub patch v1.0.2 (1C6C1B71) from May 17, 2024?~~

~~2. Or leave it as it is for possible players that are still using the old undub v1.0.1?~~