### PR TITLE
Burnout 1 Depth of Field patch

### DIFF
--- a/patches/SLUS-20307_4783F7ED.pnach
+++ b/patches/SLUS-20307_4783F7ED.pnach
@@ -3,4 +3,6 @@ description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,2021D4A8,word,00002025
 
-
+[Disable Depth of Field]
+description=Disables the Depth of Field effect that subtly blurs distant objects.
+patch=1,EE,20372D60,extended,00000000

--- a/patches/SLUS-20307_4783F7ED.pnach
+++ b/patches/SLUS-20307_4783F7ED.pnach
@@ -5,4 +5,5 @@ patch=1,EE,2021D4A8,word,00002025
 
 [Disable Depth of Field]
 description=Disables the Depth of Field effect that subtly blurs distant objects.
+author=escape209
 patch=1,EE,20372D60,extended,00000000


### PR DESCRIPTION
![animated](https://github.com/user-attachments/assets/255acf02-ddba-4b7c-b237-e5485fb27b9a)

This patch disables the very subtle depth of field effect. It's not very well implemented in the original game, as it mainly just serves to add shimmering to the tops of distant structures. It's also barely visible at native resolution.