### PR TITLE
NFS Underground: SilentPatch

### DIFF
--- a/patches/SLES-51967_FDA10318.pnach
+++ b/patches/SLES-51967_FDA10318.pnach
@@ -140,3 +140,32 @@ patch=0,EE,204CBA80,extended,B2D0DA8B
 patch=0,EE,204CBA84,extended,B2D0DA8B
 patch=0,EE,204CBA88,extended,B2D0DA8B
 patch=0,EE,204CBA8C,extended,B2D0DA8B
+
+[SilentPatch]
+author=Silent
+description=Fixes the drift track record magazine unlock conditions, drift track high scores, and more.
+
+// Fix the drift score magazine taking a best lap score and dividing it by laps.
+// Also fix the high score in the menu displaying style points instead of the full score.
+patch=0,EE,2014A738,extended,46000840 // add.s f01,f01,f00
+patch=0,EE,201DB1D4,extended,00000000
+patch=0,EE,201DB1D8,extended,00000000
+patch=0,EE,201DB1E4,extended,E62000C4 // swc1 f00,0xC4(s1)
+
+patch=0,EE,201D78A4,extended,0C0F7F7C // jal 0x003DFDF0
+patch=0,EE,201D78A8,extended,C60C00C4 // lwc1 f12,0xC4(s0)
+
+patch=0,EE,203DFDF0,extended,46006324 // cvt.w.s f12,f12
+patch=0,EE,203DFDF4,extended,0809796C // j 0x0025E5B0
+patch=0,EE,203DFDF8,extended,44056000 // mfc1 a1,f12
+
+patch=0,EE,101D7584,extended,C4
+patch=0,EE,101D75D0,extended,C4
+patch=0,EE,101D743C,extended,C4
+patch=0,EE,201D75E0,extended,00000000 // Don't round up the score
+
+
+// Fix a buffer overflow in DriverInfo::DriverInfo because the OpponentDesc has 8 bytes for the driver name
+// and 'SAMANTHA' overflows it. Later PC and PS2 releases enlarged this buffer to 12 bytes, but we don't have this luxury.
+patch=0,EE,201482B4,extended,A0A00744 // sb zero,0x744(a1)
+patch=0,EE,201E32F4,extended,0C0520AD // jal 0x001482B4

--- a/patches/SLKA-25136_C5D0EBD2.pnach
+++ b/patches/SLKA-25136_C5D0EBD2.pnach
@@ -121,3 +121,26 @@ patch=0,EE,204D6C00,extended,B2D0DA8B
 patch=0,EE,204D6C04,extended,B2D0DA8B
 patch=0,EE,204D6C08,extended,B2D0DA8B
 patch=0,EE,204D6C0C,extended,B2D0DA8B
+
+[SilentPatch]
+author=Silent
+description=Fixes the drift track record magazine unlock conditions, drift track high scores, and more.
+
+// Fix the drift score magazine taking a best lap score and dividing it by laps.
+// Also fix the high score in the menu displaying style points instead of the full score.
+patch=0,EE,2014BC60,extended,46000840 // add.s f01,f01,f00
+patch=0,EE,201DCF6C,extended,00000000
+patch=0,EE,201DCF70,extended,00000000
+patch=0,EE,201DCF7C,extended,E62000C4 // swc1 f00,0xC4(s1)
+
+patch=0,EE,201D95EC,extended,0C0F9338 // jal 0x003E4CE0
+patch=0,EE,201D95F0,extended,C60C00C4 // lwc1 f12,0xC4(s0)
+
+patch=0,EE,203E4CE0,extended,46006324 // cvt.w.s f12,f12
+patch=0,EE,203E4CE4,extended,0809870C // j 0x00261C30
+patch=0,EE,203E4CE8,extended,44056000 // mfc1 a1,f12
+
+patch=0,EE,101D92CC,extended,C4
+patch=0,EE,101D9318,extended,C4
+patch=0,EE,101D9184,extended,C4
+patch=0,EE,201D9328,extended,00000000 // Don't round up the score

--- a/patches/SLPM-65471_4608D01A.pnach
+++ b/patches/SLPM-65471_4608D01A.pnach
@@ -119,3 +119,32 @@ patch=0,EE,204CCA80,extended,B2D0DA8B
 patch=0,EE,204CCA84,extended,B2D0DA8B
 patch=0,EE,204CCA88,extended,B2D0DA8B
 patch=0,EE,204CCA8C,extended,B2D0DA8B
