### PR TITLE
Updating, adding and improving patches.

### DIFF
--- a/patches/SCES-52004_6624A78C.pnach
+++ b/patches/SCES-52004_6624A78C.pnach
@@ -14,3 +14,8 @@ patch=1,EE,205DB004,extended,3F000000
 patch=1,EE,E0020000,extended,0055A7C4
 patch=1,EE,00152014,extended,24420001
 patch=1,EE,205DB004,extended,3F800000
+
+[NTSC Mode]
+author=Gabominated
+description=Enable native NTSC Mode at start instead PAL Mode..
+patch=1,EE,001BD6B4,word,38420001

--- a/patches/SCES-52124_91A65EAE.pnach
+++ b/patches/SCES-52124_91A65EAE.pnach
@@ -1,15 +1,15 @@
-gametitle=KILL.SWITCH (E)(SCES-52124)
+gametitle=Kill.switch PAL-M SCES-52124 91A65EAE
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
+description=Widescreen hack
+patch=1,EE,2058A454,byte,00000001 //Force turn on Widescreen
+patch=1,EE,0024d854,word,3c013f25 //3c013f00 //Zoom fix
 
-//Widescreen hack 16:9
-
-//Force turn on Widescreen
-patch=1,EE,2058A454,byte,00000001
-
-//Zoom fix
-patch=1,EE,0024d854,word,3c013f25 //3c013f00
-
-
+[480p Mode]
+author=Gabominated
+description=SDTV 480p mode at start. FMVs remain in PAL.
+patch=1,EE,003513A4,word,10620005 //14620009
+patch=1,EE,0029e8d4,word,24050280 //24050200
+patch=1,EE,0029e8d8,word,240601C0 //24060200

--- a/patches/SCES-55663_44755604.pnach
+++ b/patches/SCES-55663_44755604.pnach
@@ -1,0 +1,6 @@
+gametitle=Street Cricket Champions 2 PAL-IN SCES-55663 44755604
+
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock (130%).
+patch=1,EE,00399B64,word,2A0D0001 //2A0D0002

--- a/patches/SCUS-97402_CAAEC49C.pnach
+++ b/patches/SCUS-97402_CAAEC49C.pnach
@@ -1,7 +1,20 @@
 gametitle=Killzone (NTSC-U) SCUS-97402 CAAEC49C
 
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Gabominated
+description=Enable native widescreen
+patch=1,EE,005DA364,word,00000001
+
 //[60 FPS]
 //author=asasega. Disabled due to causing double speed in menu and game FMVs and other game breaking issues.
 //description=Unlocked at 60 FPS. Might need enable EE Overclock to be stable.
 //patch=1,EE,00152014,word,24420002 //fps
 //patch=1,EE,005DB004,word,3F000000 //speed
+
+[Disable Noise Filter]
+author=Gabominated
+description=Disable noise filter in gameplay.
+patch=1,EE,0055DF6C,extended,000000FF
+patch=1,EE,E0010004,extended,0057BA88
+patch=1,EE,0055DF6C,extended,00000000

--- a/patches/SLES-50428_72BEA663.pnach
+++ b/patches/SLES-50428_72BEA663.pnach
@@ -1,15 +1,11 @@
-gametitle=MX 2002 featuring Ricky Carmichael (E)(SLES-50428)
+gametitle=MX 2002 featuring Ricky Carmichael PAL-E SLES-50428 72BEA663
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-
-//Widescreen hack 16:9
-
-//X-Fov
-patch=1,EE,001d9208,word,080aa268 // c6010068
+description=Widescreen hack 16:9
+patch=1,EE,001d9208,word,080aa268 // c6010068 //X-Fov
 patch=1,EE,001d920c,word,00000000 // c602006c
-
 patch=1,EE,002a89a0,word,3c013f40 // 00000000
 patch=1,EE,002a89a4,word,4481f000 // 00000000
 patch=1,EE,002a89a8,word,c6010068 // 00000000
@@ -18,4 +14,9 @@ patch=1,EE,002a89b0,word,461e0843 // 00000000
 patch=1,EE,002a89b4,word,e6010068 // 00000000
 patch=1,EE,002a89b8,word,08076484 // 00000000
 
-
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock.
+patch=1,EE,0012A9C8,word,2E420068 //2E420168
+patch=1,EE,00192D84,word,3C024248 //3C0241C8
+patch=1,EE,00192D94,word,3C0241C8 //3C024248

--- a/patches/SLES-50637_0E3617BC.pnach
+++ b/patches/SLES-50637_0E3617BC.pnach
@@ -1,14 +1,9 @@
-gametitle=Pro Rally 2002 (E)(SLES-50637)
-
-author=Arapapa
-description=Widescreen hack
+gametitle=Pro Rally 2002 PAL-M SLES-50637 FF920E90 Secondary CRC 0E3617BC
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-//Widescreen hack 16:9
-
-//For ELF CRC 0E3617BC
-
+author=Arapapa
+description=Widescreen hack 16:9
 patch=1,EE,E0070030,extended,00100008
 patch=1,EE,2011b760,extended,08063b04
 patch=1,EE,2018ec10,extended,4617b042
@@ -18,4 +13,7 @@ patch=1,EE,2018ec1c,extended,4481f000
 patch=1,EE,2018ec20,extended,461e0842
 patch=1,EE,2018ec24,extended,08046dd9
 
-
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock.
+patch=1,EE,0013B044,word,1440001E //1040001E

--- a/patches/SLES-50637_FF920E90.pnach
+++ b/patches/SLES-50637_FF920E90.pnach
@@ -1,18 +1,11 @@
-gametitle=Pro Rally 2002 (E)(SLES-50637)
+gametitle=Pro Rally 2002 PAL-M SLES-50637 FF920E90 Secondary CRC 0E3617BC
+//Corresponds to the main crc to activate the secondary crc 0E3617BC called RALLY.ELF
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
+description=Widescreen hack 16:9
 
-//Widescreen hack 16:9
-
-patch=1,EE,E0070030,extended,00100008
-patch=1,EE,2011b760,extended,08063b04
-patch=1,EE,2018ec10,extended,4617b042
-patch=1,EE,2018ec14,extended,3c013faa
-patch=1,EE,2018ec18,extended,3421aaab
-patch=1,EE,2018ec1c,extended,4481f000
-patch=1,EE,2018ec20,extended,461e0842
-patch=1,EE,2018ec24,extended,08046dd9
-
-
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock.

--- a/patches/SLES-50738_624F11F1.pnach
+++ b/patches/SLES-50738_624F11F1.pnach
@@ -1,4 +1,4 @@
-gametitle=Star Trek Voyager - Elite Force NTSC-U SLUS-20227 9F70EE4F
+gametitle=Star Trek Voyager - Elite Force PAL-M SLES-50738 624F11F1
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -14,7 +14,7 @@ patch=1,EE,0029acec,word,3c013fab //3c013f80
 //003f013c 00b08144 02001546
 patch=1,EE,00217e2c,word,3c013f2b //3c013f00
 
-[60 FPS]
+[50/60 FPS]
 author=Gabominated
 description=Might need EE Overclock (180%).
-patch=1,EE,001FE2CC,word,3C020035 //3C020036
+patch=1,EE,001FFD54,word,3C020036 //3C020037

--- a/patches/SLES-50992_5B9ACF79.pnach
+++ b/patches/SLES-50992_5B9ACF79.pnach
@@ -1,10 +1,9 @@
-gametitle=Hitman 2 - Silent Assassin (PAL-E) (SLES-50992) (v1.01 and 2.00)
+gametitle=Hitman 2 - Silent Assassin PAL-E SLES-50992 5B9ACF79
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-
-// 16:9
+description=Widescreen hack
 patch=1,EE,00313f7c,word,3c013f10 // 3c013f40 ver fov
 patch=1,EE,002bbe18,word,3c1b3f40 // 00000000 zoom
 patch=1,EE,002bc00c,word,3c013f00 // 3c013f80
@@ -17,4 +16,12 @@ patch=1,EE,002bc05c,word,4600a583 // e6200054
 patch=1,EE,002bc060,word,e6200054 // 3c01bf00
 patch=1,EE,002bc064,word,4600a807 // 44810000
 
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock.
+patch=1,EE,20508090,extended,00000001 //00000002
 
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start. FMVs remain in PAL.
+patch=1,EE,003066B4,word,14A20057 //10A20057

--- a/patches/SLES-51107_5B9ACF79.pnach
+++ b/patches/SLES-51107_5B9ACF79.pnach
@@ -1,10 +1,9 @@
-gametitle=Hitman 2 - Silent Assassin (PAL-I) (SLES-51107) (v1.01 and 2.00)
+gametitle=Hitman 2 - Silent Assassin PAL-I SLES-51107 5B9ACF79
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-
-// 16:9
+description=Widescreen hack
 patch=1,EE,00313f7c,word,3c013f10 // 3c013f40 ver fov
 patch=1,EE,002bbe18,word,3c1b3f40 // 00000000 zoom
 patch=1,EE,002bc00c,word,3c013f00 // 3c013f80
@@ -17,4 +16,12 @@ patch=1,EE,002bc05c,word,4600a583 // e6200054
 patch=1,EE,002bc060,word,e6200054 // 3c01bf00
 patch=1,EE,002bc064,word,4600a807 // 44810000
 
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock.
+patch=1,EE,20508090,extended,00000001 //00000002
 
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start. FMVs remain in PAL.
+patch=1,EE,003066B4,word,14A20057 //10A20057

