### PR TITLE
Add NTSC Mode patch for Road Rage 3

### DIFF
--- a/patches/SLES-51930_09736614.pnach
+++ b/patches/SLES-51930_09736614.pnach
@@ -12,7 +12,11 @@ description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 //Search pattern: 3829050008004264 (little endian)
 //Search mask:    ffffffffffffffff
-patch=1,EE,0020c8ec,word,00000000 //64420008
-patch=1,EE,0020ca84,word,00000000 //64420008
+patch=0,EE,2020c8ec,extended,00000000 //64420008
+patch=0,EE,2020ca84,extended,00000000 //64420008
 
+[NTSC Mode]
+author=Souzooka
+description=Forces game to run in NTSC mode (restart required).
 
+patch=0,EE,20118E58,extended,24060002 // addiu a2,zero,0x2


### PR DESCRIPTION
Adds NTSC mode patch to Road Rage 3 -- also has the side effect of correcting game speed because this is one of those bad PAL ports. As far as I know nothing else needs to be adjusted to correct for the change in game speed. Even the in-game timer has 8 and 1/3rds seconds pass in 10 seconds in the original PAL mode.

Also changed the no-interlacing patch to use patch=0 since it patches the code segment.