### PR TITLE
Shin Megami Tensei: Persona 4 (SLUS-21782) 16:10 Widescreen patch

### DIFF
--- a/patches/SLUS-21782_DEDC3B71.pnach
+++ b/patches/SLUS-21782_DEDC3B71.pnach
@@ -3,6 +3,7 @@ gametitle=Shin Megami Tensei: Persona 4 (SLUS-21782B)
 [Widescreen 16:9]
 description=Renders the game in 16:9 aspect ratio, instead of 4:3.
 gsaspectratio=16:9
+author=pavachan & nemesis2000
 
 //16:9 by pavachan
 patch=1,EE,0076111c,word,3fe38e38
@@ -82,6 +83,7 @@ patch=1,EE,00123430,word,24020BF6
 [Widescreen 16:10]
 description=Renders the game in 16:10 aspect ratio, instead of 4:3.
 gsaspectratio=Stretch
+author=pavachan & nemesis2000 - converted by AtaKe
 
 //16:10
 patch=1,EE,0076111c,word,3fc71c71

--- a/patches/SLUS-21782_DEDC3B71.pnach
+++ b/patches/SLUS-21782_DEDC3B71.pnach
@@ -79,4 +79,83 @@ patch=1,EE,00223008,word,3C024340 //(level up white glow)
 //partial HUD text fix by nemesis2000
 patch=1,EE,00123430,word,24020BF6
 
+[Widescreen 16:10]
+description=Renders the game in 16:10 aspect ratio, instead of 4:3.
+gsaspectratio=Stretch
+
+//16:10
+patch=1,EE,0076111c,word,3fc71c71
+
+//partial HUD fix
+patch=1,EE,00104680,word,3c043f56
+patch=1,EE,00104688,word,00731821
+patch=1,EE,0010468c,word,24636728
+patch=1,EE,00104694,word,00000000
+patch=1,EE,00104698,word,24630004
+patch=1,EE,0010469c,word,3c043f80
+
+//FMV's fix
+patch=1,EE,0046957c,word,1460000a
+patch=1,EE,00469584,word,3c03c241
+patch=1,EE,00469588,word,10000008
+patch=1,EE,0046958c,word,00000000
+patch=1,EE,004695a8,word,3c0343d4
+patch=1,EE,004695bc,word,00000000
+
+//Font fix
+patch=1,EE,002732b4,word,00118903
+patch=1,EE,002732b8,word,02338818
+patch=1,EE,002732c0,word,8E93001c
+patch=1,EE,00273368,word,82970003
+patch=1,EE,0027343c,word,24130015
+
+patch=1,EE,00275dbc,word,2415000c
+patch=1,EE,00275dd4,word,3c0241a8
+patch=1,EE,00275e00,word,01154018
+patch=1,EE,00275e04,word,00084103
+patch=1,EE,00275e08,word,0100a82d
+
+//zoom fix
+patch=1,EE,0026c620,word,0c0fa77c
+patch=1,EE,0026c624,word,0220202d
+patch=1,EE,0026c628,word,0220202d
+patch=1,EE,0026c62c,word,0200282d
+patch=1,EE,0026c630,word,0000302d
+patch=1,EE,0026c634,word,0c0fa72c
+patch=1,EE,0026c638,word,00000000
+patch=1,EE,0026c63c,word,0c0f83d0
+patch=1,EE,0026c640,word,0200202d
+patch=1,EE,0026c644,word,0240202d
+patch=1,EE,0026c648,word,3c013fa1 // 80=hor+, a1=moonwalk fix, aa=vert-
+patch=1,EE,0026c64c,word,44810000
+patch=1,EE,0026c650,word,c66c0140
+patch=1,EE,0026c654,word,0c115df4
+patch=1,EE,0026c658,word,46006303
+
+//personas art fix
+patch=1,EE,0011dc6c,word,10400032
+patch=1,EE,0011dc78,word,1060002f
+
+patch=1,EE,0011dd28,word,3c013f2d
+patch=1,EE,0011dd2c,word,44810800
+patch=1,EE,0011dd30,word,0c04756c
+patch=1,EE,0011dd34,word,46016b43
+patch=1,EE,0011dd38,word,dfbf0020
+patch=1,EE,0011dd3c,word,7bb00010
+patch=1,EE,0011dd40,word,c7b40000
+patch=1,EE,0011dd44,word,27bd0030
+patch=1,EE,0011dd48,word,03e00008
+
+patch=1,EE,0011D724,word,3c024360
+
+patch=1,EE,0011A114,word,00000000
+patch=1,EE,001369B0,word,00000000
+
+//characters art fix
+patch=1,EE,00354CE4,word,3c024360
+patch=1,EE,00223008,word,3c024360 //(level up white glow)
+
+//partial HUD text fix
+patch=1,EE,00123430,word,24020BF6
+
 


### PR DESCRIPTION
I took the existing 16:9 patch, and changed its values to work better with 16:10 displays.

Things that were changed compared to 16:9 patch:

- Game FOV (That's what //16:10 stands for)
- HUD fix - adjusted dialogue portraits
- FMV's - slight changes to size
- Persona arts - size + corrected position to be closer to how it was in 4:3 Characters art - Changed size

The changes were all tested and nothing seems to be broken (at least I didn't notice anything)

Screenshots of the patch:
![Shin Megami Tensei - Persona 4_SLUS-21782_20250131223255](https://github.com/user-attachments/assets/0703e8d5-fda0-4436-9973-b9249f43bbbc)
![Shin Megami Tensei - Persona 4_SLUS-21782_20250131223302](https://github.com/user-attachments/assets/fabf0db4-9cbc-4561-835a-ca0a909d5771)
![Shin Megami Tensei - Persona 4_SLUS-21782_20250201001336](https://github.com/user-attachments/assets/ed593daa-51dd-48a5-819b-53218b341e55)
![Shin Megami Tensei - Persona 4_SLUS-21782_20250201001449](https://github.com/user-attachments/assets/8dbafcd6-3019-482b-a016-e94232c09b2b)
