### PR TITLE
Update patches

### DIFF
--- a/patches/SCES-55571_7030A01C.pnach
+++ b/patches/SCES-55571_7030A01C.pnach
@@ -21,10 +21,7 @@ description=Might need EE Overclock at 300%.
 patch=1,EE,E0010001,extended,00700EA0 //to avoid a bug if there is no profile
 patch=1,EE,203194C0,extended,00000000 //1440FFF5
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,00412E2C,word,3C050000
-patch=1,EE,00412E34,word,3C060050
-patch=1,EE,00412E3C,word,3C070001
+description=NTSC mode at start.
+patch=1,EE,0058A9B4,extended,00000022

--- a/patches/SLES-50731_1D2818AF.pnach
+++ b/patches/SLES-50731_1D2818AF.pnach
@@ -14,13 +14,14 @@ author=asasega
 description=Might need EE Overclock at 130%.
 patch=1,EE,00113E2C,word,2C420001
 
-[480p Mode]
-gsinterlacemode=1
-author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,00280754,word,24110000
-patch=1,EE,00280758,word,24120050
-patch=1,EE,00280764,word,24130001
+[NTSC Mode]
+author=Felixthecat1970
+description=NTSC mode at start.
+patch=0,EE,2032F290,extended,4353544E
+patch=0,EE,2032F294,extended,4741542E
+patch=0,EE,2032F298,extended,72723C2E
+patch=0,EE,2016F908,extended,0000102D
+patch=0,EE,201EEC0C,extended,0000102D
 
 [Trigger control mapppings]
 author=Silent

--- a/patches/SLES-51054_ACB1989A.pnach
+++ b/patches/SLES-51054_ACB1989A.pnach
@@ -8,7 +8,6 @@ patch=1,EE,0042F134,word,3FC71C65 //3F955553
 
 [50 FPS]
 author=PeterDelta
-description=Might need EE Overclock at 130%.
-patch=1,EE,0042F138,word,00000001
+description=Might need EE Overclock (130%).
+patch=1,EE,00106F64,word,24070001
 patch=1,EE,00431804,word,3F000000 //3F800000
-patch=1,EE,004317D4,word,3CA08889 //3C888889

--- a/patches/SLES-51195_C5473413.pnach
+++ b/patches/SLES-51195_C5473413.pnach
@@ -1,4 +1,4 @@
-gametitle=Harry Potter y la Cámara Secreta (S)[SLES-51195] CRC C5473413
+gametitle=Harry Potter y la Cámara Secreta (PAL-S) [SLES-51195] CRC C5473413
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -26,5 +26,10 @@ patch=1,EE,004e8eb4,word,34218e2a //3421aaab
 
 [50 FPS]
 author=asasega
-description=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
+description=Might need EE Overclock (130%).
 patch=1,EE,00544168,word,00000001
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=0,EE,001BDAD4,word,241001C0

--- a/patches/SLES-51787_62AB6416.pnach
+++ b/patches/SLES-51787_62AB6416.pnach
@@ -1,20 +1,10 @@
-gametitle=Harry Potter - Quidditch World Cup (PAL-M10) (SLES-51787)
+gametitle=Harry Potter - Quidditch World Cup (PAL-M10) (SLES-51787) 62AB6416
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=ElHecht
-
-// 16:9
-patch=1,EE,002af358,word,3c013f40 // 00000000 hor fov
-patch=1,EE,002af35c,word,4481f000 // 00000000
-patch=1,EE,002af364,word,461ebdc2 // 00000000
-
-// hardware rendering fix
-patch=1,EE,00358ae8,word,3c013e49 // 3c013f49 remove flickering
-
-// optional hud fix
-//patch=1,EE,002ae1d4,word,3c013f40 // 00000000
-//patch=1,EE,002ae1d8,word,4481f000 // 00000000
-//patch=1,EE,002ae1e4,word,461e0842 // 00000000
-
-
+author=PeterDelta
+description=Enable native widescreen
+patch=1,EE,00464C88,word,00000001
+patch=1,EE,004B5D54,word,00464C80
+patch=1,EE,00358BF0,word,24020000
+patch=1,EE,01DC41E0,word,00000001 //menu options

