### PR TITLE
Disable all post-processing effect in Okami.

### DIFF
--- a/patches/SLES-54439_891F223F.pnach
+++ b/patches/SLES-54439_891F223F.pnach
@@ -1,11 +1,16 @@
-gametitle=Okami (PAL-M3) (SLES-54439)
+gametitle=Okami PAL-M SLES-54439 891F223F
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
 description=Widescreen Hack
-// 16:9
 patch=1,EE,001974d4,word,3c014455
 patch=1,EE,00344864,word,3c014455
 
-
+[Disable post-processing effect]
+author=Gabominated
+description=Disable all post-processing effect.
+patch=1,EE,00190A5C,word,00000000 //0C06191A
+patch=1,EE,00190A24,word,00000000 //0C063A6C
+patch=1,EE,00190B34,word,00000000 //0C063710
+patch=1,EE,001916D4,word,00000000 //0C060E70

--- a/patches/SLPM-66375_C5DEFEA0.pnach
+++ b/patches/SLPM-66375_C5DEFEA0.pnach
@@ -1,19 +1,21 @@
-gametitle=Okami (J) (SLPM_66375)
+gametitle=Okami NTSC-J SLPM-66375 C5DEFEA0
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht (pnach by Arapapa)
+description=Widescreen Hack
 //Nemesis2000's search values did not apply to NTSC-J
-
-// 16:9
-
 // 2044013c 00688144 005b41c4
 patch=1,EE,0015c364,word,3c014455 // 3c014420
-
 // 2044013c 00088144 00000000 00000000
 patch=1,EE,0033b8d0,word,3c014455 // 3c014420
-
 //both fov+ (Zoom out)
 //patch=1,EE,0015c33c,word,3c014388
 
-
+[Disable post-processing effect]
+author=Gabominated
+description=Disable all post-processing effect.
+patch=1,EE,0018F264,word,00000000 //0C061558
+patch=1,EE,0018F22C,word,00000000 //0C06363A
+patch=1,EE,0018F33C,word,00000000 //0C0632AE
+patch=1,EE,0018FCEC,word,00000000 //0C060D38

--- a/patches/SLUS-21115_21068223.pnach
+++ b/patches/SLUS-21115_21068223.pnach
@@ -1,8 +1,9 @@
-gametitle=Okami (SLUS-21115)
+gametitle=Okami NTSC-U SLUS-21115 21068223
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=nemesis2000
+description=Widescreen Hack
 patch=1,EE,0015c33c,word,3c0143a8
 patch=1,EE,0033ec38,word,3c013f9f
 patch=1,EE,0033ec3c,word,4481a800
@@ -12,4 +13,10 @@ patch=1,EE,0015c3ac,word,00000000
 patch=1,EE,0015c43c,word,3c014500
 patch=1,EE,0033ec20,word,3c014500
 
-
+[Disable post-processing effect]
+author=Gabominated
+description=Disable all post-processing effect.
+patch=1,EE,00190A84,word,00000000
+patch=1,EE,00190A4C,word,00000000
+patch=1,EE,00190B5C,word,00000000
+patch=1,EE,001916FC,word,00000000


### PR DESCRIPTION
Disable post-processing effect to improve the visual quality bothered by the excess of post-processing effect and filters that are not well rendered and do not look good on modern monitors, all this without altering the essence and art design of Okami.

This patch disable:
- Excessive blur/bloom
- Ghosting
- Noise filter

![Okami_SLUS-21115_20250220222657](https://github.com/user-attachments/assets/a9e0d0f3-8b1c-48b0-8084-9358f186005a)
![Okami_SLUS-21115_20250220222659](https://github.com/user-attachments/assets/2f9dd139-5dbf-4402-916d-5b4b5b826216)
![Okami_SLUS-21115_20250220222809](https://github.com/user-attachments/assets/26cc09a2-fc7b-4f40-9bd8-5e2ac88d1e05)
![Okami_SLUS-21115_20250220222806](https://github.com/user-attachments/assets/faf6bc23-0df0-4cfd-b990-f3b0cb1441d9)
![Okami_SLUS-21115_20250220222826](https://github.com/user-attachments/assets/3169e077-e728-4a81-b5ad-2474aed5d270)
![Okami_SLUS-21115_20250220222829](https://github.com/user-attachments/assets/9a08edc6-fafd-45b0-be3b-0b6a19bb358f)
![Okami_SLUS-21115_20250220223730](https://github.com/user-attachments/assets/7d301f13-0ae5-4eea-9eb0-93763acb239b)
![Okami_SLUS-21115_20250220223732](https://github.com/user-attachments/assets/39a9403c-c80c-4f87-aba9-aa247c492b37)
![Okami_SLUS-21115_20250220224141](https://github.com/user-attachments/assets/5f09e4d5-6fb0-4d34-a10e-01c42c0fa8d3)
![Okami_SLUS-21115_20250220224145](https://github.com/user-attachments/assets/cec2a7ce-80e5-4106-b6ec-ad63d344a87b)
![Okami_SLUS-21115_20250220224517](https://github.com/user-attachments/assets/a61cd67d-fb3d-4ffa-8910-bccd0caeec1d)
![Okami_SLUS-21115_20250220224515](https://github.com/user-attachments/assets/241c5198-3fc6-4e67-a3ed-907490adfe45)
![Okami_SLUS-21115_20250220225258](https://github.com/user-attachments/assets/49a5d47a-b555-46f2-b9da-d0681458d696)
![Okami_SLUS-21115_20250220225302](https://github.com/user-attachments/assets/74af8323-4a5f-4a1b-ae15-5a5cec7a498c)
