### PR TITLE
Changes to Widescreen Patch in The Godfather for better FOV and correcting minor gameplay issues

### DIFF
--- a/patches/SLUS-21385_D850707E.pnach
+++ b/patches/SLUS-21385_D850707E.pnach
@@ -19,3 +19,8 @@ patch=1,EE,002e5854,word,3c013f40
 patch=1,EE,002e5858,word,4481f000
 patch=1,EE,002e585c,word,461e0002
 patch=1,EE,002e5860,word,080d56ad
+
+[Remove Blackbars]
+author=BlackNRoses, pgert, Arapapa (original)
+description=No blackbars in cutscenes. Made by suggestion from pgert.
+patch=1,EE,006617B8,word,00000001

--- a/patches/SLUS-21385_D850707E.pnach
+++ b/patches/SLUS-21385_D850707E.pnach
@@ -2,7 +2,8 @@ gametitle=The Godfather (NTSC-U)(SLUS-21385)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Arapapa
+author=BlackNRoses, Arapapa (original)
+description=Fixes disproportionate FOV of character and weapon models. Cutscene, dialogue and extorsion black bars were restored to keep the 1972 movie's feel.
 
 //Widescreen hack 16:9
 
@@ -10,12 +11,11 @@ author=Arapapa
 //003f013c 00608144
 patch=1,EE,0035f26c,word,3c013f20 //3c013f00
 
-//Fov
-//5b3f013c b86d2134 00008144 5c00053c
-patch=1,EE,0036f468,word,3c013f24 //3c013f5b
-patch=1,EE,0036f46c,word,34219247 //34216db8
-
-//Cutscene Bars
-patch=1,EE,006617B8,word,00000001
-
-
+//Y-Fov
+//02001446 3000a527
+patch=1,EE,00355ab0,word,080b9614 //08164b44
+patch=1,EE,002e5850,word,46140002
+patch=1,EE,002e5854,word,3c013f40
+patch=1,EE,002e5858,word,4481f000
+patch=1,EE,002e585c,word,461e0002
+patch=1,EE,002e5860,word,080d56ad


### PR DESCRIPTION
The following is a patch correction for the "SLUS-21385_D850707E.pnach", also known as the NTSC-U version of "The Godfather". It's based off Arapapa's widescreen patches. Here's what I'm correcting:

**Before:**
Originally, while using Arapapa's 16:9 Widescreen Patch, the FOV correction would cause the player model to look bigger making its head invisible (therefore impossible to edit, without disabling patches and rebooting).

![Arapapa_og_patch1](https://github.com/user-attachments/assets/b7f7ec30-18f4-4153-af97-ce65aa12568c)
![Arapapa_og_patch2](https://github.com/user-attachments/assets/c1ea4b74-ca2a-4c02-91ea-b51a1e20e89f)

Also, weapon models would obscure their names and ammo count, making it difficult to keep track of remaining ammo.

![Arapapa_og_patch5](https://github.com/user-attachments/assets/62f2b253-98fe-4bea-ad4a-e1e24b02c04e)
![Arapapa_og_patch6](https://github.com/user-attachments/assets/b69be87f-ff3e-40c8-9df2-2779dac16572)


**After:**
With these corrections, the player model's head is no longer obscured during character creation or editing.

![BNR_Ara_patch1](https://github.com/user-attachments/assets/8374957e-db0d-4ffa-9fb8-d69f55aeb115)
![BNR_Ara_patch2](https://github.com/user-attachments/assets/849db8e7-1528-4f94-a85a-0b3fc30a235e)

Finally, weapon models no longer obscure their information.

![BNR_Ara_patch5](https://github.com/user-attachments/assets/89ebb33c-0b69-4707-9270-07110f6056e6)
![BNR_Ara_patch6](https://github.com/user-attachments/assets/cb8b0b2a-a831-4050-858f-9483d83b62e7)

**Miscellanous:**
Out of desire to preserve the original feel of the game (and the film it's based on), widescreen black bars for cutscenes where restored.

In Arapapa's original patch, black bars are removed, though they don't reveal much more information.

What do we gain by looking at Sarafina's feet? This scene is about her asking a favor to Don Corleone, and he's pondering about whether he should honor it or not.
![Arapapa_og_patch3](https://github.com/user-attachments/assets/79a5f4c8-986c-4407-ae36-45e87b7956c9)

Luca Brasi just killed this poor fella. Not much else to see.
![Luca_Brasi_Ara](https://github.com/user-attachments/assets/296f9a5d-845a-46f3-9b76-dff2efa81284)

In this correction, black bars are restored, keeping the scenes more focused on the characters.

The door is still kinda bothersome, but we also can tell this is about two people discussing a favor.
![BNR_Ara_patch3](https://github.com/user-attachments/assets/29f50644-3968-4dbb-ae4d-12830b7fbc97)

Luca still killed this poor fella. Not much else to see, 'cause there wasn't anything else from the start.
![Luca_Brasi_BNR_Ara](https://github.com/user-attachments/assets/52b8bfe8-f93b-4cdf-8492-ece9e1e0e6c9)

Aside from that, some gameplay elements (i.e dialogue and extorsion) make use of them, though not consistently.

These 2 characters are story-relevant, Luca Brasi and the Sergeant Galtosino.
![Screenshot from 2024-12-06 01-03-29](https://github.com/user-attachments/assets/d31b00b2-f090-4c64-9f41-69eb23d4bbb0)
![Screenshot from 2024-12-06 01-07-06](https://github.com/user-attachments/assets/2145ec05-ab4b-489e-8c57-e22189ceef3a)

These other 2 are a random shopkeeper and a racket boss.
![Screenshot from 2024-12-06 01-04-35](https://github.com/user-attachments/assets/47cc34d7-78e1-474d-a037-76ccba5bd11f)
![Screenshot from 2024-12-06 01-06-24](https://github.com/user-attachments/assets/54998849-f895-4c57-9e2f-90486a4efaf5)

This is a random Corleone enforcer:
![random_enforcer](https://github.com/user-attachments/assets/f8a8bc1f-d080-4411-9c0c-0c365752c523)

My guess, after further testing on native and patched aspect, is that black bars were implemented mostly on story characters, and maybe it was planned for them be used on every character, but the developers at EA Redwood Shores didn't keep a registry or database to do this automatically, so they preferred to keep it simple for quickness sake (originally, this game was delayed for about a year) and released it that way in 2006.