--- a/patches/SLES-51108_5B9ACF79.pnach
+++ b/patches/SLES-51108_5B9ACF79.pnach
@@ -1,10 +1,9 @@
-gametitle=Hitman 2 - Silent Assassin (PAL-F) (SLES-51108) (v1.01 and 2.00)
+gametitle=Hitman 2 - Silent Assassin PAL-F SLES-51108 5B9ACF79
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-
-// 16:9
+description=Widescreen hack
 patch=1,EE,00313f7c,word,3c013f10 // 3c013f40 ver fov
 patch=1,EE,002bbe18,word,3c1b3f40 // 00000000 zoom
 patch=1,EE,002bc00c,word,3c013f00 // 3c013f80
@@ -17,4 +16,12 @@ patch=1,EE,002bc05c,word,4600a583 // e6200054
 patch=1,EE,002bc060,word,e6200054 // 3c01bf00
 patch=1,EE,002bc064,word,4600a807 // 44810000
 
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock.
+patch=1,EE,20508090,extended,00000001 //00000002
 
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start. FMVs remain in PAL.
+patch=1,EE,003066B4,word,14A20057 //10A20057

--- a/patches/SLES-51109_5B9ACF79.pnach
+++ b/patches/SLES-51109_5B9ACF79.pnach
@@ -1,10 +1,9 @@
-gametitle=Hitman 2 - Silent Assassin (PAL-G) (SLES-51109) (v1.01 and 2.00)
+gametitle=Hitman 2 - Silent Assassin PAL-G SLES-51109 5B9ACF79
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-
-// 16:9
+description=Widescreen hack
 patch=1,EE,00313f7c,word,3c013f10 // 3c013f40 ver fov
 patch=1,EE,002bbe18,word,3c1b3f40 // 00000000 zoom
 patch=1,EE,002bc00c,word,3c013f00 // 3c013f80
@@ -17,4 +16,12 @@ patch=1,EE,002bc05c,word,4600a583 // e6200054
 patch=1,EE,002bc060,word,e6200054 // 3c01bf00
 patch=1,EE,002bc064,word,4600a807 // 44810000
 
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock.
+patch=1,EE,20508090,extended,00000001 //00000002
 
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start. FMVs remain in PAL.
+patch=1,EE,003066B4,word,14A20057 //10A20057

--- a/patches/SLES-51110_5B9ACF79.pnach
+++ b/patches/SLES-51110_5B9ACF79.pnach
@@ -1,10 +1,9 @@
-gametitle=Hitman 2 - Silent Assassin (PAL-S) (SLES-51110) (v1.01 and 2.00)
+gametitle=Hitman 2 - Silent Assassin PAL-S SLES-51110 5B9ACF79
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-
-// 16:9
+description=Widescreen hack
 patch=1,EE,00313f7c,word,3c013f10 // 3c013f40 ver fov
 patch=1,EE,002bbe18,word,3c1b3f40 // 00000000 zoom
 patch=1,EE,002bc00c,word,3c013f00 // 3c013f80
@@ -17,14 +16,12 @@ patch=1,EE,002bc05c,word,4600a583 // e6200054
 patch=1,EE,002bc060,word,e6200054 // 3c01bf00
 patch=1,EE,002bc064,word,4600a807 // 44810000
 
-[50 FPS]
+[50/60 FPS]
 author=Gabominated
-description=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
+description=Might need EE Overclock.
 patch=1,EE,20508090,extended,00000001 //00000002
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=Gabominated
-description=Forces progressive scan mode 480p at startup.
-patch=1,EE,20415930,extended,24120050 //00069403
-patch=1,EE,201016c8,extended,24060050 //24060003
+description=NTSC mode at start. FMVs remain in PAL.
+patch=1,EE,003066B4,word,14A20057 //10A20057

--- a/patches/SLES-51249_EE3BCA71.pnach
+++ b/patches/SLES-51249_EE3BCA71.pnach
@@ -3,17 +3,16 @@ gametitle=Castleween PAL-M SLES-51249 EE3BCA71
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-
-//Widescreen hack 16:9
-
-
-//Y-fov
-patch=1,EE,002b9c78,word,3c023f40 //3c023f80
-
-//Zoom
-patch=1,EE,002794b8,word,3c033f40 //3c033f80
+description=Widescreen hack 16:9
+patch=1,EE,002b9c78,word,3c023f40 //3c023f80 //Y-fov
+patch=1,EE,002794b8,word,3c033f40 //3c033f80 //Zoom
 
 [50 FPS]
 author=Gabominated
-description=Might need EE Overclock (130%).
+description=Might need EE Overclock.
 patch=1,EE,00217344,word,3C030000 //3C030001
+
+[Disable Blur]
+author=Gabominated
+description=Disable post-processing blur effect.
+patch=1,EE,0049B5C8,word,00000000 //00080040

--- a/patches/SLES-51348_62F6F886.pnach
+++ b/patches/SLES-51348_62F6F886.pnach
@@ -1,0 +1,6 @@
+gametitle=Die Hard - Vendetta PAL-E SLES-51348 62F6F886
+
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock (180%).
+patch=1,EE,00283438,word,AF829A90 //AF849A90

--- a/patches/SLES-51580_F97680AA.pnach
+++ b/patches/SLES-51580_F97680AA.pnach
@@ -1,6 +1,12 @@
-gametitle=London Racer World Challenge PAL-M SLES-51580 F97680AA
+gametitle=London Racer - World Challenge PAL-M SLES-51580 F97680AA
 
-[50 FPS]
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Gabominated
+description=Widescreen hack
+patch=1,EE,00386b70,word,3c02bf55 //3c02bf00 X-FOV
+
+[50/60 FPS]
 author=Gabominated
 description=Might need EE Overclock.
 patch=1,EE,00133810,word,24020000 //24020001

--- a/patches/SLES-51934_7100A15F.pnach
+++ b/patches/SLES-51934_7100A15F.pnach
@@ -1,4 +1,4 @@
-gametitle=Curse - The Eye Of Isis (PAL-M6) (SLES-51934) 7100A15F
+gametitle=Curse - The Eye of Isis PAL-M SLES-51934 7100A15F
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -43,12 +43,18 @@ patch=1,EE,0050fd64,word,3c1b3f80 // 00000000
 patch=1,EE,0050fd68,word,0804d1f0 // 00000000
 patch=1,EE,0011e8b4,word,461ef783 // 00000000 inventory-to-documents function
 
-[50 FPS]
+[50/60 FPS]
 author=PeterDelta
-description=Might need EE Overclock at 130%.
+description=Might need EE Overclock (130)%.
 patch=1,EE,00510300,byte,01
 
 [NTSC Mode]
 author=Gabominated
 description=NTSC mode at startup, FMVs remain in PAL.
+patch=1,EE,002b45b0,word,240201c0 //24020200
+
+[480p Mode]
+author=Gabominated
+description=SDTV 480p mode at start. FMVs remain in PAL.
+patch=1,EE,003B0A68,word,10620005 //14620005
 patch=1,EE,002b45b0,word,240201c0 //24020200

--- a/patches/SLES-52017_9771C478.pnach
+++ b/patches/SLES-52017_9771C478.pnach
@@ -1,10 +1,12 @@
-gametitle=The Lord of the Rings - The Return of the King (PAL-M5) (SLES-52017)
+gametitle=Lord of the Rings, The - The Return of the King PAL-M SLES-52017 9771C478
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
+description=Renders the game in 16:9 aspect ratio
+patch=1,EE,0014b13c,word,3c023f40 //3c023f80 hor fov
 
-// 16:9
-patch=1,EE,0014b13c,word,3c023f40 // 3c023f80 hor fov
-
-
+[50 FPS]
+author=Gabominated
+description=Might need EE Overclock.
+patch=1,EE,0014B334,word,3C030000 //3C033F80

--- a/patches/SLES-52512_2D24ABAD.pnach
+++ b/patches/SLES-52512_2D24ABAD.pnach
@@ -1,4 +1,4 @@
-gametitle=Headhunter - Redemption (PAL-M) SLES-52512
+gametitle=Headhunter - Redemption PAL-M SLES-52512 2D24ABAD
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -7,8 +7,25 @@ patch=1,EE,00190620,word,3c014310 //3C014334
 patch=1,EE,00190650,word,3c013fe3 //3C013FAA
 patch=1,EE,00190654,word,34218e38 //3421AAAB
 
-[50 FPS]
+[50/60 FPS]
 author=Gabominated
-description=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,2043a3c8,extended,00000001 //00000002 fps
-patch=1,EE,2059D1C4,extended,3ca3d70a //3d23d70a speed
+description=Might need EE Overclock (180%).
+patch=1,EE,20157D78,extended,0042102A
+patch=1,EE,20166f8c,extended,24070032
+patch=1,EE,201670C8,extended,2403003c
+patch=1,EE,E0010032,extended,0043BA24
+patch=1,EE,2043BA24,extended,00000019
+patch=1,EE,E001003C,extended,0043BA24
+patch=1,EE,2043BA24,extended,0000001E
+patch=1,EE,E0010001,extended,005CCF78
+patch=1,EE,20157D78,extended,0043102A
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=1,EE,00167098,word,14000018 //10000018
+
+[Disable Blur]
+author=Gabominated
+description=Disable post-processing blur effect.
+patch=1,EE,001464AC,word,00000000

--- a/patches/SLES-52703_C08BE6C0.pnach
+++ b/patches/SLES-52703_C08BE6C0.pnach
@@ -1,0 +1,18 @@
+gametitle=Psi-Ops - The Mindgate Conspiracy PAL-G SLES-52703 C08BE6C0
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Gabominated
+description=Widescreen hack ported from NTSC-U version.
+patch=1,EE,0047000C,word,241102AA
+
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock (180%).
+patch=1,EE,0017AC7C,word,3C043F20 //3C043FA0
+
+[No-Interlacing]
+gsinterlacemode=1
+author=Gabominated
+description=Attempts to disable interlaced offset rendering..
+patch=1,EE,005684D4,word,3C051000

