### PR TITLE
GunCon2 Flash Removal for various games

### DIFF
--- a/patches/SLES-50650_CD3ED649.pnach
+++ b/patches/SLES-50650_CD3ED649.pnach
@@ -14,3 +14,9 @@ patch=1,EE,0033952c,word,34436873 // 344345a2 hor fov
 //patch=1,EE,2037e2e0,extended,41100000 // tori_z (distance)
 
 
+[No GunCon Flash]
+author=Souzooka
+description=Removes flash effect when using the GunCon2 Controller
+
+patch=0,EE,2035FC30,extended,03E00008 // jr ra  // Stub disp_flash function
+patch=0,EE,2035FC34,extended,00000000 // nop

--- a/patches/SLPM-65059_35FB8EE2.pnach
+++ b/patches/SLPM-65059_35FB8EE2.pnach
@@ -14,3 +14,9 @@ patch=1,EE,00333afc,word,34436873 // 344345a2 hor fov
 //patch=1,EE,20375c60,extended,41100000 // tori_z (distance)
 
 
+[No GunCon Flash]
+author=Souzooka
+description=Removes flash effect when using the GunCon2 Controller
+
+patch=0,EE,20359800,extended,03E00008 // jr ra  // Stub disp_flash function
+patch=0,EE,20359804,extended,00000000 // nop

--- a/patches/SLUS-20219_D5D560FF.pnach
+++ b/patches/SLUS-20219_D5D560FF.pnach
@@ -10,3 +10,10 @@ author=kozarovv
 description=Sound fix for stuttering glitchy audio during FMV/cut-scenes
 patch=1,EE,00154954,extended,10000009
 //Fix code was posted at PCSX2 wiki. Additional info given was "Skip 1200000 cycles loop - fix audio."
+
+[No GunCon Flash]
+author=Souzooka
+description=Removes flash effect when using the GunCon2 Controller
+
+patch=0,EE,20120328,extended,03E00008 // jr ra  // Stub guncon2 flash function
+patch=0,EE,2012032C,extended,00000000 // nop

--- a/patches/SLUS-20221_7FBCDA34.pnach
+++ b/patches/SLUS-20221_7FBCDA34.pnach
@@ -39,3 +39,9 @@ patch=1,EE,001aedc8,word,461b0842 // 46040842 crosshair/aiming fix unit vector
 [Remove Blackbars]
 description=Removes black bars in cutscenes
 patch=1,EE,001ffc38,word,3c030000 // 3c034420
+
+[No GunCon Flash]
+author=Souzooka
+description=Removes flash effect when using the GunCon2 Controller
+
+patch=0,EE,201EC410,extended,00000000 // nop // Removes call to DispGunFlash

--- a/patches/SLUS-20645_7290669C.pnach
+++ b/patches/SLUS-20645_7290669C.pnach
@@ -6,3 +6,9 @@ description=Widescreen Hack
 patch=1,EE,0033976c,word,3f400000
 
 
+[No GunCon Flash]
+author=Souzooka
+description=Removes flash effect when using the GunCon2 Controller
+
+patch=0,EE,201AC7F0,extended,03E00008 // jr ra  // Stub guncon2 flash function
+patch=0,EE,201AC7F4,extended,00000000 // nop


### PR DESCRIPTION
Adds GunCon2 flash effect removal when firing guns for the following titles:

Resident Evil - Survivor 2 - Code - Veronica (EU)
Gun Survivor 2 - BioHazard Code - Veronica (JP)
Vampire Night (US)
Time Crisis 2 (US)
Time Crisis 3 (US)

Might port them to other regions sometime.