--- a/patches/SLES-51967_FDA10318.pnach
+++ b/patches/SLES-51967_FDA10318.pnach
@@ -25,19 +25,16 @@ author=asasega
 description=Might need EE Overclock at 130%.
 patch=1,EE,2011060C,extended,2C420001 //2C420002
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,003AF874,word,24110000
-patch=1,EE,003AF878,word,24120050
-patch=1,EE,003AF884,word,24130001
-patch=1,EE,004FEFF8,word,3C888889
+description=NTSC mode at start.
+patch=1,EE,002C5FC4,word,0000102D
 
-[Remove blur]
+[Remove Blur/Bloom]
 author=PeterDelta
-description=Remove blur effect
+description=Removes the post-processing blur/bloom effect
 patch=1,EE,204D9D10,word,00000000
+patch=1,EE,004FF998,word,01000100
 
 [Trigger control mappings]
 author=Silent

--- a/patches/SLES-52588_85931FDF.pnach
+++ b/patches/SLES-52588_85931FDF.pnach
@@ -1,4 +1,4 @@
-gametitle=Mercenaries - Playground of Destruction (PAL-E) (SLES-52588)
+gametitle=Mercenaries - Playground of Destruction (PAL-E) (SLES-52588) 85931FDF
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -26,4 +26,7 @@ patch=1,EE,004f2f3c,word,46030002 // 00000000 hud-identification fix
 patch=1,EE,004f2f40,word,461e0002 // 00000000 hud-identification fix
 patch=1,EE,004f2f44,word,080ce663 // 00000000 hud-identification fix
 
-
+[50 FPS]
+author=PeterDelta
+description=Might need EE Overclock (130%).
+patch=1,EE,003AD6B8,word,2C420001

--- a/patches/SLES-52678_2429905B.pnach
+++ b/patches/SLES-52678_2429905B.pnach
@@ -1,11 +1,8 @@
-gametitle=Viewtiful Joe [PAL-M5] (SLES_526.78)
+gametitle=Viewtiful Joe (PAL-M) SLES-52678 2429905B
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=El_Patas
-
-//Gameplay 16:9
-patch=1,EE,002B8304,word,3C01BF27 //3C01BF00 Y-FOV
-patch=1,EE,002C1458,word,3C013F20 //3C013F00 Zoom
-
-
+author=PeterDelta
+description=Renders the game in 16:9 aspect ratio
+patch=1,EE,00100E88,word,3C013FD2
+patch=1,EE,002AD2AC,word,10400039

--- a/patches/SLES-52725_CFB873AD.pnach
+++ b/patches/SLES-52725_CFB873AD.pnach
@@ -8,14 +8,25 @@ patch=1,EE,004F12DC,byte,01
 
 [50/60 FPS]
 author=asasega
-description=Might need EE Overclock at 130%.
+description=Might need EE Overclock (130%).
 patch=1,EE,201D7FBC,extended,2C420001
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,00421E54,word,24110000
-patch=1,EE,00421E58,word,24120050
-patch=1,EE,00421E64,word,24130001
-patch=1,EE,00563214,word,3C888889
+description=NTSC mode at start.
+patch=1,EE,0051715C,word,00000000
+
+[Remove Blur/Bloom]
+author=PeterDelta
+description=Removes the post-processing blur/bloom effect
+patch=1,EE,001D39D0,word,03E00008
+patch=1,EE,001D39D4,word,00000000
+patch=1,EE,00565E98,word,00000000
+patch=1,EE,00565F78,word,01000100
+
+[Widen headlight beam]
+author=PeterDelta
+description=Widens the headlight beam as seen in Underground
+patch=1,EE,00565FE8,word,3E400000
+patch=1,EE,00565A00,word,3F400000
+patch=1,EE,00565FEC,word,3EFA0000

--- a/patches/SLES-52942_EBE1972D.pnach
+++ b/patches/SLES-52942_EBE1972D.pnach
@@ -1,4 +1,4 @@
-gametitle=Midnight Club 3 - DUB Edition (PAL-M) (SLES-52942) EBE1972D
+gametitle=Midnight Club 3 - DUB Edition (PAL-M) SLES-52942 EBE1972D
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -8,5 +8,12 @@ patch=1,EE,00617D30,word,3FC71C66 //3F955554
 
 [50 FPS]
 author=PeterDelta
-description=Might need EE Overclock at 180%.
-patch=1,EE,00617D34,word,00000001 //00000002
+description=Might need EE Overclock (180%).
+patch=1,EE,001A7A74,word,24020001
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,00617EC4,word,00000000
+patch=1,EE,00617DA8,word,000001C0
+patch=1,EE,001BE4B8,word,14A0002F

