### PR TITLE
"Burnout 3 - Takedown" - Disable Motion Blur & Bloom by escape209

### DIFF
--- a/patches/SLUS-21050_BEBF8793.pnach
+++ b/patches/SLUS-21050_BEBF8793.pnach
@@ -121,28 +121,14 @@ patch=1,EE,204E0C3C,extended,3FE38E39 // Globe Aspect Ratio // 16:9 = 1.77777779
 patch=1,EE,204E0A94,extended,3FB8E38F // Globe Glow Aspect Ratio // 16:9 = 1.444444537
 
 [Disable Motion Blur]
-description=Disables Motion Blur (Emulation Speedhack + Cleaner Visibility)
+description=Disables Motion Blur (Performance Speedhack + Cleaner Visibility)
 author=UlsterRosé
-
 patch=1,EE,20665F2A,byte,00000000 // 00000001 // Motion blur, D3D11 hardware has problems with this
 
 [Disable Bloom]
-description=Disables Bloom (Biggest Emulation Speedhack)
+description=Disables Bloom (Performance Speedhack)
 author=UlsterRosé
-
 patch=1,EE,20665F28,byte,00000000 // 00000001 // Bloom, disabling this gives biggest performance boost
-
-[Disable Background Fog]
-description=Disables Background Fog (Emulation Speedhack)
-author=UlsterRosé
-
-patch=1,EE,20665F29,byte,00000000 // 00000001 // Background fog
-
-[Environment Maps]
-description=Make Cars have Reflections (Speedhack?)
-author=UlsterRosé
-
-patch=1,EE,20665F20,byte,00000000 // 00000001 // Environment maps (make cars have reflections)
 
 [60 FPS for Menus]
 author=Nehalem

--- a/patches/SLUS-21050_BEBF8793.pnach
+++ b/patches/SLUS-21050_BEBF8793.pnach
@@ -123,12 +123,12 @@ patch=1,EE,204E0A94,extended,3FB8E38F // Globe Glow Aspect Ratio // 16:9 = 1.444
 [Disable Motion Blur]
 description=Disables Motion Blur
 author=escape209
-patch=1,EE,20665F2A,byte,00000000 // 00000001 // Motion blur, D3D11 hardware has problems with this
+patch=1,EE,20665F2A,byte,00000000 // 00000001 // Disable Motion blur
 
 [Disable Bloom]
 description=Disables Bloom
 author=escape209
-patch=1,EE,20665F28,byte,00000000 // 00000001 // Bloom, disabling this gives biggest performance boost
+patch=1,EE,20665F28,byte,00000000 // 00000001 // Disable Bloom
 
 [60 FPS for Menus]
 author=Nehalem

--- a/patches/SLUS-21050_BEBF8793.pnach
+++ b/patches/SLUS-21050_BEBF8793.pnach
@@ -121,12 +121,12 @@ patch=1,EE,204E0C3C,extended,3FE38E39 // Globe Aspect Ratio // 16:9 = 1.77777779
 patch=1,EE,204E0A94,extended,3FB8E38F // Globe Glow Aspect Ratio // 16:9 = 1.444444537
 
 [Disable Motion Blur]
-description=Disables Motion Blur (Performance Speedhack + Cleaner Visibility)
+description=Disables Motion Blur
 author=UlsterRosé
 patch=1,EE,20665F2A,byte,00000000 // 00000001 // Motion blur, D3D11 hardware has problems with this
 
 [Disable Bloom]
-description=Disables Bloom (Performance Speedhack)
+description=Disables Bloom
 author=UlsterRosé
 patch=1,EE,20665F28,byte,00000000 // 00000001 // Bloom, disabling this gives biggest performance boost
 

--- a/patches/SLUS-21050_BEBF8793.pnach
+++ b/patches/SLUS-21050_BEBF8793.pnach
@@ -122,12 +122,12 @@ patch=1,EE,204E0A94,extended,3FB8E38F // Globe Glow Aspect Ratio // 16:9 = 1.444
 
 [Disable Motion Blur]
 description=Disables Motion Blur
-author=UlsterRosé
+author=escape209
 patch=1,EE,20665F2A,byte,00000000 // 00000001 // Motion blur, D3D11 hardware has problems with this
 
 [Disable Bloom]
 description=Disables Bloom
-author=UlsterRosé
+author=escape209
 patch=1,EE,20665F28,byte,00000000 // 00000001 // Bloom, disabling this gives biggest performance boost
 
 [60 FPS for Menus]

--- a/patches/SLUS-21050_BEBF8793.pnach
+++ b/patches/SLUS-21050_BEBF8793.pnach
@@ -120,6 +120,30 @@ patch=1,EE,204859B4,extended,080E9A78 // jumps back
 patch=1,EE,204E0C3C,extended,3FE38E39 // Globe Aspect Ratio // 16:9 = 1.777777791
 patch=1,EE,204E0A94,extended,3FB8E38F // Globe Glow Aspect Ratio // 16:9 = 1.444444537
 
+[Disable Motion Blur]
+description=Disables Motion Blur (Emulation Speedhack + Cleaner Visibility)
+author=UlsterRosé
+
+patch=1,EE,20665F2A,byte,00000000 // 00000001 // Motion blur, D3D11 hardware has problems with this
+
+[Disable Bloom]
+description=Disables Bloom (Biggest Emulation Speedhack)
+author=UlsterRosé
+
+patch=1,EE,20665F28,byte,00000000 // 00000001 // Bloom, disabling this gives biggest performance boost
+
+[Disable Background Fog]
+description=Disables Background Fog (Emulation Speedhack)
+author=UlsterRosé
+
+patch=1,EE,20665F29,byte,00000000 // 00000001 // Background fog
+
+[Environment Maps]
+description=Make Cars have Reflections (Speedhack?)
+author=UlsterRosé
+
+patch=1,EE,20665F20,byte,00000000 // 00000001 // Environment maps (make cars have reflections)
+
 [60 FPS for Menus]
 author=Nehalem
 description=Menus will render at 60 FPS


### PR DESCRIPTION
Disabling Motion Blur and Bloom are essential to have a smoother Burnout 3 experience on lower end devices, and sometimes for even a better experience in general i.e disabling Motion Blur.

The original repo had all these speedhacks in one cheat ( https://github.com/danpsr/burnout-3-pcsx2-speedhack/blob/main/BEBF8793.pnach ). I separated the Motion Blur and Bloom Disabling Cheats as individual cheats added them in this patch.

Essential cheats, specially for someone who wants to play Hardcore RetroAchievement for this game, but faces lags with the default Motion Blur.