--- a/patches/SLES-52917_E54D237D.pnach
+++ b/patches/SLES-52917_E54D237D.pnach
@@ -1,4 +1,4 @@
-gametitle=Scaler (PAL-M4) (SLES-52917) E54D237D
+gametitle=Scaler (PAL-E) SLES-52917 E54D237D
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -15,10 +15,7 @@ patch=1,EE,002f4c48,word,08086e78 // 00000000
 patch=1,EE,0020b274,word,3c023f40 // 3c023f80 renderfix left
 patch=1,EE,0020b290,word,3c02bf40 // 3c02bf80 renderfix right
 
-[480p Mode]
-gsinterlacemode=1
-author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,0011CDEC,word,24110000
-patch=1,EE,0011CDF0,word,24120050
-patch=1,EE,0011CDFC,word,24130001
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=1,EE,0021D654,word,14400004 //10400004

--- a/patches/SLES-52918_E54D237D.pnach
+++ b/patches/SLES-52918_E54D237D.pnach
@@ -15,10 +15,7 @@ patch=1,EE,002f4c48,word,08086e78 // 00000000
 patch=1,EE,0020b274,word,3c023f40 // 3c023f80 renderfix left
 patch=1,EE,0020b290,word,3c02bf40 // 3c02bf80 renderfix right
 
-[480p Mode]
-gsinterlacemode=1
-author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,0011CDEC,word,24110000
-patch=1,EE,0011CDF0,word,24120050
-patch=1,EE,0011CDFC,word,24130001
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=1,EE,0021D654,word,14400004 //10400004

--- a/patches/SLES-52941_80BB14B2.pnach
+++ b/patches/SLES-52941_80BB14B2.pnach
@@ -1,12 +1,16 @@
-gametitle=Gungrave: Overdose [PAL-M3] (SLES_529.41)
+gametitle=Gungrave - Overdose PAL-M SLES-52941 80BB14B2
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=El_Patas
-
-//Gameplay 16:9
+description=Widescreen hack
 patch=1,EE,0028B6C4,word,3C013F40 //00000000 (Increases hor. axis)
 patch=1,EE,0028B6C8,word,44810000 //00000000
 patch=1,EE,0028B6D0,word,4600C602 //00000000
 
-
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock (180%).
+patch=1,EE,20101C18,extended,28420001
+patch=1,EE,E0010019,extended,004455C4
+patch=1,EE,20101C18,extended,28420002

--- a/patches/SLES-53087_EE0618ED.pnach
+++ b/patches/SLES-53087_EE0618ED.pnach
@@ -1,8 +1,7 @@
-gametitle=TOCA Race Driver 3 (PAL-M) SLES-53087 EE0618ED
+gametitle=TOCA Race Driver 3 PAL-M SLES-53087 EE0618ED
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=Gabominated
-description=SDTV 480p mode at start. Might need enable EE overclock to be stable
-patch=1,EE,204BA9A4,extended,3C888889 //3CA3D70A
-patch=1,EE,20465c10,extended,24120050
+description=NTSC Mode at start.
+patch=1,EE,003FA3AC,word,24040000 //24040001
+patch=1,EE,002563A8,word,14000008 //10000008

--- a/patches/SLES-53158_E38A0AB6.pnach
+++ b/patches/SLES-53158_E38A0AB6.pnach
@@ -1,6 +1,24 @@
 gametitle=Cold Fear (PAL-M) SLES-53158 E38A0AB6
 
-[50 FPS]
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Gabominated
+description=Enable native widescreen.
+patch=1,EE,0046EF34,word,00000001
+patch=1,EE,004F9480,word,01000000
+
+[50/60 FPS]
 author=Snake356
 description=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
 patch=1,EE,0046E404,extended,00000001
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=1,EE,001449c8,word,240301c0 //24030200
+
+[480p Mode]
+author=Gabominated
+description=SDTV 480p mode at start.
+patch=1,EE,0025FA24,word,10620005 //14620005
+patch=1,EE,001449c8,word,240301c0 //24030200

--- a/patches/SLES-53280_52DEB87B.pnach
+++ b/patches/SLES-53280_52DEB87B.pnach
@@ -4,27 +4,23 @@ gametitle=7 Sins PAL-M SLES-53280 52DEB87B
 gsaspectratio=16:9
 author=Bigdemon
 description=Widescreen hack conversion
-
 //Gameplay 16:9
-
 //Zoom
 //0040023c 00088244 00000000 02080046
 //2a40023c abaa4234 02080046 02080046
 patch=1,EE,00226abc,word,3c02402a //3c024000
 patch=1,EE,00226ac0,word,3442aaab //44820800
 patch=1,EE,00226ac4,word,44820800 //00000000
-
 //Y-Fov
 //03080046 2400a0e7 2d200002
 patch=1,EE,00226ae4,word,080bf5c4 //46000803
-
 patch=1,EE,002fd710,word,46000803 //00000000
 patch=1,EE,002fd714,word,3c013f40 //00000000
 patch=1,EE,002fd718,word,4481f000 //00000000
 patch=1,EE,002fd71c,word,461e0002 //00000000
 patch=1,EE,002fd720,word,08089aba //00000000
 
-[50 FPS]
+[50/60 FPS]
 author=Gabominated
 description=Might need EE Overclock.
 patch=1,EE,00428390,word,24020002 //24020001
@@ -32,4 +28,4 @@ patch=1,EE,00428390,word,24020002 //24020001
 [NTSC Mode]
 author=Gabominated
 description=NTSC mode at start.
-patch=1,EE,001008f4,word,240201c0 //24020200
+patch=1,EE,0048971C,word,14400009 //10400009

--- a/patches/SLES-53441_F8E600FC.pnach
+++ b/patches/SLES-53441_F8E600FC.pnach
@@ -1,33 +1,27 @@
-gametitle=Heroes of the Pacific (E)(SLES-53441)
+gametitle=Heroes of the Pacific PAL-M SLES-53441 F8E600FC
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Arapapa
-
-//Widescreen hack 16:9
-
-patch=1,EE,001bb788,word,080521d8 // c6010068
-patch=1,EE,001bb78c,word,00000000 // c602006c
-
-patch=1,EE,00148760,word,3c013f40 // 00000000
-patch=1,EE,00148764,word,4481f000 // 00000000
-patch=1,EE,00148768,word,c6010068 // 00000000
-patch=1,EE,0014876c,word,c602006c // 00000000
-patch=1,EE,00148770,word,461e0843 // 00000000
-patch=1,EE,00148774,word,e6010068 // 00000000
-patch=1,EE,00148778,word,0806ede4 // 00000000
+author=Gabominated
+description=Widescreen hack
+patch=1,EE,2079AD00,extended,3FE38E3A //3FAAAAA7
+patch=1,EE,2067F140,extended,3F249244 //3F5B6DB6
+patch=1,EE,2079AE50,extended,3FE38E3A //3FAAAAA7
+patch=1,EE,2079AE54,extended,42C20000 //42920000
+patch=1,EE,2079AEE0,extended,00000002 //00000000
+patch=1,EE,209B1924,extended,b3000000 //b3000000
 
 [50/60 FPS]
 author=Gabominated
-description=Unlocked at 50/60 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,201CADD4,extended,10000007 //10400007 fps
+description=Might need EE Overclock.
+patch=1,EE,201CAE08,extended,24020002 //24020001
 patch=1,EE,E0043D23,extended,0067F2BA //condition 50herz
-patch=1,EE,1067F2B2,extended,00003CA3
-patch=1,EE,1067F2B6,extended,00003CA3
-patch=1,EE,1067F2BA,extended,00003CA3
-patch=1,EE,1067F2BE,extended,00003CA3
+patch=1,EE,2067F2B0,extended,3CA3D70A
+patch=1,EE,2067F2B4,extended,3CA3D70A
+patch=1,EE,2067F2B8,extended,3CA3D70A
+patch=1,EE,2067F2BC,extended,3CA3D70A
 patch=1,EE,E0043D08,extended,0067F2BA //condition 60herz
-patch=1,EE,1067F2B2,extended,00003C88
-patch=1,EE,1067F2B6,extended,00003C88
-patch=1,EE,1067F2BA,extended,00003C88
-patch=1,EE,1067F2BE,extended,00003C88
+patch=1,EE,2067F2B0,extended,3C888889
+patch=1,EE,2067F2B4,extended,3C888889
+patch=1,EE,2067F2B8,extended,3C888889
+patch=1,EE,2067F2BC,extended,3C888889

--- a/patches/SLES-53457_9DE65987.pnach
+++ b/patches/SLES-53457_9DE65987.pnach
@@ -1,0 +1,6 @@
+gametitle=Evil Dead - Regeneration PAL-E SLES-53457 9DE65987
+
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock (180%).
+patch=1,EE,00377194,word,24020002 //24020001

--- a/patches/SLES-53886_ADDFF505.pnach
+++ b/patches/SLES-53886_ADDFF505.pnach
@@ -1,4 +1,4 @@
-gametitle=BLACK (PAL-M) (SLES_538.86) ADDFF505
+gametitle=Black PAL-M SLES-53886 ADDFF505
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -14,19 +14,12 @@ patch=1,EE,204CAE94,word,3FE38E39 //3FAAAAAB
 patch=1,EE,205BCB90,word,3F400000 //3F800000
 
 [50/60 FPS]
