### PR TITLE
NASCAR Heat 2002: Allow specifying negative margins

### DIFF
--- a/patches/SLUS-20176_D813AF38.pnach
+++ b/patches/SLUS-20176_D813AF38.pnach
@@ -2,9 +2,7 @@ gametitle=NASCAR Heat 2002 (U)(SLUS-20176)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Arapapa
-
-//Widescreen hack 16:9
+author=Arapapa, Silent
 
 //Zoom
 patch=1,EE,00243550,word,3c013ec0 //3c013f00
@@ -13,4 +11,6 @@ patch=1,EE,00243550,word,3c013ec0 //3c013f00
 patch=1,EE,0024356c,word,3c01bfa0 //3c01bf70
 patch=1,EE,00243570,word,34216d37 //3421a3d7
 
-
+//Unlimited margins
+patch=1,EE,0014c42c,word,10000009 //b 0x0014c454
+patch=1,EE,0014c488,word,1000FFF2 //b 0x0014c454


### PR DESCRIPTION
Reposting my old improvement for the widescreen patch from here:
<https://forums.pcsx2.net/Thread-PCSX2-Widescreen-Game-Patches?pid=612346#pid612346>

Improved upon Arapapa's widescreen patch for NASCAR Heat 2002 (NTSC-U) to allow for specifying negative left/right margins. Albeit counter-intuitive, this allows to properly align HUD to 16:9 boundaries instead of having all elements stuck at their 4:3 boundaries.

![image](https://github.com/user-attachments/assets/50477d8f-a735-4689-a95a-d79f405ce35e)
![image](https://github.com/user-attachments/assets/5b031e3d-7da5-499d-9b93-cbc6cfbc8be2)
