### PR TITLE
WS: Disable Kao the Kangaroo Round 2 patches.

### DIFF
--- a/patches/SLUS-20296_5D8B63C1.pnach
+++ b/patches/SLUS-20296_5D8B63C1.pnach
@@ -1,23 +1,23 @@
-gametitle=Kao the Kangaroo Round 2 (U)(SLUS-20296)
+//gametitle=Kao the Kangaroo Round 2 (U)(SLUS-20296)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=Arapapa
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=Arapapa
 
 //Widescreen hack 16:9
 
 //X-Fov
 //c3180d46 00180244 00000a44
-patch=1,EE,00234290,word,080e60d4
+//patch=1,EE,00234290,word,080e60d4
 
-patch=1,EE,00398350,word,460d18c3
-patch=1,EE,00398354,word,3c013f40
-patch=1,EE,00398358,word,4481f000
-patch=1,EE,0039835c,word,461e18c2
-patch=1,EE,00398360,word,0808d0a5
+//patch=1,EE,00398350,word,460d18c3
+//patch=1,EE,00398354,word,3c013f40
+//patch=1,EE,00398358,word,4481f000
+//patch=1,EE,0039835c,word,461e18c2
+//patch=1,EE,00398360,word,0808d0a5
 
 //Render fix
 //003f033c 00088344 00000000 02000246
-patch=1,EE,001c6168,word,3c033f2b //3c033f00
+//patch=1,EE,001c6168,word,3c033f2b //3c033f00
 
 


### PR DESCRIPTION
Patches broke shadows.

See https://forums.pcsx2.net/Thread-Bug-Report-Kao-the-Kangaroo-Round-2-NTSC