### PR TITLE
SpyHunter Widescreen and 50/60 FPS patches

### DIFF
--- a/patches/SLES-50268_B5BF9785.pnach
+++ b/patches/SLES-50268_B5BF9785.pnach
@@ -1,0 +1,26 @@
+gametitle=Spy Hunter (PAL) (SLES-50268)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Souzooka
+description=16:9 3D
+
+// Replace a call to vkWindow::getPixelAspectRatio with our own constant value
+patch=0,EE,20285084,extended,3C013FF3   // lui at,0x3FF3 // 1.8984375f
+patch=0,EE,20285088,extended,44810000   // mtc1 at,f00
+
+[50 FPS]
+author=Souzooka
+description=Runs the game at 50 FPS; 180% EE Cycle Rate recommended
+
+// NOTE: Player car is slightly less grippy at 50fps
+
+// NOP out a wait loop
+patch=0,EE,202AC81C,extended,00000000   // nop
+
+// When on top of an enemy oil slick, the player's steering direction is multiplied by a constant value each frame
+// This is the multiplier and is modified to behave similarly to 30fps (this was the same original value on NTSC and PAL, so eh)
+patch=0,EE,20110C70,extended,3C013F9C   // lui at,0x3F9C
+patch=0,EE,20110C74,extended,3421CCCD   // ori at,at,0xCCCD
+patch=0,EE,20113FA4,extended,3C013F9C   // lui at,0x3F9C
+patch=0,EE,20113FA8,extended,3421CCCD   // ori at,at,0xCCCD

--- a/patches/SLUS-20056_E3ADA82E.pnach
+++ b/patches/SLUS-20056_E3ADA82E.pnach
@@ -1,14 +1,26 @@
-gametitle=Spy Hunter (SLUS-20056)
+gametitle=Spy Hunter (NTSC-U) (SLUS-20056)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-description=Widescreen Patch (16:9) by Monsterjamp
+author=Souzooka
+description=16:9 3D
 
-//FOV
-patch=1,EE,20393FD0,word,3F400000
+// Replace a call to vkWindow::getPixelAspectRatio with our own constant value
+patch=0,EE,20288774,extended,3C013FA0   // lui at,0x3FA0 // 1.25f
+patch=0,EE,20288778,extended,44810000   // mtc1 at,f00
 
-//Prevents objects from disappearing from sides of screen
-patch=1,EE,2196FE00,word,3F0CCCCD
-patch=1,EE,2196FDE0,word,BF0CCCCD
+[60 FPS]
+author=Souzooka
+description=Runs the game at 60 FPS
 
+// NOTE: Player car is slightly less grippy at 60fps
 
+// NOP out a wait loop
+patch=0,EE,202AFECC,extended,00000000   // nop
+
+// When on top of an enemy oil slick, the player's steering direction is multiplied by a constant value each frame
+// This is the multiplier and is modified to behave similarly to 30fps
+patch=0,EE,20110D18,extended,3C013F9C   // lui at,0x3F9C
+patch=0,EE,20110D1C,extended,3421CCCD   // ori at,at,0xCCCD
+patch=0,EE,2011404C,extended,3C013F9C   // lui at,0x3F9C
+patch=0,EE,20114050,extended,3421CCCD   // ori at,at,0xCCCD


### PR DESCRIPTION
Adds 50/60fps patches to SpyHunter. Also adds widescreen patches, replacing the US patch, which appears to have culling issues.

The original patch seems to have conditions to fix culling issues, but these affect addresses which are in the heap (0x196FE00 and 0x196FDE0) so if this worked at one point, it no longer does.

Old patch:
![Spy Hunter_SLUS-20056_20250309204405](https://github.com/user-attachments/assets/b9a75526-d4b0-4bab-9a6a-97a1dbb430bf)

New patch:
![Spy Hunter_SLUS-20056_20250309204618](https://github.com/user-attachments/assets/8942f58c-5f80-4dec-a26b-041c9bf56fc1)
