### PR TITLE
Add Air Ranger 2 Plus anti-blur patch

### DIFF
--- a/patches/SLPM-65409_EE61D258.pnach
+++ b/patches/SLPM-65409_EE61D258.pnach
@@ -1,0 +1,8 @@
+gametitle=Air Ranger 2 Plus - Rescue Helicopter (NTSC-J) (SLPM-65409)
+
+[Anti-Blur]
+author=Souzooka
+description=Removes depth-of-field effect (must be initially enabled outside mission)
+
+patch=0,EE,201DAD50,extended,00000000 // nop // removes call to gplEffeDepthSet when mission begins
+patch=0,EE,201DB014,extended,00000000 // nop // removes call to gplEffeDepthClr when mission ends


### PR DESCRIPTION
Gives the player glasses so that they can properly fly a helicopter.

Must be enabled outside a mission to properly stop the depth of field task from spawning.

Before:
![Air Ranger 2 Plus - Rescue Helicopter_SLPM-65409_20250309170122](https://github.com/user-attachments/assets/97e5c3e2-16c4-4b43-a5c0-47d0c6d464c1)

After:
![Air Ranger 2 Plus - Rescue Helicopter_SLPM-65409_20250309170747_(2)](https://github.com/user-attachments/assets/46d0ddb4-3828-46a5-bd16-e5b19af37cca)