-author=PeterDelta
-description=Might need EE Overclock at 180%.
-patch=1,EE,1040DFF4,extended,02000001
-patch=1,EE,E0040007,extended,003BD274 //50hz
-patch=1,EE,E001D70A,extended,005A929C
-patch=1,EE,205A929C,extended,3CA3D70A
-patch=1,EE,204BC93C,extended,3CA3D70A
-patch=1,EE,2040EC2C,extended,3CA3D70A
-patch=1,EE,E004000E,extended,003BD274 //60hz
-patch=1,EE,E0018889,extended,005A929C
-patch=1,EE,205A929C,extended,3C888889
-patch=1,EE,204BC93C,extended,3C888889
-patch=1,EE,2040EC2C,extended,3C888889
+author=PerterDelta & Gabominated
+description=Might need EE Overclock (180%).
+patch=1,EE,0012513C,word,24040001 //24040002
+patch=1,EE,001C5BC0,word,24040001 //24040002
+patch=1,EE,00102638,word,24040032 //24040019
+patch=1,EE,00125128,word,2410003C //2410001E
 
 [Video Mode]
 author=Gabominated

--- a/patches/SLES-53949_E3B1855B.pnach
+++ b/patches/SLES-53949_E3B1855B.pnach
@@ -1,0 +1,6 @@
+gametitle=Magna Carta - Tears of Blood PAL-I SLES-53949 E3B1855B
+
+[50/60 FPS]
+author=Cloudn
+description=Port from NTSC-U version. Might need EE Overclock.
+patch=1,EE,001C6534,word,28410001 //28410002

--- a/patches/SLES-54030_CAA04879.pnach
+++ b/patches/SLES-54030_CAA04879.pnach
@@ -1,0 +1,27 @@
+gametitle=Black PAL-E SLES-54030 CAA04879
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Gabominated
+description=Widescreen ported from NTSC-U version.
+patch=1,EE,003BE83C,word,00000001 //00000000
+patch=1,EE,004BC150,word,00000001 //00000000
+patch=1,EE,004BD18C,word,00000101 //00000000
+patch=1,EE,004CA554,word,3FE38E39 //3FAAAAAB
+patch=1,EE,004CA5F0,word,3FAAAAAB //3F99999A
+patch=1,EE,004CA5F4,word,3FE38E39 //3FAAAAAB
+patch=1,EE,004CA694,word,3FE38E39 //3FAAAAAB
+patch=1,EE,005BC390,word,3F400000 //3F800000
+
+[50/60 FPS]
+author=Gabominated
+description=Native 50/60 FPS. Might need EE Overclock (180%).
+patch=1,EE,001250BC,word,24040001 //24040002
+patch=1,EE,001c5b40,word,24040001 //24040002
+patch=1,EE,00102638,word,24040032 //24040019
+patch=1,EE,001250a8,word,2410003c //2410001e
+
+[Video Mode]
+author=Gabominated
+description=Always display standard-480p video selector.
+patch=1,EE,003BE7A4,word,00000001

--- a/patches/SLES-54150_85495C17.pnach
+++ b/patches/SLES-54150_85495C17.pnach
@@ -2,15 +2,10 @@ gametitle=Bionicle Heroes PAL-M SLES-54150 85495C17
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Arapapa
-
-//Widescreen hack 16:9
-
-// Zoom fix (Internal Widescreen Option)
-patch=1,EE,00388cf8,word,3c013f80 //3c013f40
-
-//X-Fov
-patch=1,EE,00388d28,word,3c013f10 //3c013f40
+author=Gabominated
+description=Enable native widescreen.
+patch=1,EE,00388D04,word,3C013F10 //3C013F00 zoom fix
+patch=1,EE,0065F798,word,00000001 //00000000
 
 [50 FPS]
 author=Gabominated

--- a/patches/SLES-54182_301A1B6E.pnach
+++ b/patches/SLES-54182_301A1B6E.pnach
@@ -1,12 +1,15 @@
-gametitle=Scarface - The World is Yours (MULTI4) (SLES-54182)
+gametitle=Scarface - The World is Yours PAL-M SLES-54182 301A1B6E
 
-[50 FPS]
+[50/60 FPS]
 author=Gabominated
-description=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
-patch=1,EE,00DAFCBC,word,00000000 //00000001
+description=Might need EE Overclock (130%).
+patch=1,EE,20DAFCBC,extended,00000000 //00000001
 
 [480p Mode]
-gsinterlacemode=1
 author=Gabominated
-description=SDTV 480p mode at start. Might need enable EE Overclock to be stable.
-patch=1,EE,2072dc38,extended,24120050
+description=SDTV 480p mode at start.
+patch=1,EE,00DAFC1C,word,00000000 //00000001
+patch=1,EE,00DAFC20,word,00000001 //00000000
+patch=1,EE,00DAFC34,word,00000002 //00000003
+patch=1,EE,00DAFC38,word,00000001 //00000000
+patch=1,EE,00DAFC40,word,000001E0 //00000200

--- a/patches/SLES-54183_9A660CC1.pnach
+++ b/patches/SLES-54183_9A660CC1.pnach
@@ -1,0 +1,15 @@
+gametitle=Scarface - The World is Yours PAL-G SLES-54183 9A660CC1
+
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock (130%).
+patch=1,EE,20DADCBC,extended,00000000 //00000001
+
+[480p Mode]
+author=Gabominated
+description=SDTV 480p mode at start.
+patch=1,EE,00DADC1C,word,00000000 //00000001
+patch=1,EE,00DADC20,word,00000001 //00000000
+patch=1,EE,00DADC34,word,00000002 //00000003
+patch=1,EE,00DADC38,word,00000001 //00000000
+patch=1,EE,00DADC40,word,000001E0 //00000200

--- a/patches/SLES-54184_20F4FDF8.pnach
+++ b/patches/SLES-54184_20F4FDF8.pnach
@@ -1,0 +1,15 @@
+gametitle=Scarface - The World is Yours PAL-R SLES-54184 20F4FDF8
+
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock (130%).
+patch=1,EE,20DAFABC,extended,00000000 //00000001
+
+[480p Mode]
+author=Gabominated
+description=SDTV 480p mode at start.
+patch=1,EE,00DAFA1C,word,00000000 //00000001
+patch=1,EE,00DAFA20,word,00000001 //00000000
+patch=1,EE,00DAFA34,word,00000002 //00000003
+patch=1,EE,00DAFA38,word,00000001 //00000000
+patch=1,EE,00DAFA40,word,000001E0 //00000200

--- a/patches/SLES-54271_B69AF9A5.pnach
+++ b/patches/SLES-54271_B69AF9A5.pnach
@@ -1,0 +1,15 @@
+gametitle=Scarface - The World is Yours PAL-E SLES-54271 B69AF9A5
+
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock (130%).
+patch=1,EE,20DB01BC,extended,00000000 //00000001
+
+[480p Mode]
+author=Gabominated
+description=SDTV 480p mode at start.
+patch=1,EE,00DB011C,word,00000000 //00000001
+patch=1,EE,00DB0120,word,00000001 //00000000
+patch=1,EE,00DB0134,word,00000002 //00000003
+patch=1,EE,00DB0138,word,00000001 //00000000
+patch=1,EE,00DB0140,word,000001E0 //00000200

--- a/patches/SLES-54430_E1F17139.pnach
+++ b/patches/SLES-54430_E1F17139.pnach
@@ -1,0 +1,24 @@
+gametitle=Teen Titans PAL-F SLES-54430 E1F17139
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=ElHecht
+description=Widescreen hack
+patch=1,EE,00205784,word,080f1e0c // 4600ab06 jump to 003c7830
+patch=1,EE,00205788,word,00000000 // 0c072734
+patch=1,EE,003c7830,word,3c013f40 // 00000000 hor fov gameplay
+patch=1,EE,003c7834,word,4481f000 // 00000000
+patch=1,EE,003c7838,word,461ead43 // 00000000
+patch=1,EE,003c783c,word,4600ab06 // 00000000
+patch=1,EE,003c7840,word,0c072734 // 00000000
+patch=1,EE,003c7844,word,00000000 // 00000000
+patch=1,EE,003c7848,word,080815e2 // 00000000 jump back to 00205788
+patch=1,EE,001c9d78,word,3c023fc0 // 3c024000 zoom cut-scenes
+patch=1,EE,001c9da8,word,3c013f40 // 00000000 ver fov cut-scenes
+patch=1,EE,001c9dac,word,4481f000 // 00000000
+patch=1,EE,001c9db4,word,461e0342 // 00000000
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=1,EE,0015E73C,word,14800004 //10800004

--- a/patches/SLES-54431_E1F17139.pnach
+++ b/patches/SLES-54431_E1F17139.pnach
@@ -1,0 +1,24 @@
+gametitle=Teen Titans PAL-E SLES-54431 E1F17139
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=ElHecht
+description=Widescreen hack
+patch=1,EE,00205784,word,080f1e0c // 4600ab06 jump to 003c7830
+patch=1,EE,00205788,word,00000000 // 0c072734
+patch=1,EE,003c7830,word,3c013f40 // 00000000 hor fov gameplay
+patch=1,EE,003c7834,word,4481f000 // 00000000
+patch=1,EE,003c7838,word,461ead43 // 00000000
+patch=1,EE,003c783c,word,4600ab06 // 00000000
+patch=1,EE,003c7840,word,0c072734 // 00000000
+patch=1,EE,003c7844,word,00000000 // 00000000
+patch=1,EE,003c7848,word,080815e2 // 00000000 jump back to 00205788
+patch=1,EE,001c9d78,word,3c023fc0 // 3c024000 zoom cut-scenes
+patch=1,EE,001c9da8,word,3c013f40 // 00000000 ver fov cut-scenes
+patch=1,EE,001c9dac,word,4481f000 // 00000000
+patch=1,EE,001c9db4,word,461e0342 // 00000000
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=1,EE,0015E73C,word,14800004 //10800004

--- a/patches/SLES-54553_7C8125F4.pnach
+++ b/patches/SLES-54553_7C8125F4.pnach
@@ -1,15 +1,13 @@
-gametitle=DreamWorks Shrek Smash n' Crash Racing (E)(SLES-54553)
+gametitle=DreamWorks Shrek - Smash n' Crash Racing PAL-M SLES-54553 7C8125F4
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
 description=Widescreen Hack
 //Widescreen hack 16:9
