### PR TITLE
Conflict: Vietnam - Add 60 FPS patch (tested)

### DIFF
--- a/patches/SLUS-21045_CC6CBF20.pnach
+++ b/patches/SLUS-21045_CC6CBF20.pnach
@@ -14,4 +14,6 @@ patch=1,EE,003095f0,word,34218cc1 //3421a993
 //patch=1,EE,0030962c,word,3c013f0e //3c013f0a
 //patch=1,EE,00309630,word,342190dd //342160dd
 
-
+[60 FPS]
+author=asasega
+patch=1,EE,20303570,word,2C420001


### PR DESCRIPTION
60 FPS patch by asasega. Game runs perfectly well at 60 FPS. Occassions where it doesn't are barely noticeable around 56–60 FPS and only for a few short moments, and these can be remedied by overclocking up to 130 or 180%. Areas which would slow down the game considerably are handled correctly by the game itself, which sets itself back to 30 FPS while maintaining the correct game speed. (The only example I was able to find of this is the area in Mission 1 which has a guard tower and a vehicle repair garage.) Tested thoroughly in Missions 1–4 for about two hours. All 14 missions except Mission 7 (a boat ride) and Mission 13 (a helicopter ride) have the exact same core gameplay, and 7 and 13 barely diverge from this (you are not actually piloting either vehicle). Game makes minimal use of physics.