### PR TITLE
Scripts: Fix the validation script

### DIFF
--- a/.github/scripts/validate_patches.py
+++ b/.github/scripts/validate_patches.py
@@ -18,14 +18,14 @@ def log_error(file_path, line_number, message, line, shouldCleanLine = False):
     print(f'Error in {file_path} (line {line_number}): {message}\n\t"{line}"')
 
 def is_file_valid(file_path):
-    with open(file_path, 'r') as file:
+    with open(file_path, 'r', encoding='utf-8') as file:
         for line_number, line in enumerate(file, 1):
             cleaned_line = clean_line(line)
             if cleaned_line == "":
                 continue
             elif cleaned_line.startswith("["):
                 if not cleaned_line.endswith("]"):
-                    print(f'Error in {file_path} group format (line {line_number}): Unclosed brackets for group.\n\T"{line}"')
+                    print(f'Error in {file_path} group format (line {line_number}): Unclosed brackets for group.\n\t"{line}"')
                     return False
                 continue
             elif re.match(r'^(\s*(gametitle|comment|gsaspectratio|gsinterlacemode|author|description)\s*=)', line, re.IGNORECASE):
@@ -41,7 +41,7 @@ def is_file_valid(file_path):
                 if not re.match(r'^patch=(0|1|2),(EE|IOP),[0-9A-Fa-f]{1,8},(byte|short|word|double|extended|beshort|beword|bedouble|bytes),[0-9A-Fa-f]{1,8}', line):
                     log_error(file_path, line_number, "Invalid patch format.", line, True)
                     return False
-                if re.match(",\d{8}(\n|\s*(//.*)*)+(?!.)", line):
+                if re.match(r",\d{8}(\n|\s*(//.*)*)+(?!.)", line):
                     log_error(file_path, line_number, "Invalid comment syntax at end of patch line.", line, False)
                     return False
             elif cleaned_line.startswith("dpatch"):
@@ -71,7 +71,7 @@ def is_file_valid(file_path):
 
 def main():
     error_found = False
-    print('Started validating patches files')
+    print('Started validating patch files')
 
     files = glob.glob(patches_glob_path)
     file_count = len(files)

--- a/.github/workflows/pack_patches.yml
+++ b/.github/workflows/pack_patches.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Create archives
         run: |
           7z a -r patches.zip ./patches/*
 
       - name: Upload archives
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cheats
           path: ./patches.zip
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Create a new release
         uses: marvinpinto/action-automatic-releases@latest

--- a/.github/workflows/validate_patches.yml
+++ b/.github/workflows/validate_patches.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Validate all patches
         run: |


### PR DESCRIPTION
This PR does the following:
1. The validation script got some syntax warnings fixed and now explicitly reads the patch files as UTF-8. This makes the validation script work correctly also on Windows.
2. Outdated actions have been updated. `marvinpinto/action-automatic-releases` is deprecated and should be replaced, but one of the possible replacements, `softprops/action-gh-release`, has its fair share of issues - and currently cannot be used by us properly due to https://github.com/softprops/action-gh-release/issues/191.