### PR TITLE
WS: Disable NTSC Family Guy WS

### DIFF
--- a/patches/SLUS-21560_D2790A77.pnach
+++ b/patches/SLUS-21560_D2790A77.pnach
@@ -1,14 +1,14 @@
-gametitle=Family Guy (SLUS-20718)
+gametitle=Family Guy - Video Game (SLUS-21560)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=Brandondorf9999
-description=Widescreen update
-patch=1,EE,0011B3A8,word,00000000 //10400009
-patch=1,EE,0011B3BC,word,3C013F80 //3C013F59
-patch=1,EE,0011B3C0,word,34210000 //3421999A
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=Brandondorf9999
+//description=Widescreen update. Breaks eye textures on models.
+//patch=1,EE,0011B3A8,word,00000000 //10400009
+//patch=1,EE,0011B3BC,word,3C013F80 //3C013F59
+//patch=1,EE,0011B3C0,word,34210000 //3421999A
 
-[60 FPS]
-author=asasega
-description=Patches the game to run at 60 FPS.
-patch=1,EE,20259698,word,00000001 //00000002
+//[60 FPS]
+//author=asasega
+//description=Patches the game to run at 60 FPS. Breaks collision in the Brian stages.
+//patch=1,EE,20259698,word,00000001 //00000002


### PR DESCRIPTION
Seems to break the eyes on models.

![image](https://github.com/user-attachments/assets/ed2ecc1a-bd59-44ea-993f-34add3c759bf)