### PR TITLE
Add patches and fixes

### DIFF
--- a/patches/SLES-50054_8CB701AF.pnach
+++ b/patches/SLES-50054_8CB701AF.pnach
@@ -1,0 +1,20 @@
+gametitle=Midnight Club - Street Racing (PAL-M) SLES-50054 8CB701AF
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Renders the game in 16:9 aspect ratio
+patch=1,EE,2047A700,extended,3F400000
+patch=1,EE,204280A0,extended,3FAB0000
+patch=1,EE,2047A714,extended,3F800000
+patch=1,EE,2047A73C,extended,3F800000
+patch=1,EE,204280E0,extended,3F800000
+patch=1,EE,E0030003,extended,00328220
+patch=1,EE,2047A714,extended,3F400000
+patch=1,EE,2047A73C,extended,3F400000
+patch=1,EE,204280E0,extended,3F400000
+
+[50 FPS]
+author=PeterDelta
+description=Might need EE Overclock (130%).
+patch=1,EE,00304844,extended,00000001

--- a/patches/SLES-50071_831078BD.pnach
+++ b/patches/SLES-50071_831078BD.pnach
@@ -4,11 +4,17 @@ gametitle=Midnight Club - Street Racing (PAL-M) SLES-50071 831078BD
 gsaspectratio=16:9
 author=PeterDelta
 description=Renders the game in 16:9 aspect ratio
-patch=1,EE,0047B580,word,3F471C97 //3F800000 
-patch=1,EE,0047B594,word,3F471C97 //3F800000
-patch=1,EE,0047B5BC,word,3F471C97 //3F800000
+patch=1,EE,2047B580,extended,3F400000
+patch=1,EE,20428F20,extended,3FAB0000
+patch=1,EE,2047B594,extended,3F800000
+patch=1,EE,2047B5BC,extended,3F800000
+patch=1,EE,20428F60,extended,3F800000
+patch=1,EE,E0030003,extended,003290A0
+patch=1,EE,2047B594,extended,3F400000
+patch=1,EE,2047B5BC,extended,3F400000
+patch=1,EE,20428F60,extended,3F400000
 
 [50 FPS]
 author=PeterDelta
-description=Might need EE Overclock at 130%.
-patch=1,EE,003054C4,word,00000001
+description=Might need EE Overclock (130%).
+patch=1,EE,003054C4,extended,00000001

--- a/patches/SLPM-66675_F266B00B.pnach
+++ b/patches/SLPM-66675_F266B00B.pnach
@@ -1,9 +1,9 @@
-gametitle=Kingdom Hearts 2 Final Mix + (NTSC-J) (SLPM 666 75)
+gametitle=Kingdom Hearts 2 Final Mix + (NTSC-J) SLPM-66675 F266B00B
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=Kingdom Hearts 2 Final Mix + (NTSC-J)
-
+author=ElHecht
+description=Renders the game in 16:9 aspect ratio
 // old widescreen
 //patch=1,EE,203A7BBC,word,3F19999A // 3F4CCCCC (hor axis)
 //patch=1,EE,2036A0B8,word,43C00000 // 44000000 (zoom)
@@ -32,33 +32,31 @@ patch=1,EE,2036CE94,word,3F400000 // 3F800000
 patch=1,EE,2036CE98,word,3F400000 // 3F800000
 patch=1,EE,2036CE9C,word,3F400000 // 3F800000
 
-//black border fix
-patch=1,EE,0014AD80,word,24050000
-patch=1,EE,0014ADA8,word,24050000
-patch=1,EE,0014ADD0,word,24050000
-patch=1,EE,0014AE00,word,24050000
-
 //lower subtitles
 patch=1,EE,001ac8d8,word,240a0190
-
-//subtitles off
-//patch=1,EE,0022d8d4,word,11e00019
 
 //Disable image map names
 //patch=1,EE,00149B52,extended,00000000
 //patch=1,EE,2036B3B0,extended,00000000 // Fallback text duration, in frames (float; 60 frames = 1 sec)
 
-//60 FPS
-//patch=1,EE,00349E1C,extended,00000000
+[Remove Blackbars]
+author=ElHecht
+description=Removes black bars in cutscenes
+patch=1,EE,0014AD80,word,24050000
+patch=1,EE,0014ADA8,word,24050000
+patch=1,EE,0014ADD0,word,24050000
+patch=1,EE,0014AE00,word,24050000
 