+
+[SilentPatch]
+author=Silent
+description=Fixes the drift track record magazine unlock conditions, drift track high scores, and more.
+
+// Fix the drift score magazine taking a best lap score and dividing it by laps.
+// Also fix the high score in the menu displaying style points instead of the full score.
+patch=0,EE,2014A8C0,extended,46000840 // add.s f01,f01,f00
+patch=0,EE,201DB35C,extended,00000000
+patch=0,EE,201DB360,extended,00000000
+patch=0,EE,201DB36C,extended,E62000C4 // swc1 f00,0xC4(s1)
+
+patch=0,EE,201D7A2C,extended,0C0F822C // jal 0x003E08B0
+patch=0,EE,201D7A30,extended,C60C00C4 // lwc1 f12,0xC4(s0)
+
+patch=0,EE,203E08B0,extended,46006324 // cvt.w.s f12,f12
+patch=0,EE,203E08B4,extended,08097B28 // j 0x0025ECA0
+patch=0,EE,203E08B8,extended,44056000 // mfc1 a1,f12
+
+patch=0,EE,101D770C,extended,C4
+patch=0,EE,101D7758,extended,C4
+patch=0,EE,101D75C4,extended,C4
+patch=0,EE,101D7768,extended,00000000 // Don't round up the score
+
+
+// Fix a buffer overflow in DriverInfo::DriverInfo because the OpponentDesc has 8 bytes for the driver name
+// and 'SAMANTHA' overflows it. Later PC and PS2 releases enlarged this buffer to 12 bytes, but we don't have this luxury.
+patch=0,EE,2014843C,extended,A0A00744 // sb zero,0x744(a1)
+patch=0,EE,201E3474,extended,0C05210F // jal 0x0014843C

--- a/patches/SLUS-20811_CB99CD12.pnach
+++ b/patches/SLUS-20811_CB99CD12.pnach
@@ -134,3 +134,32 @@ patch=0,EE,204CBA80,extended,B2D0DA8B
 patch=0,EE,204CBA84,extended,B2D0DA8B
 patch=0,EE,204CBA88,extended,B2D0DA8B
 patch=0,EE,204CBA8C,extended,B2D0DA8B
+
+[SilentPatch]
+author=Silent
+description=Fixes the drift track record magazine unlock conditions, drift track high scores, and more.
+
+// Fix the drift score magazine taking a best lap score and dividing it by laps.
+// Also fix the high score in the menu displaying style points instead of the full score.
+patch=0,EE,2014A738,extended,46000840 // add.s f01,f01,f00
+patch=0,EE,201DB1D4,extended,00000000
+patch=0,EE,201DB1D8,extended,00000000
+patch=0,EE,201DB1E4,extended,E62000C4 // swc1 f00,0xC4(s1)
+
+patch=0,EE,201D78A4,extended,0C0F7F7C // jal 0x003DFDF0
+patch=0,EE,201D78A8,extended,C60C00C4 // lwc1 f12,0xC4(s0)
+
+patch=0,EE,203DFDF0,extended,46006324 // cvt.w.s f12,f12
+patch=0,EE,203DFDF4,extended,0809796C // j 0x0025E5B0
+patch=0,EE,203DFDF8,extended,44056000 // mfc1 a1,f12
+
+patch=0,EE,101D7584,extended,C4
+patch=0,EE,101D75D0,extended,C4
+patch=0,EE,101D743C,extended,C4
+patch=0,EE,201D75E0,extended,00000000 // Don't round up the score
+
+
+// Fix a buffer overflow in DriverInfo::DriverInfo because the OpponentDesc has 8 bytes for the driver name
+// and 'SAMANTHA' overflows it. Later PC and PS2 releases enlarged this buffer to 12 bytes, but we don't have this luxury.
+patch=0,EE,201482B4,extended,A0A00744 // sb zero,0x744(a1)
+patch=0,EE,201E32F4,extended,0C0520AD // jal 0x001482B4


### PR DESCRIPTION
Featured fixes:

* Fixed the unlock requirements for Magazine 22, which is awarded for setting a Drift Track record. The magazine is now awarded for beating the average lap high score, ensuring the requirements are fair regardless of the number of laps in the event.
* Drift events now display the total score as their High Score instead of style points.
* Fixed a buffer overflow issue in the UI display of opponent names. This resolves a bug where Samantha's name appeared corrupted during races.

Same as in https://cookieplmonster.github.io/mods/need-for-speed-underground-ps2/#silentpatch, submitted to the patch db so it can be used with RetroAchievements Hardcore Mode.