### PR TITLE
Tokyo Xtreme Racer 0 (J): Fix widescreen patch

### DIFF
--- a/patches/SLPS-25028_F9D5C6A6.pnach
+++ b/patches/SLPS-25028_F9D5C6A6.pnach
@@ -11,19 +11,19 @@ patch=0,EE,101DD0D0,extended,3F40 // Menus
 
 // 16:9 - Gameplay HUD
 patch=0,EE,101B06D8,extended,01FC // Move the entire cluster to the right
-patch=0,EE,101A915C,extended,0040 // Tacho needle
+patch=0,EE,101A915C,extended,0030 // Tacho needle
 patch=0,EE,101A9208,extended,0020 // Shift assist
-patch=0,EE,101A9188,extended,002A // Left indicator
-patch=0,EE,101A91B4,extended,003A // Right indicator
-patch=0,EE,101A9274,extended,005E // Current gear
+patch=0,EE,101A9188,extended,0020 // Left indicator
+patch=0,EE,101A91B4,extended,0031 // Right indicator
+patch=0,EE,101A9274,extended,004E // Current gear
 patch=0,EE,101A92AC,extended,0015 // Speed
 patch=0,EE,201A92BC,extended,010B4023 // Speed, distance between letters (19)
 patch=0,EE,101A9324,extended,0016 // Bottom left line
-patch=0,EE,101A91DC,extended,0040 // mph text
+patch=0,EE,101A91DC,extended,003F // kph text
 patch=0,EE,101A9350,extended,0056 // Bottom right line
-patch=0,EE,2033E390,extended,3F400000
+patch=0,EE,20336000,extended,3F400000
 patch=0,EE,20336048,extended,3F400000
-patch=0,EE,2033E4B0,extended,3F400000
+patch=0,EE,20336120,extended,3F400000
 patch=0,EE,20336168,extended,3F400000
 patch=0,EE,203361B0,extended,3F400000
 patch=0,EE,203361F8,extended,3F400000


### PR DESCRIPTION
fix a bug that some elements are not correctly modified.

---

Before:
![txr0_ws_before](https://github.com/user-attachments/assets/cb3d122a-b3b3-4a6f-8f3b-ebd5585dc2dd)

After:
![txr0_ws_after](https://github.com/user-attachments/assets/227c74ea-02eb-496d-a44e-a5f420bbfd98)