-//60 FPS toggle on (game play, cutscenes ect)
-//patch=1,EE,D034dca8,extended,00000003
-//patch=1,EE,00349E1C,extended,00000000
-//patch=1,EE,00349E2c,extended,00000000
+[60 FPS]
+author=PeterDelta
+description=Might need EE Overclock (130%).
+patch=1,EE,00349E1C,extended,00000000
+patch=1,EE,E0010005,extended,0032BA24 //by PeterDelta
+patch=1,EE,00349E1C,extended,00000001
+patch=1,EE,2036B0F8,extended,3F800000
+patch=1,EE,2036EF20,extended,3F800000
 
-//60 FPS toggle off (FMV's)
-//patch=1,EE,D034dca8,extended,00000001
-//patch=1,EE,00349E1C,extended,00000001
-//patch=1,EE,00349E2c,extended,00000001
-
-
+[Subtitles off]
+author=ElHecht
+description=Disable subtitles during scenes
+patch=1,EE,0022d8d4,word,11e00019

--- a/patches/SLUS-21005_DA0535FD.pnach
+++ b/patches/SLUS-21005_DA0535FD.pnach
@@ -1,17 +1,9 @@
-gametitle=Kingdom Hearts II NTSC-U
+gametitle=Kingdom Hearts II (NTSC-U) SLUS-21005 DA0535FD
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-comment=KH2 - NTSC-U
-
-// old 16:9 hack by - cassidy1991
-//patch=1,EE,203B223C,word,3F19999A // 3F4CCCCC (hor axis)
-//patch=1,EE,20378100,word,43C00000 // 44000000 (zoom)
-//patch=1,EE,2037F484,word,3F19999A // 3F4CCCCC (character menu proportions)
-//patch=1,EE,203B233C,word,3F19999A // 3F4CCCCC (continue screen proportions)
-//patch=1,EE,203840D0,word,3F19999A // 3F4CCCCC (world map cutscene proportions)
-
-// new 16:9 hack by - ElHecht
+author=ElHecht
+description=Renders the game in 16:9 aspect ratio
 patch=1,EE,00106c70,word,3c013f4c // c480004c
 patch=1,EE,00106c88,word,3421cccc // 4600a7c6
 patch=1,EE,00106c8c,word,4481f800 // 00000000
@@ -32,7 +24,15 @@ patch=1,EE,2037ae4c,word,3F400000 // 3F800000
 //lower subtitles
 patch=1,EE,001aae88,word,240a0190
 
+// old 16:9 hack by - cassidy1991
+//patch=1,EE,203B223C,word,3F19999A // 3F4CCCCC (hor axis)
+//patch=1,EE,20378100,word,43C00000 // 44000000 (zoom)
+//patch=1,EE,2037F484,word,3F19999A // 3F4CCCCC (character menu proportions)
+//patch=1,EE,203B233C,word,3F19999A // 3F4CCCCC (continue screen proportions)
+//patch=1,EE,203840D0,word,3F19999A // 3F4CCCCC (world map cutscene proportions)
+
 [Remove Blackbars]
+author=ElHecht
 description=Removes black bars in cutscenes
 patch=1,EE,0014aaf0,word,24050000
 patch=1,EE,0014ab18,word,24050000
@@ -40,10 +40,15 @@ patch=1,EE,0014ab40,word,24050000
 patch=1,EE,0014ab70,word,24050000
 
 [60 FPS]
-description=Forces the game to run at 60.
-//60 FPS
+author=PeterDelta
+description=Might need EE Overclock (130%).
 patch=1,EE,00356F4C,extended,00000000
+patch=1,EE,E0010005,extended,0033E784 //by PeterDelta
+patch=1,EE,00356F4C,extended,00000001
+patch=1,EE,20379178,extended,3F800000
+patch=1,EE,2037CE98,extended,3F800000
 
 [Subtitles off]
+author=ElHecht
 description=Disable subtitles during scenes
 patch=1,EE,002274cc,word,11e00019

--- a/patches/SLUS-21059_652050D2.pnach
+++ b/patches/SLUS-21059_652050D2.pnach
@@ -31,3 +31,7 @@ patch=1,EE,00222494,word,44810000
 patch=1,EE,00222498,word,46006302
 
 
+[480p Mode]
+author=PeterDelta
+description=SDTV 480p mode at start.
+patch=1,EE,003EF450,extended,01


### PR DESCRIPTION
Midnight Club - Street Racing: Fixed car selection
Tekken 5 USA: Added 480p patch, enables native 480p mode from start
Kingdom Hearts II USA and JAP Final Mix+ version: 60 FPS patch was missing in these versions, now they are complete