--- a/patches/SLES-53154_26420115.pnach
+++ b/patches/SLES-53154_26420115.pnach
@@ -36,36 +36,3 @@ patch=1,EE,00144174,word,3C033F64
 patch=1,EE,001441C4,word,3C023F64
 patch=1,EE,0013D9D0,word,3C023F10
 patch=1,EE,0010EC74,word,3C0341E4
-
-[Widescreen/20:9]
-gsaspectratio=Stretch
-author=nemesis2000, El_Patas & Arapapa, converted by pgert
-patch=1,EE,0011C0D4,word,3C023F12
-patch=1,EE,0012E6EC,word,3C033F12
-patch=1,EE,001440F8,word,3C053F12
-patch=1,EE,00144174,word,3C033F12
-patch=1,EE,001441C4,word,3C023F12
-patch=1,EE,0013D9D0,word,3C023F55
-patch=1,EE,0010EC74,word,3C034192
-
-[Widescreen/21:9]
-gsaspectratio=Stretch
-author=nemesis2000, El_Patas & Arapapa, converted by pgert
-patch=1,EE,0011C0D4,word,3C023F1A
-patch=1,EE,0012E6EC,word,3C033F1A
-patch=1,EE,001440F8,word,3C053F1A
-patch=1,EE,00144174,word,3C033F1A
-patch=1,EE,001441C4,word,3C023F1A
-patch=1,EE,0013D9D0,word,3C023F60
-patch=1,EE,0010EC74,word,3C03419A
-
-[Widescreen/32:9]
-gsaspectratio=Stretch
-author=nemesis2000, El_Patas & Arapapa, converted by pgert
-patch=1,EE,0011C0D4,word,3C023EC0
-patch=1,EE,0012E6EC,word,3C033EC0
-patch=1,EE,001440F8,word,3C053EC0
-patch=1,EE,00144174,word,3C033EC0
-patch=1,EE,001441C4,word,3C023EC0
-patch=1,EE,0013D9D0,word,3C023FAB
-patch=1,EE,0010EC74,word,3C0242AB

--- a/patches/SLES-53557_692CBA8E.pnach
+++ b/patches/SLES-53557_692CBA8E.pnach
@@ -1,6 +1,23 @@
-gametitle=Need for Speed - Most Wanted [PAL-E] [SLES-53557]
+gametitle=Need for Speed - Most Wanted [PAL-E] [SLES-53557] 692CBA8E
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Widescreen fix
+patch=1,EE,00AAFD54,word,00000001
+patch=1,EE,0054BD38,word,3F400000
 
 [Remove Brown Filter]
 author=fobes
 description=Disables the brownish yellow post processing filter
 patch=1,EE,00551058,extended,20000001
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,00322DB4,word,0000102D
+
+[Remove Blur]
+author=PeterDelta
+description=Removes the blur effect
+patch=1,EE,00550424,word,00000000

--- a/patches/SLES-53559_CA2A1B04.pnach
+++ b/patches/SLES-53559_CA2A1B04.pnach
@@ -3,18 +3,21 @@ gametitle=Need for Speed - Most Wanted [PAL-M] [SLES-53559] CA2A1B04
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PeterDelta
-description=Enable native widescreen
-patch=1,EE,00AAF954,byte,01
+description=Widescreen fix
+patch=1,EE,00AAF954,word,00000001
+patch=1,EE,0054BD38,word,3F400000
 
 [Remove Brown Filter]
 author=fobes
 description=Disables the brownish yellow post processing filter
 patch=1,EE,00551058,extended,20000001
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
+author=Felixthecat1970
+description=NTSC mode at start.
+patch=0,EE,20322DB4,extended,0000102D
+
+[Remove Blur]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,004938DC,word,24110000
-patch=1,EE,004938E0,word,24120050
-patch=1,EE,004938EC,word,24130001
+description=Removes the blur effect
+patch=1,EE,00550424,word,00000000

--- a/patches/SLES-53728_B18DC525.pnach
+++ b/patches/SLES-53728_B18DC525.pnach
@@ -1,11 +1,14 @@
-gametitle=Harry Potter and the Goblet of Fire [PAL-M5] (SLES_537.28)
+gametitle=Harry Potter and the Goblet of Fire (PAL-M5) SLES-53728 B18DC525
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=El_Patas
-description=Widescreen Hack
+description=Renders the game in 16:9 aspect ratio
 //Gameplay 16:9
 patch=1,EE,0029FD74,word,3C013FE3 //3C013FAA
 patch=1,EE,0029FD78,word,34218E39 //3421AAAB
 
