### PR TITLE
SC4 (NTSC-U) support

### DIFF
--- a/patches/SLUS-21356_0198F1AD.pnach
+++ b/patches/SLUS-21356_0198F1AD.pnach
@@ -1,4 +1,4 @@
-gametitle=Tom Clancy's Splinter Cell 4: Double Agent * NTSC-U * SLUS-21356 * C0498D24
+gametitle=Tom Clancy's Splinter Cell 4: Double Agent * NTSC-U * SLUS-21356 * 0198F1AD
 // CRC shifts from C0498D24 to 0198F1AD (SC4_OFF.ELF) when selecting Single Player mode.
 
 [Widescreen 16:9]


### PR DESCRIPTION
According to @Gabominated the CRC for Splinter Cell 4: Double Agent (NTSC-U)
 shifts from C0498D24 to 0198F1AD when selecting Single Player mode.
https://github.com/Gabominated/PCSX2/blob/main/PCSX2%20Patches/SLUS-21356_0198F1AD.pnach
This PR adds required support for this.