-
 //X-Fov
 //02080046 5000a0e7 040040c4
 patch=1,EE,002789c0,word,08069cb4
-
 patch=1,EE,001a72d0,word,46000802
 patch=1,EE,001a72d4,word,3c013faa
 patch=1,EE,001a72d8,word,3421aaab
@@ -17,4 +15,7 @@ patch=1,EE,001a72dc,word,4481f000
 patch=1,EE,001a72e0,word,461e0002
 patch=1,EE,001a72e4,word,0809e271
 
-
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start. FMVs remain in PAL.
+patch=1,EE,0016E1F4,word,240201c0 //24030200

--- a/patches/SLES-54666_EDCBBC68.pnach
+++ b/patches/SLES-54666_EDCBBC68.pnach
@@ -3,11 +3,8 @@ gametitle=Mr. Bean PAL-M SLES-54666 EDCBBC68
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-
-//Widescreen hack 16:9
-
+description=Widescreen hack 16:9
 patch=1,EE,001b6ba4,word,08093ae8
-
 patch=1,EE,0024eba0,word,4600bb06
 patch=1,EE,0024eba4,word,3c013faa
 patch=1,EE,0024eba8,word,3421aaab
@@ -15,8 +12,15 @@ patch=1,EE,0024ebac,word,4481f000
 patch=1,EE,0024ebb0,word,461e6302
 patch=1,EE,0024ebb4,word,0806daea
 
-[50 FPS]
+[50/60 FPS]
 author=Gabominated & PeterDelta
 description=Might need EE Overclock (180%).
 patch=1,EE,0054B694,word,00000001 //00000002
 patch=1,EE,00195AE4,word,3C0142C8 //3C014248
+patch=1,EE,00195B40,word,3C0142f0 //3C014270
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=1,EE,00195B14,word,14000017 //10000017
+patch=1,EE,00195B30,word,10400014 //14400014

--- a/patches/SLES-55012_73351A86.pnach
+++ b/patches/SLES-55012_73351A86.pnach
@@ -1,0 +1,6 @@
+gametitle=Golden Compass, The PAL-M SLES-55012 73351A86
+
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock.
+patch=1,EE,0021D644,word,28630001 //28630002

--- a/patches/SLES-55536_E4278493.pnach
+++ b/patches/SLES-55536_E4278493.pnach
@@ -4,22 +4,22 @@ gametitle=Disney/Pixar Cars - Race-O-Rama PAL-M SLES-55536 E4278493
 gsaspectratio=16:9
 author=Bigdemon
 description=Widescreen Hack Conversion
-//Widescreen hack 16:9
-
-//Zoom
-patch=1,EE,0014750c,word,3c063fc0 //3c064000
-
-//Y-Fov
-patch=1,EE,00147540,word,080c4cd4
+patch=1,EE,0014750c,word,3c063fc0 //3c064000 //Zoom
+patch=1,EE,00147540,word,080c4cd4 //Y-Fov
 patch=1,EE,00313350,word,460418c3
 patch=1,EE,00313354,word,3c013f40
 patch=1,EE,00313358,word,4481f000
 patch=1,EE,0031335c,word,461e18c3
 patch=1,EE,00313360,word,08051d51
 
-[50 FPS]
+[50/60 FPS]
 author=Gabominated
 description=Might need EE Overclock.
-patch=1,EE,201A07D4,extended,0060102D //0060202D
+patch=1,EE,201A07D4,extended,0060102D
 patch=1,EE,E0010001,extended,003FCD38
 patch=1,EE,201A07D4,extended,0060202D
+
+[NTSC/480p Mode]
+author=Gabominated
+description=Unlocked NTSC mode with 480p mode available at option menu.
+patch=1,EE,0015417c,word,24030003 //24030001

--- a/patches/SLPM-65257_8CFE667F.pnach
+++ b/patches/SLPM-65257_8CFE667F.pnach
@@ -1,26 +1,26 @@
-gametitle=Silent Hill 3 [NTSC-J] (SLPM-65257)
+gametitle=Silent Hill 3 NTSC-J SLPM-65257 8CFE667F
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-description=NTSC-J Widescreen Hack by nemesis2000
-
+author=nemesis2000
+description=Widescreen Hack
 patch=1,EE,001b4a24,word,3c023f28 //3c023f61
 patch=1,EE,001b4a28,word,3442f5c3 //344247ae
-
 //Items & Weapons and Supplies fix
 //4c3f023c cdcc4234 00108544
 patch=1,EE,002ad938,word,3c023f19 //3c023f4c
 patch=1,EE,002ad93c,word,3442999a //3442cccd
-
 //Oringal FMV's fix by nemesis2000
 patch=1,EE,002b6078,word,24112550 //fmv height
 patch=1,EE,002b6064,word,24106D50 //fmv y-pos
 patch=1,EE,002b619c,word,24100000 //fmv black borders
 patch=1,EE,002b61a4,word,24100000 //fmv black borders
-
 patch=1,EE,002b607c,word,24032000 //fmv height
 patch=1,EE,002b6068,word,24037000 //fmv y-pos
 patch=1,EE,002b61bc,word,24100000 //fmv black borders
 patch=1,EE,002b61c0,word,24100000 //fmv black borders
 
-
+[60 FPS]
+author=asasega
+description=Might need EE Overclock.
+patch=1,EE,2013058C,extended,00000000

--- a/patches/SLPM-65972_25D968B0.pnach
+++ b/patches/SLPM-65972_25D968B0.pnach
@@ -1,14 +1,16 @@
-gametitle=Constantine (J)(SLPM-65972)
+gametitle=Constantine NTSC-J SLPM-65972 25D968B0
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-
+description=Widescreem hack
 //X-Fov - ELF hack
 //803f013c 00108144 0c00438e
 patch=1,EE,002b7b90,word,3c013f40 //3c013f80
-
 //Memory Hack
 //patch=1,EE,2081B7F4,extended,3F400000 // 3F800000
 
-
+[60 FPS]
+author=Gabominated
+description=Might need EE Overclock (180%).
+patch=1,EE,004BB330,word,00000000 //00000001

--- a/patches/SLPM-65984_60FE139C.pnach
+++ b/patches/SLPM-65984_60FE139C.pnach
@@ -1,9 +1,9 @@
-gametitle=Grand Theft Auto - San Andreas (SLPM-65984)
+gametitle=Grand Theft Auto - San Andreas NTSC-J SLPM-65984 60FE139C
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-description=Widescreen fix by BloodRaynare
-
+author=BloodRaynare
+description=Widescreen fix
 patch=1,EE,001130bc,word,3c013f9d
 patch=1,EE,001130c0,word,44810000
 patch=1,EE,001130c4,word,46006302
@@ -13,7 +13,12 @@ patch=1,EE,0021dd04,word,0c044c2f
 patch=1,EE,00242c94,word,0c044c32
 
 [Remove Radiosity Filter]
+author=refractionpcsx2
 description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
-
 //Remove Radiosity Filter
 patch=1,EE,2051B5E8,extended,00000000
+
+[60 FPS]
+author=Gabominated
+description=Might need EE overclock (130%).
+patch=1,EE,0034EA80,word,24020002 //24020001

--- a/patches/SLPM-66354_B3A9F9ED.pnach
+++ b/patches/SLPM-66354_B3A9F9ED.pnach
@@ -1,9 +1,9 @@
-gametitle=BLACK (J) (SLPM-66354)
+gametitle=Black NTSC-J SLPM-66354 B3A9F9ED
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=No.47 (pnach by Arapapa)
-
+description=Widescreen hack
 patch=1,EE,203BF03C,word,00000001 //00000000
 patch=1,EE,204BC950,word,00000001 //00000000
 patch=1,EE,204BD98C,word,00000001 //00000000
@@ -13,4 +13,15 @@ patch=1,EE,204CADF4,word,3FE38E39 //3FAAAAAB
 patch=1,EE,204CAE94,word,3FE38E39 //3FAAAAAB
 patch=1,EE,205BC390,word,3F400000 //3F800000
 
+[60 FPS]
+author=Gabominated
+description=Native 60 FPS. Might need EE Overclock (180%).
+patch=1,EE,001c5c38,word,24040001 //24040002
+patch=1,EE,001251b4,word,24040001 //24040002
+patch=1,EE,00102648,word,2404003c //2404001e
+patch=1,EE,001251A0,word,2410003c //2410001e
 
+[Video Mode]
+author=Gabominated
+description=Always display standard-480p video selector.
+patch=1,EE,003BE924,word,00000001

--- a/patches/SLPS-25314_B6AA81EE.pnach
+++ b/patches/SLPS-25314_B6AA81EE.pnach
@@ -1,17 +1,30 @@
-gametitle=Nebula - Echo Night (J)(SLPS-25314)
+gametitle=Nebula - Echo Night NTSC-J SLPS-25314 B6AA81EE
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-
-//Widescreen hack 16:9
-
+description=Widescreen hack 16:9
 //Force turn on Internal Widescreen
 //01 00 00 00 00 00 00 3F 01 01 00 00 18 EE 29 00
 patch=1,EE,202AD621,byte,00000001
-
 //703f033c 003f023c d7a36334
 //patch=1,EE,00143ed0,word,3c033fa0 //3c023f70 Y-Fov
 patch=1,EE,00143ed4,word,3c023f1f //3c023f00 Zoom
 
+[60 FPS]
+author=Gabominated
+description=Might need EE Overclock.
+patch=1,EE,001401BC,word,14200014
 
