### PR TITLE
Fixes to RB:C1GP [SLPM-65897] WS patch + pnach for English patched version

### DIFF
--- a/patches/SLPM-65897_1C087362.pnach
+++ b/patches/SLPM-65897_1C087362.pnach
@@ -5,26 +5,26 @@ gsaspectratio=16:9
 author=wxvu & igorciz777
 
 //Rendering: General
-patch=1,EE,20167318,extended,3C043F10 //3C043F40
+patch=0,EE,20167318,extended,3C043F10 //3C043F40
 
 //Rendering: Reflections
-patch=1,EE,2016783C,extended,3C033F10 //3C033F40
+patch=0,EE,2016783C,extended,3C033F10 //3C033F40
 
 //Rendering: Rear View Mirror
-patch=1,EE,20167A58,extended,3C043F10 //3C043F40
+patch=0,EE,20167A58,extended,3C043F10 //3C043F40
 
 [Widescreen 16:10]
 gsaspectratio=Stretch
 author=wxvu & igorciz777
 
 //Rendering: General
-patch=1,EE,20167318,extended,3C043F20 //3C043F40
+patch=0,EE,20167318,extended,3C043F20 //3C043F40
 
 //Rendering: Reflections
-patch=1,EE,2016783C,extended,3C033F20 //3C033F40
+patch=0,EE,2016783C,extended,3C033F20 //3C033F40
 
 //Rendering: Rear View Mirror
-patch=1,EE,20167A58,extended,3C043F20 //3C043F40
+patch=0,EE,20167A58,extended,3C043F20 //3C043F40
 
 [No-Interlacing]
 gsinterlacemode=1

--- a/patches/SLPM-65897_9C4C9611.pnach
+++ b/patches/SLPM-65897_9C4C9611.pnach
@@ -5,26 +5,26 @@ gsaspectratio=16:9
 author=wxvu & igorciz777
 
 //Rendering: General
-patch=1,EE,20167318,extended,3C043F10 //3C043F40
+patch=0,EE,20167318,extended,3C043F10 //3C043F40
 
 //Rendering: Reflections
-patch=1,EE,2016783C,extended,3C033F10 //3C033F40
+patch=0,EE,2016783C,extended,3C033F10 //3C033F40
 
 //Rendering: Rear View Mirror
-patch=1,EE,20167A58,extended,3C043F10 //3C043F40
+patch=0,EE,20167A58,extended,3C043F10 //3C043F40
 
 [Widescreen 16:10]
 gsaspectratio=Stretch
 author=wxvu & igorciz777
 
 //Rendering: General
-patch=1,EE,20167318,extended,3C043F20 //3C043F40
+patch=0,EE,20167318,extended,3C043F20 //3C043F40
 
 //Rendering: Reflections
-patch=1,EE,2016783C,extended,3C033F20 //3C033F40
+patch=0,EE,2016783C,extended,3C033F20 //3C033F40
 
 //Rendering: Rear View Mirror
-patch=1,EE,20167A58,extended,3C043F20 //3C043F40
+patch=0,EE,20167A58,extended,3C043F20 //3C043F40
 
 [No-Interlacing]
 gsinterlacemode=1

--- a/patches/SLPM-65897_9C4C9611.pnach
+++ b/patches/SLPM-65897_9C4C9611.pnach
@@ -1,4 +1,4 @@
-gametitle=Racing Battle C1 Grand Prix (J)(SLPM-65897)
+gametitle=Racing Battle C1 Grand Prix (J)(SLPM-65897) (English Patched)
 
 [Widescreen 16:9]
 gsaspectratio=16:9


### PR DESCRIPTION
Adds widescreen rendering to mirrors and reflections
![patch](https://github.com/user-attachments/assets/067fe101-05ba-485c-ab6b-faa80a4e82c8)

Also adds a pnach file for the English patched version (CRC 9C4C9611)
https://github.com/igorciz777/RBC1GP-Translation-Pipeline/releases/

