### PR TITLE
Add de-interlace and ntsc mode patches for Project Minerva Professional (EU)

### DIFF
--- a/patches/SLES-52472_0AF4683D.pnach
+++ b/patches/SLES-52472_0AF4683D.pnach
@@ -1,0 +1,15 @@
+gametitle=Project Minerva Professional (PAL) (SLES_524.72)
+
+[No-Interlacing]
+author=Souzooka
+gsinterlacemode=1
+description=Attempts to disable interlaced offset rendering.
+
+patch=0,EE,201C21EC,extended,00000000 // nop
+
+[NTSC Mode]
+author=Souzooka
+description=Sets game to NTSC Mode upon startup (display mode can be changed in-game).
+
+// Changes code immediate used to set display mode setting from 1 -> 0
+patch=0,EE,201C00E0,extended,00008021 // addu s0,zero,zero


### PR DESCRIPTION
Adds patches to remove interlacing artefacts and force the game to NTSC upon startup (after reaching the title menu, you can scroll down to options and change to NTSC, but this patch just does that for the user).