+[Performance Fix]
+author=Gabominated
+description=Remove flashlight shadows to increase performance.
+patch=1,EE,001441f4,word,3c020000
+
+[Disable Flicker Filter]
+author=Gabominated
+description=Disable slightly blurry flicker filter.
+patch=1,EE,002835E8,word,00000000
+patch=1,EE,002835F0,word,00000000
+patch=1,EE,002835F8,word,00000000
+patch=1,EE,00283600,word,00000000

--- a/patches/SLUS-20072_FBC3BC36.pnach
+++ b/patches/SLUS-20072_FBC3BC36.pnach
@@ -1,15 +1,12 @@
-gametitle=MX 2002 featuring Ricky Carmichael (U)(SLUS-20072)
+gametitle=MX 2002 featuring Ricky Carmichael NTSC-U SLUS-20072 FBC3BC36
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-
-//Widescreen hack 16:9
-
+description=Widescreen hack 16:9
 //X-Fov
 patch=1,EE,002657d0,word,080a9af4 // c6010068
 patch=1,EE,002657d4,word,00000000 // c602006c
-
 patch=1,EE,002a6bd0,word,3c013f40 // 00000000
 patch=1,EE,002a6bd4,word,4481f000 // 00000000
 patch=1,EE,002a6bd8,word,c6010068 // 00000000
@@ -18,4 +15,12 @@ patch=1,EE,002a6be0,word,461e0843 // 00000000
 patch=1,EE,002a6be4,word,e6010068 // 00000000
 patch=1,EE,002a6be8,word,080995f6 // 00000000
 
-
+[60 FPS]
+author=Gabominated
+description=Might need EE Overclock.
+patch=1,EE,002FC818,word,00000000 //00000001
+patch=1,EE,00144248,word,3c023c08 //3c023c88
+patch=1,EE,00145014,word,3c023c88 //3c023d08
+patch=1,EE,00191314,word,3c023c88 //3c023d08
+patch=1,EE,0012a564,word,3c023c88 //3c023d08
+patch=1,EE,00150638,word,3c023c88 //3c023d08

--- a/patches/SLUS-20165_1771BFE4.pnach
+++ b/patches/SLUS-20165_1771BFE4.pnach
@@ -1,0 +1,18 @@
+gametitle=Legacy of Kain - Soul Reaver 2 NTSC-U SLUS-20165 1771BFE4 v1.01
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Gabominated & pelvicthrustman
+description=Widescreen Hack
+patch=1,EE,001705FC,word,3C013F60 //3C013F95
+patch=1,EE,00170600,word,00000000 //34215556
+patch=1,EE,00170638,word,00000000 //1443000B
+patch=1,EE,0023E918,word,43c00000 //44000000 FOV
+patch=1,EE,00112DCC,word,3C013F40 //3C013F10 render fix
+patch=1,EE,0023E920,word,00000001 //00000000 debug ws mode
+
+[Remove black bars]
+author=pelvicthrustman
+description=Remove black bars in cutscenes.
+patch=1,EE,0013db5c,word,3C01BF80 //3C01BF40
+patch=1,EE,0013db64,word,3c013f80 //3C013F40

--- a/patches/SLUS-20165_230CB71D.pnach
+++ b/patches/SLUS-20165_230CB71D.pnach
@@ -1,10 +1,26 @@
-gametitle=Legacy of Kain - Soul Reaver 2 (USA) (v2.00) Game CRC=0x230CB71D
+gametitle=Legacy of Kain - Soul Reaver 2 NTSC-U SLUS-20165 230CB71D v2.00
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Gabominated
+description=Widescreen Hack
+patch=1,EE,00170BFC,word,3C013F60 //3C013F95
+patch=1,EE,00170C00,word,00000000 //34215556
+patch=1,EE,00170C38,word,00000000 //1443000B
+patch=1,EE,0023F418,word,43c00000 //44000000 FOV
+patch=1,EE,0011328C,word,3C013F40 //3C013F10 render fix
+patch=1,EE,0023F420,word,00000001 //00000000 debug ws mode
+
+[remove black bars]
+author=Gabominated
+description=Remove black bars in cutscenes.
+patch=1,EE,0013E144,word,3C01BF80 //3C01BF40
+patch=1,EE,0013E14C,word,3c013f80 //3C013F40
 
 [No-Interlacing]
 gsinterlacemode=1
+author=Red-tv
 description=Origial patch by Red_Tv, offsets updated for v2.00
 patch=1,EE,201a9510,word,30420000
 patch=1,EE,00201574,word,00000000
 patch=1,EE,03223edc,word,00000000
-
-

--- a/patches/SLUS-20324_EC3E8E86.pnach
+++ b/patches/SLUS-20324_EC3E8E86.pnach
@@ -1,11 +1,13 @@
-gametitle=Paris-Dakar Rally (U)(SLUS-20324)
+gametitle=Paris Dakar Rally SLUS-20324 EC3E8E86
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-
-//Widescreen hack 16:9
+description=Widescreen hack 16:9
 patch=1,EE,001ab57c,word,3c033f10 //3c033f40 Menu
 patch=1,EE,0017beb0,word,3c023f10 //3c023f40 Gameplay
 
-
+[60 FPS]
+author=asasega
+description=Might need EE Overclock.
+patch=1,EE,2012A164,extended,2C420001 //2C420002

--- a/patches/SLUS-20620_1E4F42FF.pnach
+++ b/patches/SLUS-20620_1E4F42FF.pnach
@@ -1,8 +1,22 @@
 gametitle=Smash Cars NTSC-U SLUS-20620 1E4F42FF
 
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=sergx12
+description=Widescreen Hack
+patch=1,EE,00123a5c,word,3c023cbe //3c023c8e fov singleplayer
+patch=1,EE,00123a64,word,3442a2d8 //3442fa35
+patch=1,EE,00123aa4,word,3c023cbe //
+patch=1,EE,00123aac,word,3442a2d8 //
+patch=1,EE,00123c3c,word,3c023cbe // fov multiplayer
+patch=1,EE,00123c44,word,3442a2d8 //
+patch=1,EE,00123c98,word,3c023cbe //
+patch=1,EE,00123ca0,word,3442a2d8 //
+patch=1,EE,001b06bc,word,3c033fab //3c033f80 vert fov
+
 [60 FPS]
 author=Gabominated
-description=Might need EE Overclock.
-patch=1,EE,201B0E7C,extended,2C410002 //2C410002
+description=Might need EE Overclock (130%).
+patch=1,EE,201B0E7C,extended,2C410002
 patch=1,EE,E0010001,extended,00394C30
 patch=1,EE,101B0E7C,extended,2C410001

--- a/patches/SLUS-20770_4CE187F6.pnach
+++ b/patches/SLUS-20770_4CE187F6.pnach
@@ -1,7 +1,8 @@
-gametitle=LotR The - The Return of the King  SLUS_207.70
+gametitle=Lord of the Rings, The - The Return of the King NTSC-U SLUS-20770 4CE187F6
 
 [Widescreen 16:9]
 gsaspectratio=16:9
+author=sergx12
 description=Widescreen Hack
 patch=1,EE,21019110,extended,3F400000 // 3F800000
 patch=1,EE,21019120,extended,442b0000 // 44000000
@@ -9,5 +10,5 @@ patch=1,EE,21019128,extended,3Fab0000 // 3F800000
 
 [60 FPS]
 author=Gabominated
-description=Unlocked at 60 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,2014B768,extended,10000013 //14400003
+description=Might need EE Overclock.
+patch=1,EE,0014B784,word,3C030000 //3C033F80

--- a/patches/SLUS-20817_2F5EB1FF.pnach
+++ b/patches/SLUS-20817_2F5EB1FF.pnach
@@ -1,4 +1,4 @@
-gametitle=Headhunter - Redemption SLUS_208.17
+gametitle=Headhunter - Redemption NTSC-U SLUS-20817 2F5EB1FF
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -7,4 +7,16 @@ patch=1,EE,00190618,word,3c014310
 patch=1,EE,00190648,word,3c013fe3
 patch=1,EE,0019064c,word,34218e38
 
+[60 FPS]
+author=Gabominated
+description=Might need EE overclock (180%).
+patch=1,EE,20157D70,extended,0042102a
+patch=1,EE,201670c0,extended,2403003c
+patch=1,EE,2043BAA4,extended,0000001E
+patch=1,EE,E0010001,extended,005CCFF8
+patch=1,EE,20157D70,extended,0043102a
 
+[Disable Blur]
+author=Gabominated
+description=Disable post-processing blur effect.
+patch=1,EE,001464AC,word,00000000

--- a/patches/SLUS-20845_D6D704BB.pnach
+++ b/patches/SLUS-20845_D6D704BB.pnach
@@ -1,28 +1,34 @@
-gametitle=Cold Winter (SLUS-20845)
+gametitle=Cold Winter NTSC-U SLUS-20845 D6D704BB
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=nemesis2000
-
+description=Widescreen hack
 patch=1,EE,003c4cf4,word,3c013f40
 patch=1,EE,003c4cfc,word,44810800
 patch=1,EE,003c4d00,word,03e00008
 patch=1,EE,003c4d04,word,4601a083
-
 //weapon
 patch=1,EE,00310f4c,word,c6740330
 patch=1,EE,00310f54,word,c7a30048
 patch=1,EE,00310f60,word,e7a20050
 patch=1,EE,00310f64,word,c6620330
-
 //gameplay
 patch=1,EE,001dcc34,word,8E440058
 patch=1,EE,001dcc40,word,e7a20040
 
-//480p
-patch=1,EE,004f677c,word,3c050000
-patch=1,EE,004f6784,word,3c060050
-patch=1,EE,004f678c,word,3c070001
-patch=1,EE,004f69e4,word,3c090010
+[60 FPS]
+author=felixthecat1970
+description=Might need EE Overclock
+patch=0,EE,201FE694,extended,24020001
+patch=0,EE,2042A534,extended,24630000
+patch=0,EE,2042A548,extended,24840000
 
