### PR TITLE
Disable more 60 fps patches

### DIFF
--- a/patches/SLUS-21273_8BE5DFF3.pnach
+++ b/patches/SLUS-21273_8BE5DFF3.pnach
@@ -1,7 +1,7 @@
-gametitle=Matrix, The - Path of Neo (U)(SLUS-21273)
+//gametitle=Matrix, The - Path of Neo (U)(SLUS-21273)
 
-[60 FPS]
-author=asasega
-description=Unlocked at 60 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,00463E1C,word,3F800000
-patch=1,EE,00463E2C,word,42700000
+//[60 FPS]
+//author=asasega
+//description=Unlocked at 60 FPS. Might need enable EE Overclock to be stable. Disabled due to causing instablility and soft locks.
+//patch=1,EE,00463E1C,word,3F800000
+//patch=1,EE,00463E2C,word,42700000

--- a/patches/SLUS-21661_8FCCB5D9.pnach
+++ b/patches/SLUS-21661_8FCCB5D9.pnach
@@ -7,5 +7,6 @@ description=Patches the game to run at Widescreen 16:9 aspect ratio.
 patch=1,EE,0011940C,word,3C013F4d
 patch=1,EE,00119410,word,3421b6e0
 
-[60 FPS]
-patch=1,EE,20268558,extended,00000001
+//[60 FPS]
+// Breaks jumping.
+//patch=1,EE,20268558,extended,00000001


### PR DESCRIPTION
Disables Matrix Path of Neo NTSC 60 fps patch and Ben 10 Protector of The Earth 60 fps as they both break aspects of the games.

Fixes #524 