### PR TITLE
WS: Disable more problematic patches

### DIFF
--- a/patches/SLES-50677_DEFA4763.pnach
+++ b/patches/SLES-50677_DEFA4763.pnach
@@ -1,9 +1,9 @@
-gametitle=Shadow Hearts SLES_506.77
+//gametitle=Shadow Hearts SLES_506.77
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-comment=Widescreen Hack
-patch=1,EE,0028fa98,word,3c043f40
-patch=1,EE,00284814,word,3c023f40
+//Disabled due to causing dark lines in the screen.
 
-
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//comment=Widescreen Hack
+//patch=1,EE,0028fa98,word,3c043f40
+//patch=1,EE,00284814,word,3c023f40

--- a/patches/SLUS-20659_004B2E96.pnach
+++ b/patches/SLUS-20659_004B2E96.pnach
@@ -1,22 +1,24 @@
-gametitle=Disney Presents Piglet's Big Game (U)(SLUS-20659)
+//gametitle=Disney Presents Piglet's Big Game (U)(SLUS-20659)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=Arapapa
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=Arapapa
+
+//Temporarily disabled till it can be investigated.
 
 //Widescreen hack 16:9
 
 //Zoom
 //4940023c 00088344 db0f4434
-patch=1,EE,00295cbc,word,3c024086 //3c024049
+//patch=1,EE,00295cbc,word,3c024086 //3c024049
 
 //Y-Fov
 //aa3f023c abaa4234  00688244(5th, 6th)
-patch=1,EE,002d9504,word,3c023fe3 //3c023faa Gameplay
-patch=1,EE,002d9508,word,34428e32 //3442aaab
+//patch=1,EE,002d9504,word,3c023fe3 //3c023faa Gameplay
+//patch=1,EE,002d9508,word,34428e32 //3442aaab
 
-patch=1,EE,0032aba8,word,3c023fe3 //3c023faa
-patch=1,EE,0032abac,word,34428e32 //3442aaab Cutscene
+//patch=1,EE,0032aba8,word,3c023fe3 //3c023faa
+//patch=1,EE,0032abac,word,34428e32 //3442aaab Cutscene
 
 /////////////////////////////////////////
 //patch=1,EE,00142df4,word,08042578
@@ -27,5 +29,3 @@ patch=1,EE,0032abac,word,34428e32 //3442aaab Cutscene
 //patch=1,EE,001095ec,word,4481f000
 //patch=1,EE,001095f0,word,461e4202
 //patch=1,EE,001095f4,word,08050b7e
-
-

--- a/patches/SLUS-21390_17493C04.pnach
+++ b/patches/SLUS-21390_17493C04.pnach
@@ -1,12 +1,14 @@
-gametitle=Urban Chaos - Riot Response (NTSC-U) (SLUS-21390)
+//gametitle=Urban Chaos - Riot Response (NTSC-U) (SLUS-21390)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=ElHecht
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=ElHecht
+
+//Disabled due to causing SPS.
 
 // 16:9
-patch=1,EE,00655260,word,3c013f40 // 00000000 hor fov
-patch=1,EE,00655264,word,34210000 // 00000000 hor fov
+//patch=1,EE,00655260,word,3c013f40 // 00000000 hor fov
+//patch=1,EE,00655264,word,34210000 // 00000000 hor fov
 
 // 16:10
 //patch=1,EE,00655260,word,3c013f55 // 00000000 hor fov
@@ -15,12 +17,10 @@ patch=1,EE,00655264,word,34210000 // 00000000 hor fov
 // 16:9 and 16:10 modifications
 // no need to change anything here! all modifications are calculated
 // based on the hor fov value in the upper 16:9/16:10 section
-patch=1,EE,0018f548,word,08195498 // e7a40000
-patch=1,EE,0018f54c,word,00000000 // c7b40070
-patch=1,EE,00655268,word,4481f000 // 00000000
-patch=1,EE,0065526c,word,461e2102 // 00000000
-patch=1,EE,00655270,word,e7a40000 // 00000000
-patch=1,EE,00655274,word,c7b40070 // 00000000
-patch=1,EE,00655278,word,08063d53 // 00000000
-
-
+//patch=1,EE,0018f548,word,08195498 // e7a40000
+//patch=1,EE,0018f54c,word,00000000 // c7b40070
+//patch=1,EE,00655268,word,4481f000 // 00000000
+//patch=1,EE,0065526c,word,461e2102 // 00000000
+//patch=1,EE,00655270,word,e7a40000 // 00000000
+//patch=1,EE,00655274,word,c7b40070 // 00000000
+//patch=1,EE,00655278,word,08063d53 // 00000000


### PR DESCRIPTION
Disables WS patches for Urban Chaos and Shadow Hearts PAL as they cause SPS and graphical issues and disables piglets big games WS until I can fully investigate the game and it's issues.