-
+[480p Mode]
+author=felixthecat1970
+description=SDTV 480p mode at start.
+patch=0,EE,10107C60,extended,00000001
+patch=0,EE,10679C0C,extended,000001C0
+patch=0,EE,1042983C,extended,240201C0
+patch=0,EE,10106858,extended,00000001
+patch=0,EE,203C0018,extended,080F000C

--- a/patches/SLUS-20850_71584BAC.pnach
+++ b/patches/SLUS-20850_71584BAC.pnach
@@ -1,13 +1,16 @@
-gametitle=Blowout (SLUS-20850)
+gametitle=Blowout NTSC-U SLUS-20850 71584BAC
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=nemesis2000
-
+description=Widescreen hack
 patch=1,EE,001D1A3C,word,00000000
 patch=1,EE,003BB878,word,00000001
 patch=1,EE,003B8C34,word,C0222222
 patch=1,EE,003B8C4C,word,40222222
 patch=1,EE,003B8C6C,word,40222222
 
-
+[60 FPS]
+author=asasega
+description=Might need EE overclock (130%).
+patch=1,EE,202B1578,extended,28630001 //28630002

--- a/patches/SLUS-20943_83FB515E.pnach
+++ b/patches/SLUS-20943_83FB515E.pnach
@@ -1,28 +1,21 @@
-gametitle=Heroes of the Pacific (U)(SLUS-20943)
+gametitle=Heroes of the Pacific NTSC-U SLUS-20943 83FB515E
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Arapapa
-
-//Widescreen hack 16:9
-
-patch=1,EE,001bb1c8,word,08052064 // c6010068
-patch=1,EE,001bb1cc,word,00000000 // c602006c
-
-patch=1,EE,00148190,word,3c013f40 // 00000000
-patch=1,EE,00148194,word,4481f000 // 00000000
-patch=1,EE,00148198,word,c6010068 // 00000000
-patch=1,EE,0014819c,word,c602006c // 00000000
-patch=1,EE,001481a0,word,461e0843 // 00000000
-patch=1,EE,001481a4,word,e6010068 // 00000000
-patch=1,EE,001481a8,word,0806ec74 // 00000000
+author=Gabominated
+description=Widescreen hack
+patch=1,EE,20799100,extended,3FE38E3A //3FAAAAA7
+patch=1,EE,2067D740,extended,3F249244 //3F5B6DB6
+patch=1,EE,20799250,extended,3FE38E3A //3FAAAAA7
+patch=1,EE,20799254,extended,42C20000 //42920000
+patch=1,EE,207992E0,extended,00000002 //00000000
+patch=1,EE,20A178E4,extended,b3000000 //b3000000
 
 [60 FPS]
 author=Gabominated
-description=Unlocked at 60 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,001CA814,word,10000007 //10400007
-patch=1,EE,E0043D08,extended,0067D8B2
-patch=1,EE,1067D8B2,extended,00003C88
-patch=1,EE,1067D8B6,extended,00003C88
-patch=1,EE,1067D8BA,extended,00003C88
-patch=1,EE,1067D8BE,extended,00003C88
+description=Might need EE Overclock.
+patch=1,EE,201CA848,word,24020002
+patch=1,EE,0067D8B0,word,3c888889
+patch=1,EE,0067D8B4,word,3c888889
+patch=1,EE,0067D8B8,word,3c888889
+patch=1,EE,0067D8BC,word,3c888889

--- a/patches/SLUS-21020_83C9749E.pnach
+++ b/patches/SLUS-21020_83C9749E.pnach
@@ -1,12 +1,17 @@
-gametitle=Gungrave Overdose (NTSC-U)
+gametitle=Gungrave - Overdose NTSC-U SLUS-21020 83C9749E
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-
+description=Widescreen hack
 // 16:9 (search 00000000 00000000 43ad1346 00000000)
 patch=1,EE,00288904,word,3c013f40 // 00000000 hor fov
 patch=1,EE,00288908,word,44810000 // 00000000
 patch=1,EE,00288910,word,4600c602 // 00000000
 
-
+[60 FPS]
+author=Gabominated
+description=Might need EE Overclock (180%).
+patch=1,EE,20101B84,extended,28420001
+patch=1,EE,E0010019,extended,00431544
+patch=1,EE,20101B84,extended,28420002

--- a/patches/SLUS-21026_AE1F3139.pnach
+++ b/patches/SLUS-21026_AE1F3139.pnach
@@ -1,10 +1,9 @@
-gametitle=Battlefield 2: Modern Combat (SLUS-21026)
+gametitle=Battlefield 2 - Modern Combat NTSC-U SLUS-21026 AE1F3139
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Nemesis
+author=nemesis2000
 description=Widescreen hack
-
 patch=1,EE,0022d4b0,word,3c013fab
 patch=1,EE,0022d8e8,word,3c013fab
 patch=1,EE,003bf5c0,word,3c013f40
@@ -12,9 +11,7 @@ patch=1,EE,003bf5d0,word,4481f000
 patch=1,EE,003bf69c,word,461e0303
 patch=1,EE,003bfd88,word,461e0303
 patch=1,EE,0040b4fc,word,461e0303
-
 patch=1,EE,0027C1C8,word,24020002 // vert- widescreen turn on
-
 //vert- widescreen correction
 patch=1,EE,0022d490,word,3c013fab
 patch=1,EE,0022d8c8,word,3c013fab
@@ -22,5 +19,5 @@ patch=1,EE,0022d8c8,word,3c013fab
 
 [60 FPS]
 author=asasega
-description=Unlocked at 60 FPS. Might need enable EE Overclock to be stable.
+description=Might need EE Overclock.
 patch=1,EE,0022DD7C,word,24630001

--- a/patches/SLUS-21037_2BDA8ADB.pnach
+++ b/patches/SLUS-21037_2BDA8ADB.pnach
@@ -1,4 +1,4 @@
-gametitle=Project - Snowblind SLUS-21037 2BDA8ADB secundary crc 7849F069
+gametitle=Project - Snowblind SLUS-21037 2BDA8ADB secondary crc 7849F069
 //Corresponds to the main crc to activate the secondary crc 7849F069 called B03GM.ELF
 
 [Widescreen 16:9]
@@ -8,4 +8,8 @@ description=Widescreen Hack
 
 [60 FPS]
 author=asasega & Gabominated
-description=Unlocked at 60 FPS. Might need enable EE Overclock to be stable.
+description=Might need EE Overclock.
+
+[Disable Blur/Bloom]
+author=Gabominated
+description=Disable post-processing blur/bloom effect.

--- a/patches/SLUS-21037_7849F069.pnach
+++ b/patches/SLUS-21037_7849F069.pnach
@@ -1,4 +1,4 @@
-gametitle=Project - Snowblind SLUS-21037 2BDA8ADB secundary crc 7849F069
+gametitle=Project - Snowblind NTSC-U SLUS-21037 2BDA8ADB secondary crc 7849F069
 //Game changes ELF when select single player to BO3GM.ELF with active CRC 7849F069
 
 [Widescreen 16:9]
@@ -10,5 +10,10 @@ patch=1,EE,00B764F4,word,3Fe38e39 //3FAAAAAB //cutscenes
 
 [60 FPS]
 author=asasega & Gabominated
-description=Unlocked at 60 FPS. Might need enable EE Overclock to be stable.
+description=Might need EE Overclock.
 patch=1,EE,002d4c04,word,2c620000 //0062102B
+
+[Disable Blur/Bloom]
+author=Gabominated
+description=Disable post-processing blur/bloom effect.
+patch=1,EE,004E97C8,word,00000000 //00000018

--- a/patches/SLUS-21047_ECFBAB36.pnach
+++ b/patches/SLUS-21047_ECFBAB36.pnach
@@ -1,6 +1,13 @@
-gametitle=Cold Fear (NSTC-U) SLUS-21047 ECFBAB36
+gametitle=Cold Fear NSTC-U SLUS-21047 ECFBAB36
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Gabominated
+description=Enable native widescreen.
+patch=1,EE,0046EFB4,word,00000001
+patch=1,EE,004F9500,word,01000000
 
 [60 FPS]
 author=asasega
-description=Unlocked at 60 FPS. Might need enable EE Overclock to be stable.
+description=Might need EE Overclock.
 patch=1,EE,0046E484,extended,00000001

--- a/patches/SLUS-21077_A8C4C0A9.pnach
+++ b/patches/SLUS-21077_A8C4C0A9.pnach
@@ -1,15 +1,15 @@
-gametitle=Gauntlet: Seven Sorrows (SLUS-21077)
+gametitle=Gauntlet - Seven Sorrows NTSC-U SLUS-21077 A8C4C0A9
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=nemesis2000
-
+description=Widescreen hack
 patch=1,EE,00446200,word,24020002 //built in widescreen
 
-//480p
+[480p Mode]
+author=nemesis2000
+description=SDTV 480p mode at start.
 patch=1,EE,00107244,word,3c050000
 patch=1,EE,0010724c,word,3c060050
 patch=1,EE,00107254,word,3c070001
 patch=1,EE,00107514,word,3c090010
-
-

--- a/patches/SLUS-21151_F2A25D7B.pnach
+++ b/patches/SLUS-21151_F2A25D7B.pnach
@@ -1,18 +1,24 @@
-gametitle=Cars (U)(SLUS-21151)
+gametitle=Disney/Pixar Cars NTSC-U SLUS-21151 F2A25D7B
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=El_Patas (NTSC-U by Arapapa)
-
 //Gameplay 16:9
-
-
 patch=1,EE,00116d48,word,3c023fab //3c023f80
 patch=1,EE,00116d50,word,3C033CAE //3C033C8E
 patch=1,EE,00116d54,word,34635555 //3463FA34