-
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,004DC4DC,word,00000000

--- a/patches/SLES-53729_0BC3B265.pnach
+++ b/patches/SLES-53729_0BC3B265.pnach
@@ -1,6 +1,6 @@
 gametitle=Battlefield 2 - Modern Combat (PAL-M) SLES-53729 0BC3B265
 
-[50 FPS]
+[50/60 FPS]
 author=PeterDelta
-description=Might need EE Overclock at 130%.
+description=Might need EE Overclock (130%).
 patch=1,EE,0022D9DC,word,24630001 //24630002

--- a/patches/SLES-53857_805C3B3A.pnach
+++ b/patches/SLES-53857_805C3B3A.pnach
@@ -1,6 +1,32 @@
-gametitle=Need for Speed - Most Wanted [Black Edition] [PAL-M] [SLES-53857]
+gametitle=Need for Speed - Most Wanted [Black Edition] [PAL-M] [SLES-53857] 805C3B3A
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Widescreen fix
+patch=1,EE,00AAF954,word,00000001
+patch=1,EE,0054BD38,word,3F400000
+
+[Languages]
+author=Felixthecat1970
+description=Set language in BIOS: Italian, Spanish, Dutch.
+patch=0,EE,003862E4,extended,0C0C4A80
+patch=0,EE,202797D4,extended,0C14CF2C
+patch=0,EE,202797F0,extended,0C14CF2C
+patch=0,EE,20533CB0,extended,3C030057
+patch=0,EE,20533CB4,extended,8C62EE08
+patch=0,EE,20533CB8,extended,2C5B0003
+patch=0,EE,20533CBC,extended,13600002
+patch=0,EE,20533CC0,extended,00000000
+patch=0,EE,20533CC4,extended,0000102D
+patch=0,EE,20533CC8,extended,03E00008
 
 [Remove Brown Filter]
 author=fobes
 description=Disables the brownish yellow post processing filter
 patch=1,EE,00551058,extended,20000001
+
+[NTSC Mode]
+author=Felixthecat1970
+description=NTSC mode at start.
+patch=0,EE,20322DB4,extended,0000102D

--- a/patches/SLES-54322_CF36D003.pnach
+++ b/patches/SLES-54322_CF36D003.pnach
@@ -1,18 +1,18 @@
-gametitle=Need for Speed - Carbon (PAL-S-I) SLES-54323 4078F8F1
+gametitle=Need for Speed - Carbon (PAL-E) SLES-54322 CF36D003
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PeterDelta
 description=Widescreen fix
-patch=1,EE,E0010000,extended,00A6E894
-patch=1,EE,00A6E894,extended,00000001
+patch=1,EE,E0010000,extended,00A6E494
+patch=1,EE,00A6E494,extended,00000001
 patch=1,EE,2061E7F8,extended,3F400000
 patch=1,EE,2061E810,extended,3F400000
 
 [NTSC Mode]
 author=PeterDelta
 description=NTSC mode at start.
-patch=1,EE,00394A84,word,0000102D
+patch=1,EE,00394A9C,word,0000102D
 
 [Remove Blur/Bloom]
 author=PeterDelta

--- a/patches/SLES-54324_26DFEE66.pnach
+++ b/patches/SLES-54324_26DFEE66.pnach
@@ -1,0 +1,21 @@
+gametitle=Need for Speed - Carbon (PAL-R) SLES-54324 26DFEE66
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Widescreen fix
+patch=1,EE,E0010000,extended,00A6E514
+patch=1,EE,00A6E514,extended,00000001
+patch=1,EE,2061E978,extended,3F400000
+patch=1,EE,2061E990,extended,3F400000
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,00394B9C,word,0000102D
+
+[Remove Blur/Bloom]
+author=PeterDelta
+description=Removes the post-processing blur/bloom effect
+patch=1,EE,006244C4,word,00000000
+patch=1,EE,006245F0,word,01000000

