### PR TITLE
Add new widescreen patch for Skyscraper

### DIFF
--- a/patches/SLES-55152_EAEEC017.pnach
+++ b/patches/SLES-55152_EAEEC017.pnach
@@ -2,13 +2,14 @@ gametitle=Skyscraper PAL-M SLES-55152 EAEEC017
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Arapapa
+author=Souzooka
+description=16:9 Widescreen + aspect-corrected UI (requires reset)
 
-//Widescreen hack 16:9
-
-patch=1,EE,0025c240,word,3c013fab
+// Changes game resolution from 640x512 to 640x384
+// UI automatically scales to adjust to the new aspect ratio
+patch=0,EE,20307758,extended,180
 
 [50 FPS]
 author=Gabominated
 description=Might need EE Overclock.
-patch=1,EE,0022AF9C,word,10400010 //14400010
+patch=0,EE,0022AF9C,word,10400010 //14400010


### PR DESCRIPTION
This changes the internal resolution of the game to 640x384 from 640x512, and the game automatically corrects the UI for the new aspect ratio. Ideally (maybe in the future) whatever code reads the vertical resolution and scales the UI can be overwritten, but increasing the internal resolution in the emulator to account for the decreased vertical resolution is easy enough.

Also changed the 50fps patch to use patch=0; this modifies game code so the patch=1 is unnecessary.

Screenshots:

4:3:
![Skyscraper_SLES-55152_20250323195807](https://github.com/user-attachments/assets/21bc3578-a105-41d6-93f3-8145534ce7ea)

Old patch:
![Skyscraper_SLES-55152_20250323195827](https://github.com/user-attachments/assets/e8f098f9-f599-4695-9b91-d80f44c9ef4d)

New patch:
![Skyscraper_SLES-55152_20250323195543](https://github.com/user-attachments/assets/26bc4ab2-0112-4215-892b-9a97dd3bbb67)
