### PR TITLE
Fixed widescreen patch for Racing Battle C1 Grand Prix [SLPM-65897]

### DIFF
--- a/patches/SLPM-65897_1C087362.pnach
+++ b/patches/SLPM-65897_1C087362.pnach
@@ -2,12 +2,9 @@ gametitle=Racing Battle C1 Grand Prix (J)(SLPM-65897)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Arapapa
+author=github.com/igorciz777
 
-//Wide Screen hack 16:9
-
-//X-Fov
-patch=1,EE,00165a00,word,3c023f40 //3c023f80
+patch=1,EE,00167318,word,3c043f10 //3c043f40
 
 
 [No-Interlacing]


### PR DESCRIPTION
This ws patch removes rendering issues of the previous patch, e.g. misaligned lights

![comp1](https://github.com/user-attachments/assets/6ab42539-164d-40f7-a7c3-0b7ee8d46613)

![comp2](https://github.com/user-attachments/assets/6ad795ff-835e-4f47-9322-8f8db8359a3a)