-
 //Render fix
 patch=1,EE,001d5dc4,word,3c03bfab //3c03bf80
 patch=1,EE,001d5dc8,word,3c023fab //3c023f80
 
+[60 FPS]
+author=Gabominated
+description=Might need EE Overclock (130%).
+patch=1,EE,001B1EE4,extended,24040001
+patch=1,EE,E0010001,extended,004956B8
+patch=1,EE,001B1EE4,extended,24040002
 
+[Disable Blur/Bloom]
+author=Gabominated
+description=Disable post-processing Blur/Bloom effect
+patch=1,EE,004F7B90,word,00000201

--- a/patches/SLUS-21376_5C891FF1.pnach
+++ b/patches/SLUS-21376_5C891FF1.pnach
@@ -1,4 +1,4 @@
-gametitle=BLACK (SLUS_21376)
+gametitle=Black NTSC-U SLUS-21376 5C891FF1
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -13,14 +13,13 @@ patch=1,EE,204CA5F4,word,3FE38E39
 patch=1,EE,204CA694,word,3FE38E39
 patch=1,EE,205BC390,word,3F400000
 
-
 [60 FPS]
-author=asasega and PeterDelta
-description=Unlocked at 60 FPS. Might need enable 180% EE Overclock to be stable.
-patch=1,EE,1040DF74,extended,00000001 // 60 fps
-patch=1,EE,205A8A9C,extended,3C888889 // speed
-patch=1,EE,204BC13C,extended,3C888889
-patch=1,EE,2040EBAC,extended,3C888889
+author=Gabominated & PeterDelta
+description=Native 60 FPS. Might need EE Overclock (180%).
+patch=1,EE,001c5b10,word,24040001 //24040002
+patch=1,EE,0012508C,word,24040001 //24040002
+patch=1,EE,00102648,word,2404003c //2404001e
+patch=1,EE,00125078,word,2410003c //2410001e
 
 [Video Mode]
 author=Gabominated

--- a/patches/SLUS-21428_EB6C8519.pnach
+++ b/patches/SLUS-21428_EB6C8519.pnach
@@ -1,5 +1,12 @@
 gametitle=Bionicle Heroes NTSC-U SLUS-21428 EB6C8519
 
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Gabominated
+description=Enable native widescreen.
+patch=1,EE,00388D04,word,3C013F10 //3C013F00 zoom fix
+patch=1,EE,0065F798,word,00000001 //00000000
+
 [60 FPS]
 author=Gabominated
 description=Might need EE Overclock.

--- a/patches/SLUS-21600_F52477F7.pnach
+++ b/patches/SLUS-21600_F52477F7.pnach
@@ -1,13 +1,13 @@
-gametitle=Spider-Man: Friend or Foe (NTSC-U)
+gametitle=Spider-Man - Friend or Foe NTSC-U SLUS-21600 F52477F7
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-description=Widescreen Hack
-
-//Gameplay 16:9
-patch=1,EE,203EC448,extended,3FE38E38 //3FAAAAAB (Increases hor. axis)
+author=Gabominated
+description=Enable native widescreen.
+patch=1,EE,003F0BD4,word,00000100
+patch=1,EE,004075F0,word,00000001
 
 [60 FPS]
 author=Gabominated
-description=Unlocked at 60 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,2037DCA0,extended,00000001 //00000002
+description=Might need EE Overclock (180%).
+patch=1,EE,0037DCA0,word,00000001 //00000002


### PR DESCRIPTION
Update, addition and improvement of several patches, below are some previews

Disable blur in Castleween
![Castleween_SLES-51249_20250306151311](https://github.com/user-attachments/assets/cca2c97d-9f48-4730-b243-43fd4fad5df2)
![Castleween_SLES-51249_20250306151315](https://github.com/user-attachments/assets/a8b14b7a-a175-438b-a7a5-ec1e1da77f21)
![Castleween_SLES-51249_20250306151545](https://github.com/user-attachments/assets/56105c1a-6b1a-43e7-86cc-51f54fdfb636)
![Castleween_SLES-51249_20250306151555](https://github.com/user-attachments/assets/5e07ab4b-2a12-4e58-ab9c-35177132ac57)

Unlock NTSC mode with 480p mode include at option menu in Disney/Pixar Cars - Race-O-Rama PAL-M
![Disney_Pixar Cars - Race-O-Rama_SLES-55536_20250124232155](https://github.com/user-attachments/assets/3d5993eb-2670-4298-b3e8-ea9dc5ba51c8)
![Disney_Pixar Cars - Race-O-Rama_SLES-55536_20250306182341](https://github.com/user-attachments/assets/6e8ba9e2-2833-450b-ab2d-f6f1f0db0443)
![Disney_Pixar Cars - Race-O-Rama_SLES-55536_20250124231001](https://github.com/user-attachments/assets/b4736582-21a2-4050-a79b-2114e93122bb)

Disable Blur/Bloom in Disney/Pixar Cars NTSC-U
![Disney_Pixar Cars_SLUS-21151_20250304212047](https://github.com/user-attachments/assets/546f11d2-ed1b-4835-9305-60e56af7d47b)
![Disney_Pixar Cars_SLUS-21151_20250304212058](https://github.com/user-attachments/assets/8fb0f7ea-6acb-4653-9b37-8b092f6292b2)
![Disney_Pixar Cars_SLUS-21151_20250304212218](https://github.com/user-attachments/assets/74335b6a-a1ff-464d-8050-ae103e6372c9)
![Disney_Pixar Cars_SLUS-21151_20250304212228](https://github.com/user-attachments/assets/96677163-b321-4151-94e8-51e7f4c0008a)
![Disney_Pixar Cars_SLUS-21151_20250304214639](https://github.com/user-attachments/assets/bce78ddf-50ed-4a94-b2cc-028b264a1182)
![Disney_Pixar Cars_SLUS-21151_20250304214645](https://github.com/user-attachments/assets/7e251281-252e-47c1-93b1-583597100472)

Disable Blur in Headhunter - Redemption
![Headhunter - Redemption_SLUS-20817_20250304162025](https://github.com/user-attachments/assets/1ee562c2-1add-415a-92da-ca5d17f68a87)
![Headhunter - Redemption_SLUS-20817_20250304162052](https://github.com/user-attachments/assets/95019ac0-3df1-403f-a633-85ea126e4006)
![Headhunter - Redemption_SLUS-20817_20250304162838](https://github.com/user-attachments/assets/753a511d-86b5-461d-8aa4-43094e6d0193)
![Headhunter - Redemption_SLUS-20817_20250304162902](https://github.com/user-attachments/assets/66637944-785f-4340-bb6f-63b01bfdf813)
![Headhunter - Redemption_SLUS-20817_20250306144537](https://github.com/user-attachments/assets/88efd3e7-5aff-4828-a563-b7606994afbb)
![Headhunter - Redemption_SLUS-20817_20250306144546](https://github.com/user-attachments/assets/13d54357-bda5-4620-b452-731381d13fae)
![Headhunter - Redemption_SLUS-20817_20250306145157](https://github.com/user-attachments/assets/dc461d5e-e775-4df0-92e2-f48417f4bd77)
![Headhunter - Redemption_SLUS-20817_20250306145202](https://github.com/user-attachments/assets/58268714-d391-4935-8e0f-1f5538c83cd7)

Current Widescreen patch in Heroes of the Pacific
![Heroes of the Pacific_SLUS-20943_20250128155630](https://github.com/user-attachments/assets/915eadf0-5b8b-4d8c-aa59-58f993e158d3)
New patch that includes HUD and shadows
![Heroes of the Pacific_SLUS-20943_20250128160051](https://github.com/user-attachments/assets/23e50773-df08-4eb5-b842-5efd02de70db)

Disable noise filter in Killzone NTSC-U
![Killzone_SCUS-97402_20250218194728](https://github.com/user-attachments/assets/21fa2647-a70c-4506-9c95-686e0fe8e061)
![Killzone_SCUS-97402_20250218194718](https://github.com/user-attachments/assets/2ffb59c3-7a30-4e00-86e2-826f249fe000)

Adding Widescreen patch in Legacy of Kain - Soul Reaver 2 v1.01 and  v2.00
![Legacy of Kain - Soul Reaver 2_SLUS-20165_20250216151545](https://github.com/user-attachments/assets/595f6ddd-d8d1-4479-9d80-2c79ff6347fd)
![Legacy of Kain - Soul Reaver 2_SLUS-20165_20250216151521](https://github.com/user-attachments/assets/ba4e94f4-c39b-49d7-b635-665fc3355e89)
![Legacy of Kain - Soul Reaver 2_SLUS-20165_20250216171654](https://github.com/user-attachments/assets/6fb2befb-2501-4f65-8674-cb843a314488)
![Legacy of Kain - Soul Reaver 2_SLUS-20165_20250216171702](https://github.com/user-attachments/assets/23e1ec0c-a9a0-4e1e-8112-248251e38311)

Adding Widescreen patch in London Racer World Challenge
![London Racer World Challenge_SLES-51580_20241121142705](https://github.com/user-attachments/assets/438e60a5-741a-4269-8327-6b4f21d1199a)
![London Racer World Challenge_SLES-51580_20241121142554](https://github.com/user-attachments/assets/66c5361e-5a4d-46c1-ac00-58f9cf086bfa)

Diable bloom that causes ghosting in Project - Snowblind NTSC-U
![Project - Snowblind_SLUS-21037_20250217225940](https://github.com/user-attachments/assets/61fda12a-5830-4946-88ac-897ae4414408)
![Project - Snowblind_SLUS-21037_20250217225947](https://github.com/user-attachments/assets/971565ab-cef4-41e9-aa9a-1bc9a22f37bf)