--- a/patches/SLES-54492_C2909885.pnach
+++ b/patches/SLES-54492_C2909885.pnach
@@ -1,4 +1,24 @@
-gametitle=Need for Speed - Carbon [Collector's Edition] (PAL-E) (SLES-54492)
+gametitle=Need for Speed - Carbon [Collector's Edition] (PAL-E) (SLES-54492) C2909885
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Widescreen fix
+patch=1,EE,E0010000,extended,00A6EC94
+patch=1,EE,00A6EC94,extended,00000001
+patch=1,EE,2061E678,extended,3F400000
+patch=1,EE,2061E690,extended,3F400000
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,003949E4,word,0000102D
+
+[Remove Blur/Bloom]
+author=PeterDelta
+description=Removes the post-processing blur/bloom effect
+patch=1,EE,006241C4,word,00000000
+patch=1,EE,006242F0,word,01000000
 
 [Fix Most Wanted Black Edition save detection]
 author=Silent

--- a/patches/SLES-54755_2609B672.pnach
+++ b/patches/SLES-54755_2609B672.pnach
@@ -2,6 +2,11 @@ gametitle=Transformers - The Game (PAL-E) SLES-54755 2609B672
 
 [50 FPS]
 author=PeterDelta
-description=Might need EE Overclock at 180%.
+description=Might need EE Overclock (180%).
 patch=1,EE,00382D80,word,28420001 //28420002
 patch=1,EE,00434E94,word,3C013F00 //3C013F80
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,004A4660,word,00000000

--- a/patches/SLES-54756_F453BCD9.pnach
+++ b/patches/SLES-54756_F453BCD9.pnach
@@ -2,6 +2,11 @@ gametitle=Transformers - The Game (PAL-S-F) SLES-54756 F453BCD9
 
 [50 FPS]
 author=PeterDelta
-description=Might need EE Overclock at 180%.
+description=Might need EE Overclock (180%).
 patch=1,EE,00382DA8,word,28420001 //28420002
 patch=1,EE,00434EBC,word,3C013F00 //3C013F80
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,004A4660,word,00000000

--- a/patches/SLES-54779_01A9BF0E.pnach
+++ b/patches/SLES-54779_01A9BF0E.pnach
@@ -1,16 +1,23 @@
-gametitle=Harry Potter and The Order of the Phoenix (E)(SLES-54779)
+gametitle=Harry Potter and the Order of the Phoenix (PAL-M) SLES-54779 01A9BF0E
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-description=Widescreen Hack
-//Widescreen hack 16:9
+description=Widescreen fix
+patch=1,EE,004C42C8,word,24020002 //30420003 Force turn on Internal Widescreen
+patch=1,EE,00354528,word,3C013F20 //3C013F00 Zoom fix
 
-//Force turn on Internal Widescreen
-patch=1,EE,004c42c8,word,24020002 //30420003
+[50 FPS]
+author=PeterDelta
+description=Might need EE Overclock (130%).
+patch=1,EE,0065AA04,word,00000001
 
-//Zoom fix
-//003f013c 00108144 02000146 (2nd)
-patch=1,EE,00354528,word,3c013f20 //3c013f00
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,005990EC,word,00000000
 
-
+[Remove Blur/Bloom]
+author=PeterDelta
+description=Removes the post-processing blur/bloom effect
+patch=1,EE,00324908,word,00000000

--- a/patches/SLES-55004_9E457DD6.pnach
+++ b/patches/SLES-55004_9E457DD6.pnach
@@ -8,10 +8,7 @@ patch=1,EE,20168A10,extended,24020001 //li v0, 1
 patch=1,EE,206828D8,extended,3F400000 //Horizontal: 0.75f Corrects Aspect Ratio
 patch=1,EE,206828DC,extended,3F8CCCCD //Vertical: 1.10f
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,00587054,word,24110000
-patch=1,EE,00587058,word,24120050
-patch=1,EE,00587064,word,24130001
+description=NTSC mode at start.
+patch=1,EE,0041900C,word,0000102D

--- a/patches/SLES-55198_37245C3F.pnach
+++ b/patches/SLES-55198_37245C3F.pnach
@@ -1,4 +1,4 @@
-gametitle=Iron Man SLUS_217.39
+gametitle=Iron Man (PAL-M) SLES-55198 37245C3F
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -7,8 +7,13 @@ description=Widescreen Hack
 patch=1,EE,20148FD0,extended,3C0C3FAA
 patch=1,EE,20148FD8,extended,358CAAAB
 
-
-[60 FPS]
+[50/60 FPS]
 author=asasega
-description=Unlocked at 60 FPS. Might need enable 180% EE Overclock to be stable.
+description=Might need EE Overclock (180%).
 patch=1,EE,00159354,word,2C620000
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,00431D7C,word,4353544E
+patch=1,EE,00431D80,word,52454400

--- a/patches/SLES-55249_CA5F8BC1.pnach
+++ b/patches/SLES-55249_CA5F8BC1.pnach
@@ -1,0 +1,12 @@
+gametitle=Harry Potter and the Half-Blood Prince (PAL-M) SLES-55249 CA5F8BC1
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Widescreen fix
+patch=1,EE,003C8F60,word,3C013F17
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,005616B4,word,00000000

--- a/patches/SLES-55351_422281E6.pnach
+++ b/patches/SLES-55351_422281E6.pnach
@@ -1,0 +1,17 @@
+gametitle=Need for Speed - Undercover (PAL-S-I) SLES-55351 422281E6
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Widescreen fix
+patch=1,EE,006535B0,word,3F400000
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,003D180C,word,0000102D
+
+[Remove Blur]
+author=PeterDelta
+description=Removes the blur effect
+patch=1,EE,0065CC7C,word,00000000

--- a/patches/SLES-55353_A2BFF202.pnach
+++ b/patches/SLES-55353_A2BFF202.pnach
@@ -1,0 +1,17 @@
+gametitle=Need for Speed - Undercover (PAL-R) SLES-55353 A2BFF202
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Widescreen fix
+patch=1,EE,00653630,word,3F400000
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,003D1824,word,0000102D
+
+[Remove Blur]
+author=PeterDelta
+description=Removes the blur effect
+patch=1,EE,0065CCFC,word,00000000

--- a/patches/SLUS-20209_E5F2DF38.pnach
+++ b/patches/SLUS-20209_E5F2DF38.pnach
@@ -4,10 +4,10 @@ gametitle=Midnight Club II (U)(SLUS-20209) E5F2DF38
 gsaspectratio=16:9
 author=PeterDelta
 description=Renders the game in 16:9 aspect ratio
-patch=1,EE,0042FAB4,word,3FC71CEA //3F955553
+patch=1,EE,0042FAB4,word,3FC71C65 //3F955553
 
 [60 FPS]
-author=asasega
-description=Unlocked at 60 FPS. Might need enable 130% EE Overclock to be stable.
-patch=1,EE,2042FAB8,word,00000001 //FPS
-patch=1,EE,20432164,word,3C888889
+author=asasega & PeterDelta
+description=Might need EE Overclock (130%).
+patch=1,EE,00106F64,word,24070001
+patch=1,EE,00432164,word,3C888889

--- a/patches/SLUS-20769_39E7ECF4.pnach
+++ b/patches/SLUS-20769_39E7ECF4.pnach
@@ -1,20 +1,10 @@
-gametitle=Harry Potter - Quidditch World Cup (NTSC-U)
+gametitle=Harry Potter - Quidditch World Cup (NTSC-U) SLUS-20769 39E7ECF4
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=ElHecht
-
-// 16:9
-patch=1,EE,002af388,word,3c013f40 // 00000000 hor fov
-patch=1,EE,002af38c,word,4481f000 // 00000000
-patch=1,EE,002af394,word,461ebdc2 // 00000000
-
-// hardware rendering fix
-patch=1,EE,00358ae8,word,3c013e49 // 3c013f49 remove flickering
-
-// optional hud fix
-//patch=1,EE,002ae204,word,3c013f40 // 00000000
-//patch=1,EE,002ae208,word,4481f000 // 00000000
-//patch=1,EE,002ae214,word,461e0842 // 00000000
-
-
+author=PeterDelta
+description=Enable native widescreen
+patch=1,EE,00464C88,word,00000001
+patch=1,EE,004B5D54,word,00464C80
+patch=1,EE,00358BF0,word,24020000
+patch=1,EE,01DF61E0,word,00000001 //menu options

--- a/patches/SLUS-20926_51E019BC.pnach
+++ b/patches/SLUS-20926_51E019BC.pnach
@@ -1,4 +1,4 @@
-gametitle=Harry Potter and the Prisoner of Azkaban (PAL-M) SLES-52440 51E019BC
+gametitle=Harry Potter and the Prisoner of Azkaban (NTSC-U) SLUS-20926 51E019BC
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -17,15 +17,10 @@ author=PeterDelta
 description=Removes black bars in cutscenes. HUD keeps visible
 patch=1,EE,004D93C0,extended,00000000
 
-[50 FPS]
+[60 FPS]
 author=asasega
 description=Might need EE Overclock (130%).
 patch=1,EE,2047B81C,word,00000001
-
-[NTSC Mode]
-author=PeterDelta
-description=NTSC mode at start.
-patch=0,EE,00132110,word,240501C0
 
 [Remove Blur/Bloom]
 author=PeterDelta

--- a/patches/SLUS-20951_080D5356.pnach
+++ b/patches/SLUS-20951_080D5356.pnach
@@ -1,9 +1,8 @@
-gametitle=Viewtiful Joe SLUS_209.51
+gametitle=Viewtiful Joe (NTSC-U) SLUS-20951 080D5356
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-description=Widescreen Hack
-patch=1,EE,002b4904,word,3c01bf22
-patch=1,EE,002bce28,word,3c013f22
-
-
+author=PeterDelta
+description=Renders the game in 16:9 aspect ratio
+patch=1,EE,00100E88,word,3C013FD2
+patch=1,EE,002A98AC,word,10400039

--- a/patches/SLUS-21267_270F8C03.pnach
+++ b/patches/SLUS-21267_270F8C03.pnach
@@ -1,6 +1,18 @@
 gametitle=Need for Speed - Most Wanted [NTSC-U] [SLUS-21267]
 
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Widescreen fix
+patch=1,EE,00AAFDD4,word,00000001
+patch=1,EE,0054BA38,word,3F400000
+
 [Remove Brown Filter]
 author=fobes
 description=Disables the brownish yellow post processing filter
 patch=1,EE,00550D58,extended,20000001
+
+[Remove Blur]
+author=PeterDelta
+description=Removes the blur effect
+patch=1,EE,0055014C,word,00000000

--- a/patches/SLUS-21493_7841A89E.pnach
+++ b/patches/SLUS-21493_7841A89E.pnach
@@ -1,4 +1,19 @@
-gametitle=Need for Speed - Carbon (NTSC-U) (SLUS-21493)
+gametitle=Need for Speed - Carbon (NTSC-U) (SLUS-21493) 7841A89E
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Widescreen fix
+patch=1,EE,E0010000,extended,00A6E994
+patch=1,EE,00A6E994,extended,00000001
+patch=1,EE,2061E4F8,extended,3F400000
+patch=1,EE,2061E510,extended,3F400000
+
+[Remove Blur/Bloom]
+author=PeterDelta
+description=Removes the post-processing blur/bloom effect
+patch=1,EE,00624044,word,00000000
+patch=1,EE,00624170,word,01000000
 
 [Fix Most Wanted Black Edition save detection]
 author=Silent

--- a/patches/SLUS-21619_4C01B1B0.pnach
+++ b/patches/SLUS-21619_4C01B1B0.pnach
@@ -1,16 +1,18 @@
-gametitle=Harry Potter and The Order of the Phoenix (U)(SLUS-21619)
+gametitle=Harry Potter and the Order of the Phoenix (NTSC-U) SLUS-21619 4C01B1B0
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
+description=Widescreen fix
+patch=1,EE,004BF588,word,24020002 //30420003 Force turn on Internal Widescreen
+patch=1,EE,00350750,word,3C013F20 //3C013F00 Zoom fix
 
-//Widescreen hack 16:9
+[60 FPS]
+author=PeterDelta
+description=Might need EE Overclock (130%).
+patch=1,EE,00655B84,word,00000001
 
-//Force turn on Internal Widescreen
-patch=1,EE,004bf588,word,24020002 //30420003
-
-//Zoom fix
-//003f013c 00108144 02000146 (2nd)
-patch=1,EE,00350750,word,3c013f20 //3c013f00
-
-
+[Remove Blur/Bloom]
+author=PeterDelta
+description=Removes the post-processing blur/bloom effect
+patch=1,EE,00320B30,word,00000000


### PR DESCRIPTION
I have replaced the patches that force 480p with ntsc to make it more accurate, in those where I had to correct the speed it is no longer necessary, and the image is well framed. Although visually there is no difference in pcsx2, when putting them on the ps2 the 480p patch the image appears green (possibly because my cable is not sync on green or because of the tv... and you have to change RGB to YCbCr) and with the ntsc patch it appears in color.

![Harry Potter - Quidditch World Cup_SLES-51787_20250226201206](https://github.com/user-attachments/assets/6f801db7-faae-4b58-a1ee-5d558fe987e5)
![Harry Potter - Quidditch World Cup_SLES-51787_20250226201220](https://github.com/user-attachments/assets/68fd1226-a97c-4878-9b0f-d1221bc76c1d)
The current patch has texture glitches, luckily the game has native widescreen, I activate it from the beginning so I don't have to go to options every time we want to play
____________
![Need for Speed - Underground 2_SLES-52725_20250221150638](https://github.com/user-attachments/assets/a25151cb-4bea-4657-b82a-b7044d097c4b)
![Need for Speed - Underground 2_SLES-52725_20250221150641](https://github.com/user-attachments/assets/3f2c8a0d-7261-4a66-a657-19a4a74c03f2)
![Need for Speed - Underground 2_SLES-52725_20250221142018](https://github.com/user-attachments/assets/5dd0ae27-15c6-4ed5-a4ab-dc2305670bc1)
![Need for Speed - Underground 2_SLES-52725_20250221142031](https://github.com/user-attachments/assets/1c0a78ed-6b9e-462a-acb1-2bd576f19b5a)
![Need for Speed - Underground 2_SLES-52725_20250218205304](https://github.com/user-attachments/assets/d825c50d-6741-44c7-a79a-9af435046a74)
![Need for Speed - Underground 2_SLES-52725_20250218205109](https://github.com/user-attachments/assets/19605c6b-1123-4c1d-9e2f-ea17be7cf212)
________________
![Need for Speed - Carbon_SLES-54323_20250218210045](https://github.com/user-attachments/assets/25ce16cb-55cd-4c3a-9496-8cfbb0a1aadd)
![Need for Speed - Carbon_SLES-54323_20250218210154](https://github.com/user-attachments/assets/0bf6e76c-4469-434d-9bf6-383628929a97)
![Need for Speed - Underground_SLES-51967_20250218205619](https://github.com/user-attachments/assets/221ff7f7-ca17-4927-a773-51d0d9c3caef)
![Need for Speed - Underground_SLES-51967_20250218205657](https://github.com/user-attachments/assets/63458e8a-bb75-4748-8438-730884aa7152)

Bloom was removed to avoid that ghosting effect of the lights without affecting the lighting.
______________
![Need for Speed - Undercover_SLES-55351_20250226220911](https://github.com/user-attachments/assets/bb7f26e3-3ddb-4a32-a237-11ee48ba89ab)
4:3 original
![Need for Speed - Undercover_SLES-55351_20250226220739](https://github.com/user-attachments/assets/85200923-b858-4ed3-923b-195649e37c00)
16:9 fix
![Need for Speed - Undercover_SLES-55351_20250226220704](https://github.com/user-attachments/assets/4f9eb568-86e1-4e57-967e-3fd61a88936f)
16:9 original
With carbon and most wanted they are also corrected
___________
![The Bard's Tale_SLES-53154_20250216005450](https://github.com/user-attachments/assets/4557125d-2629-4fab-bf99-ed85158d26ed)
![The Bard's Tale_SLES-53154_20250216005439](https://github.com/user-attachments/assets/9baa63e0-371a-4257-bd9e-1f53770a2800)
20:9, 21:9: When moving around the map, the game seems to have difficulty rendering the map

![The Bard's Tale_SLES-53154_20250226213559](https://github.com/user-attachments/assets/21495b85-6025-45e8-8613-39be0622d25a)
32:9: When starting the letters are not displayed
![The Bard's Tale_SLES-53154_20250226214307](https://github.com/user-attachments/assets/4f0f1e4d-f85a-4b0b-96d1-7c732b0b3ce5)
Example of 16:9 patch, it shows correctly
_____________
![Viewtiful Joe_SLES-52678_20250226215146](https://github.com/user-attachments/assets/a08285f6-2bd2-4820-a51e-da0f16b463e9)
Current patch: Missing shadows and changed effects

![Viewtiful Joe_SLES-52678_20250212221945](https://github.com/user-attachments/assets/8e6c37fd-9561-40b4-a748-a7f1b9337439)
![Viewtiful Joe_SLES-52678_20250212234808](https://github.com/user-attachments/assets/b4bebbd7-4cc1-41f1-a459-ad084aa71f23)
___________
![Harry Potter and the Prisoner of Azkaban_SLES-52440_20250208165904](https://github.com/user-attachments/assets/a9626d5c-fc59-443a-83b5-46be7c8ed851)
![Harry Potter and the Prisoner of Azkaban_SLES-52440_20250208234336](https://github.com/user-attachments/assets/03f2ed2b-0a29-4120-9442-172f5af65650)
Fix
