### PR TITLE
Update patches

### DIFF
--- a/patches/SCES-51164_A2837592.pnach
+++ b/patches/SCES-51164_A2837592.pnach
@@ -70,3 +70,8 @@ patch=1,EE,0029F904,word,31310000 //31310001
 patch=1,EE,002A1CAC,word,30B20000 //30B20001
 patch=1,EE,00326DBC,word,00000000 //64420008
 patch=1,EE,00326E44,word,00000000 //64420008
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=0,EE,0010024C,word,240A0002

--- a/patches/SCES-52004_6624A78C.pnach
+++ b/patches/SCES-52004_6624A78C.pnach
@@ -19,3 +19,10 @@ patch=1,EE,205DB004,extended,3F800000
 author=Gabominated
 description=Enable native NTSC Mode at start instead PAL Mode..
 patch=1,EE,001BD6B4,word,38420001
+
+[Disable Noise Effect]
+author=PeterDelta
+description=Disable noise filter in gameplay
+patch=1,EE,0055EBE8,extended,00000001
+patch=1,EE,E0010004,extended,0057C708
+patch=1,EE,0055EBE8,extended,00000002

--- a/patches/SCES-53133_FB0E6D72.pnach
+++ b/patches/SCES-53133_FB0E6D72.pnach
@@ -141,11 +141,8 @@ patch=1,EE,202FF9B0,extended,3FE38E39
 patch=1,EE,202FF9E8,extended,3FE38E39
 patch=1,EE,20331330,extended,3FE38E39
 
-[480p Mode]
-gsinterlacemode=1
-author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,0029DACC,extended,00000001
-patch=1,EE,E0019680,extended,0029D114
-patch=1,EE,0029DACC,extended,00000000
-patch=1,EE,2029D284,extended,3F555550
+//[480p Mode]
+//author=PeterDelta
+//description=SDTV 480p mode at start. Cannot be conditioned, FMV no sync, gameplay is fine
+//patch=1,EE,0029DACC,extended,00000001
+//patch=1,EE,2029D284,extended,3F555550

--- a/patches/SCUS-97399_D6385328.pnach
+++ b/patches/SCUS-97399_D6385328.pnach
@@ -1,9 +1,9 @@
-gametitle=God of War (SCUS-97399)
+gametitle=God of War (NTSC-U) (SCUS-97399) D6385328
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=nemesis2000
-
+description=Widescreen fix
 patch=1,EE,00169250,word,3c013f11
 patch=1,EE,00169254,word,342135fc
 patch=1,EE,00169258,word,44812000
@@ -30,7 +30,7 @@ patch=1,EE,001692a8,word,c605037c
 patch=1,EE,001692ac,word,e604037c
 patch=1,EE,001692b0,word,c605037c
 patch=1,EE,001692b4,word,3c020033
-patch=1,EE,001692b8,word,3c013f40
+//patch=1,EE,001692b8,word,3c013f40
 patch=1,EE,001692bc,word,44810800
 patch=1,EE,001692c0,word,c442f1b0
 patch=1,EE,001692c4,word,46020842
@@ -132,10 +132,19 @@ patch=1,EE,00169440,word,7ba20060
 patch=1,EE,00169444,word,7c820030
 patch=1,EE,00169448,word,03e00008
 patch=1,EE,0016944c,word,27bd0090
+patch=1,EE,e0020001,extended,0029cc90 //FMV_Fix
+patch=1,EE,20304d94,extended,00000002
+patch=1,EE,2021e4f0,extended,24070000
+patch=1,EE,e0010000,extended,0029cc90
+patch=1,EE,2021E4f0,extended,8c47cc90
+patch=1,EE,e0020001,extended,0029cc50 //Menu_Background_Fix
+patch=1,EE,e0010001,extended,0029cc90
+patch=1,EE,201692b8,extended,3c013f10
 
-patch=1,EE,e0010424,extended,0110f088
-patch=1,EE,2110f060,extended,be96e345
+patch=1,EE,e0020000,extended,0029cc50
+patch=1,EE,e0010001,extended,0029cc90
+patch=1,EE,201692b8,extended,3c013f40
 
-//patch=1,EE,00169268,word,3c013f22  //old value
-
-
+patch=1,EE,e0020001,extended,0029cc50
+patch=1,EE,e0010000,extended,0029cc90
+patch=1,EE,201692b8,extended,3c013f40

--- a/patches/SLES-50054_8CB701AF.pnach
+++ b/patches/SLES-50054_8CB701AF.pnach
@@ -14,7 +14,12 @@ patch=1,EE,2047A714,extended,3F400000
 patch=1,EE,2047A73C,extended,3F400000
 patch=1,EE,204280E0,extended,3F400000
 
-[50 FPS]
+[50/60 FPS]
 author=PeterDelta
 description=Might need EE Overclock (130%).
 patch=1,EE,00304844,extended,00000001
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,00275180,word,0000102D

--- a/patches/SLES-50071_831078BD.pnach
+++ b/patches/SLES-50071_831078BD.pnach
@@ -14,7 +14,12 @@ patch=1,EE,2047B594,extended,3F400000
 patch=1,EE,2047B5BC,extended,3F400000
 patch=1,EE,20428F60,extended,3F400000
 
-[50 FPS]
+[50/60 FPS]
 author=PeterDelta
 description=Might need EE Overclock (130%).
 patch=1,EE,003054C4,extended,00000001
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,00275CEC,word,0000102D

--- a/patches/SLES-50504_F9E3CF90.pnach
+++ b/patches/SLES-50504_F9E3CF90.pnach
@@ -8,11 +8,7 @@ patch=1,EE,002aa624,extended,3c013fe3
 patch=1,EE,002aa628,extended,34218e38
 patch=1,EE,002a9e60,extended,3c013f2b
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,002EEFA0,word,34050050
-patch=1,EE,002EEFA4,word,24030002
-patch=1,EE,002EEFA8,word,0000000C
-patch=1,EE,002EEFAC,word,03E00008
+description=NTSC mode at start.
+patch=1,EE,0023CCD8,word,14000011

--- a/patches/SLES-50505_F9E3CF90.pnach
+++ b/patches/SLES-50505_F9E3CF90.pnach
@@ -8,11 +8,7 @@ patch=1,EE,002aa624,extended,3c013fe3
 patch=1,EE,002aa628,extended,34218e38
 patch=1,EE,002a9e60,extended,3c013f2b
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,002EEFA0,word,34050050
-patch=1,EE,002EEFA4,word,24030002
-patch=1,EE,002EEFA8,word,0000000C
-patch=1,EE,002EEFAC,word,03E00008
+description=NTSC mode at start.
+patch=1,EE,0023CCD8,word,14000011

--- a/patches/SLES-50507_F9E3CF90.pnach
+++ b/patches/SLES-50507_F9E3CF90.pnach
@@ -8,11 +8,7 @@ patch=1,EE,002aa624,extended,3c013fe3
 patch=1,EE,002aa628,extended,34218e38
 patch=1,EE,002a9e60,extended,3c013f2b
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,002EEFA0,word,34050050
-patch=1,EE,002EEFA4,word,24030002
-patch=1,EE,002EEFA8,word,0000000C
-patch=1,EE,002EEFAC,word,03E00008
+description=NTSC mode at start.
+patch=1,EE,0023CCD8,word,14000011

--- a/patches/SLES-50508_F9E3CF90.pnach
+++ b/patches/SLES-50508_F9E3CF90.pnach
@@ -8,11 +8,7 @@ patch=1,EE,002aa624,word,3c013fe3
 patch=1,EE,002aa628,word,34218e38
 patch=1,EE,002a9e60,word,3c013f2b
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,002EEFA0,word,34050050
-patch=1,EE,002EEFA4,word,24030002
-patch=1,EE,002EEFA8,word,0000000C
-patch=1,EE,002EEFAC,word,03E00008
+description=NTSC mode at start.
+patch=1,EE,0023CCD8,word,14000011

--- a/patches/SLES-50509_F9E3CF90.pnach
+++ b/patches/SLES-50509_F9E3CF90.pnach
@@ -8,11 +8,7 @@ patch=1,EE,002aa624,word,3c013fe3
 patch=1,EE,002aa628,word,34218e38
 patch=1,EE,002a9e60,word,3c013f2b
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,002EEFA0,word,34050050
-patch=1,EE,002EEFA4,word,24030002
-patch=1,EE,002EEFA8,word,0000000C
-patch=1,EE,002EEFAC,word,03E00008
+description=NTSC mode at start.
+patch=1,EE,0023CCD8,word,14000011

--- a/patches/SLES-50812_CB179BA2.pnach
+++ b/patches/SLES-50812_CB179BA2.pnach
@@ -1,4 +1,4 @@
-gametitle=Spider-Man - The Movie (E)(SLES-50812)
+gametitle=Spider-Man (PAL-E) SLES-50812 CB179BA2
 
 //[Widescreen 16:9]
 //gsaspectratio=16:9
@@ -13,3 +13,9 @@ gametitle=Spider-Man - The Movie (E)(SLES-50812)
 //patch=1,EE,002b5e64,word,3c013c28 //3c013c0e
 
 //Missing render fix
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,004CCCA0,word,00000001
+patch=1,EE,004CCCA8,word,000001C0

--- a/patches/SLES-50876_E94FBF35.pnach
+++ b/patches/SLES-50876_E94FBF35.pnach
@@ -1,6 +1,12 @@
 gametitle=Driv3r (PAL-M) SLES-50876 E94FBF35
 
-[50 FPS]
+[50/60 FPS]
 author=PeterDelta
 description=Might need EE Overclock (130%).
-patch=1,EE,00297810,word,24440002
+patch=0,EE,00297810,word,24440002
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=0,EE,002862B0,word,14A00006
+patch=0,EE,0029D77C,word,24060002

--- a/patches/SLES-50965_CCF57297.pnach
+++ b/patches/SLES-50965_CCF57297.pnach
@@ -1,4 +1,4 @@
-gametitle=Spider-Man - The Movie (S)(SLES-50965) CCF57297
+gametitle=Spider-Man (PAL-S) SLES-50965 CCF57297
 
 //[Widescreen 16:9]
 //gsaspectratio=16:9
@@ -9,3 +9,9 @@ gametitle=Spider-Man - The Movie (S)(SLES-50965) CCF57297
 //Zoom
 //patch=1,EE,002b5e64,word,3c013c28 //3c013c0e
 //Missing render fix
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,004CD0A0,word,00000001
+patch=1,EE,004CD0A8,word,000001C0

--- a/patches/SLES-51192_C5473413.pnach
+++ b/patches/SLES-51192_C5473413.pnach
@@ -32,4 +32,12 @@ description=Widescreen Hack
 
 // Commented out as it broke loading screen font and other stuff.
 
+[50/60 FPS]
+author=asasega
+description=Might need EE Overclock (130%).
+patch=1,EE,00544168,word,00000001
 
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=0,EE,001BDAD4,word,241001C0

--- a/patches/SLES-51194_C5473413.pnach
+++ b/patches/SLES-51194_C5473413.pnach
@@ -1,10 +1,5 @@
 gametitle=Harry Potter und die Kammer des Schreckens (G)[SLES-51194] CRC C5473413
 
-[50 FPS]
-author=asasega
-description=Unlocked at 50 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,00544168,word,00000001
-
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=arapapa
@@ -16,3 +11,13 @@ patch=1,EE,004CA79C,word,34210000 // 34210FDA
 // Y-FOV
 patch=1,EE,004E8EB0,word,3C013FE3 // 3C013FAA
 patch=1,EE,004E8EB4,word,34218E2A // 3421AAAB
+
+[50/60 FPS]
+author=asasega
+description=Might need EE Overclock (130%).
+patch=1,EE,00544168,word,00000001
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=0,EE,001BDAD4,word,241001C0

--- a/patches/SLES-51250_3DF10389.pnach
+++ b/patches/SLES-51250_3DF10389.pnach
@@ -1,13 +1,13 @@
-gametitle=Shox (PAL)
+gametitle=Shox - Rally Reinvented (PAL-E) SLES-51250 3DF10389
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Arapapa
+author=PeterDelta
+description=Enable native widescreen
+patch=1,EE,0035B978,extended,16280001
 
-//Widescreen hack 16:9
-
-//X-Fov
-patch=1,EE,00206354,word,3c013fe3 //3c013faa
-patch=1,EE,00206358,word,34218e2a //3421aaab
-
-
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,002277C0,word,1440000C
+patch=1,EE,00356E54,word,00000000

--- a/patches/SLES-51251_DDAC3815.pnach
+++ b/patches/SLES-51251_DDAC3815.pnach
@@ -1,0 +1,13 @@
+gametitle=Shox - Rally Reinvented (PAL-A) SLES-51251 DDAC3815
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Enable native widescreen
+patch=1,EE,0035BBF8,extended,16280001
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,00227880,word,1440000C
+patch=1,EE,003570D4,word,00000000

--- a/patches/SLES-51333_5BE3F481.pnach
+++ b/patches/SLES-51333_5BE3F481.pnach
@@ -4,20 +4,18 @@ gametitle=Dark Angel (PAL-M) SLES-51333 5BE3F481
 gsaspectratio=16:9
 author=PeterDelta
 description=Renders the game in 16:9 aspect ratio
-patch=1,EE,002504BC,word,3C013F30
-patch=1,EE,0034AB30,word,3C013F1A
-patch=1,EE,00280878,word,3C013FE3
-patch=1,EE,0028AB98,word,3C013F22
+patch=0,EE,002504BC,word,3C013F30
+patch=0,EE,0034AB30,word,3C013F1A
+patch=0,EE,00280878,word,3C013FE3
+patch=0,EE,0028AB98,word,3C013F22
 
 [50/60 FPS]
 author=PeterDelta
 description=Might need EE Overclock (130%).
-patch=1,EE,00280B74,word,1040000D
+patch=0,EE,00280B74,word,1040000D
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,003B9B64,word,24110000
-patch=1,EE,003B9B68,word,24120050
-patch=1,EE,003B9B74,word,24130001
+description=NTSC mode at start.
+patch=0,EE,00338658,word,24040002
+patch=0,EE,00338668,word,240601C0

--- a/patches/SLES-51467_6EEE06DD.pnach
+++ b/patches/SLES-51467_6EEE06DD.pnach
@@ -4,13 +4,14 @@ gametitle=Freedom Fighters (PAL-E) SLES-51467 6EEE06DD FF.ELF
 gsaspectratio=16:9
 author=PeterDelta
 description=Enable native widescreen
-patch=1,EE,0056967C,byte,01
+patch=1,EE,0056967C,extended,01
 
-[480p Mode]
-gsinterlacemode=1
+[50/60 FPS]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,0046CA84,word,3C050000
-patch=1,EE,0046CA8C,word,3C060050
-patch=1,EE,0046CA94,word,3C070001
+description=Might need EE Overclock (130%).
 patch=1,EE,0056B808,word,00000000
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,0033128C,word,14A2005C

--- a/patches/SLES-51467_BADCA543.pnach
+++ b/patches/SLES-51467_BADCA543.pnach
@@ -6,6 +6,10 @@ gsaspectratio=16:9
 author=PeterDelta
 description=Enable native widescreen
 
-[480p Mode]
+[50/60 FPS]
 author=PeterDelta
-description=SDTV 480p mode at start.
+description=Might need EE Overclock (130%).
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.

--- a/patches/SLES-51468_A6698B41.pnach
+++ b/patches/SLES-51468_A6698B41.pnach
@@ -4,13 +4,14 @@ gametitle=Freedom Fighters (PAL-F) SLES-51468 A6698B41 FF.ELF
 gsaspectratio=16:9
 author=PeterDelta
 description=Enable native widescreen
-patch=1,EE,0056987C,byte,01
+patch=1,EE,0056987C,extended,01
 
-[480p Mode]
-gsinterlacemode=1
+[50/60 FPS]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,0046CB84,word,3C050000
-patch=1,EE,0046CB8C,word,3C060050
-patch=1,EE,0046CB94,word,3C070001
+description=Might need EE Overclock (130%).
 patch=1,EE,0056BA08,word,00000000
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,0033135C,word,14A2005C

--- a/patches/SLES-51468_BADCA543.pnach
+++ b/patches/SLES-51468_BADCA543.pnach
@@ -6,6 +6,10 @@ gsaspectratio=16:9
 author=PeterDelta
 description=Enable native widescreen
 
-[480p Mode]
+[50/60 FPS]
 author=PeterDelta
-description=SDTV 480p mode at start.
+description=Might need EE Overclock (130%).
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.

--- a/patches/SLES-51469_6EEE06DD.pnach
+++ b/patches/SLES-51469_6EEE06DD.pnach
@@ -4,13 +4,14 @@ gametitle=Freedom Fighters (PAL-G) SLES-51469 6EEE06DD FF.ELF
 gsaspectratio=16:9
 author=PeterDelta
 description=Enable native widescreen
-patch=1,EE,0056967C,byte,01
+patch=1,EE,0056967C,extended,01
 
-[480p Mode]
-gsinterlacemode=1
+[50/60 FPS]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,0046CA84,word,3C050000
-patch=1,EE,0046CA8C,word,3C060050
-patch=1,EE,0046CA94,word,3C070001
+description=Might need EE Overclock (130%).
 patch=1,EE,0056B808,word,00000000
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,0033128C,word,14A2005C

--- a/patches/SLES-51469_BADCA543.pnach
+++ b/patches/SLES-51469_BADCA543.pnach
@@ -6,6 +6,10 @@ gsaspectratio=16:9
 author=PeterDelta
 description=Enable native widescreen
 
-[480p Mode]
+[50/60 FPS]
 author=PeterDelta
-description=SDTV 480p mode at start.
+description=Might need EE Overclock (130%).
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.

--- a/patches/SLES-51470_6EEE06DD.pnach
+++ b/patches/SLES-51470_6EEE06DD.pnach
@@ -4,13 +4,14 @@ gametitle=Freedom Fighters (PAL-I) SLES-51470 6EEE06DD FF.ELF
 gsaspectratio=16:9
 author=PeterDelta
 description=Enable native widescreen
-patch=1,EE,0056967C,byte,01
+patch=1,EE,0056967C,extended,01
 
-[480p Mode]
-gsinterlacemode=1
+[50/60 FPS]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,0046CA84,word,3C050000
-patch=1,EE,0046CA8C,word,3C060050
-patch=1,EE,0046CA94,word,3C070001
+description=Might need EE Overclock (130%).
 patch=1,EE,0056B808,word,00000000
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,0033128C,word,14A2005C

--- a/patches/SLES-51470_BADCA543.pnach
+++ b/patches/SLES-51470_BADCA543.pnach
@@ -6,6 +6,10 @@ gsaspectratio=16:9
 author=PeterDelta
 description=Enable native widescreen
 
-[480p Mode]
+[50/60 FPS]
 author=PeterDelta
-description=SDTV 480p mode at start.
+description=Might need EE Overclock (130%).
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.

--- a/patches/SLES-51471_6EEE06DD.pnach
+++ b/patches/SLES-51471_6EEE06DD.pnach
@@ -4,13 +4,14 @@ gametitle=Freedom Fighters (PAL-S) SLES-51471 6EEE06DD FF.ELF
 gsaspectratio=16:9
 author=PeterDelta
 description=Enable native widescreen
-patch=1,EE,0056967C,byte,01
+patch=1,EE,0056967C,extended,01
 
-[480p Mode]
-gsinterlacemode=1
+[50/60 FPS]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,0046CA84,word,3C050000
-patch=1,EE,0046CA8C,word,3C060050
-patch=1,EE,0046CA94,word,3C070001
+description=Might need EE Overclock (130%).
 patch=1,EE,0056B808,word,00000000
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,0033128C,word,14A2005C

--- a/patches/SLES-51471_BADCA543.pnach
+++ b/patches/SLES-51471_BADCA543.pnach
@@ -6,6 +6,10 @@ gsaspectratio=16:9
 author=PeterDelta
 description=Enable native widescreen
 
-[480p Mode]
+[50/60 FPS]
 author=PeterDelta
-description=SDTV 480p mode at start.
+description=Might need EE Overclock (130%).
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.

--- a/patches/SLES-51548_FBF2383B.pnach
+++ b/patches/SLES-51548_FBF2383B.pnach
@@ -1,29 +1,34 @@
 gametitle=X-Men 2 - Wolverine's Revenge (PAL-M3) (SLES-51548)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=ElHecht
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=ElHecht
 
 // 16:9
-patch=1,EE,002ce814,word,3c013f40 // 00000000 hor fov
+//patch=1,EE,002ce814,word,3c013f40 // 00000000 hor fov
 
 // 16:10
 //patch=1,EE,002ce814,word,3c013f55 // 00000000 hor fov
 //patch=1,EE,002ce818,word,34215555 // 00000000 hor fov
 
 // 16:9 and 16:10 modifications
-patch=1,EE,0017ec0c,word,080b3a03 // 0c068008
-patch=1,EE,0017ec10,word,00000000 // 46151f43
-patch=1,EE,0017ec14,word,00000000 // e6150000
-patch=1,EE,002ce80c,word,0c068008 // 00000000
-patch=1,EE,002ce810,word,00000000 // 00000000
-patch=1,EE,002ce81c,word,4481e800 // 00000000
-patch=1,EE,002ce820,word,461de703 // 00000000
-patch=1,EE,002ce824,word,4615ef42 // 00000000
-patch=1,EE,002ce828,word,e61d0000 // 00000000
-patch=1,EE,002ce82c,word,46151f43 // 00000000
-patch=1,EE,002ce830,word,0805fb05 // 00000000
+//patch=1,EE,0017ec0c,word,080b3a03 // 0c068008
+//patch=1,EE,0017ec10,word,00000000 // 46151f43
+//patch=1,EE,0017ec14,word,00000000 // e6150000
+//patch=1,EE,002ce80c,word,0c068008 // 00000000
+//patch=1,EE,002ce810,word,00000000 // 00000000
+//patch=1,EE,002ce81c,word,4481e800 // 00000000
+//patch=1,EE,002ce820,word,461de703 // 00000000
+//patch=1,EE,002ce824,word,4615ef42 // 00000000
+//patch=1,EE,002ce828,word,e61d0000 // 00000000
+//patch=1,EE,002ce82c,word,46151f43 // 00000000
+//patch=1,EE,002ce830,word,0805fb05 // 00000000
 //patch=1,EE,001699e8,word,3c014200 // 3c014300 remove blurry effect
-patch=1,EE,001a09f0,word,3c013fee // 3c013f80 renderfix
+//patch=1,EE,001a09f0,word,3c013fee // 3c013f80 renderfix
 
+//Causes rendering errors and crashes after level 3.
 
+[Remove Blur]
+author=PeterDelta
+description=Removes the post-processing blur effect
+patch=1,EE,001699CC,word,00000000

--- a/patches/SLES-51666_1BD0A97E.pnach
+++ b/patches/SLES-51666_1BD0A97E.pnach
@@ -9,3 +9,8 @@ patch=1,EE,002D4C64,word,3C023FE3 //3C023FAA
 patch=1,EE,002D4C68,word,34428E32 //3442AAAB
 patch=1,EE,003257C4,word,3C023FE3 //3C023FAA
 patch=1,EE,003257C8,word,34428E32 //3442AAAB
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,00438A74,word,000001C0

--- a/patches/SLES-51820_EF47C233.pnach
+++ b/patches/SLES-51820_EF47C233.pnach
@@ -1,4 +1,4 @@
-gametitle=Sniper Elite [PAL-M5] (SLES-51820) EF47C233
+gametitle=Sniper Elite (PAL-M5) SLES-51820 EF47C233
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -12,3 +12,9 @@ patch=1,EE,00502848,word,3fe38e2a //3faaaaab Y-FOV
 author=PeterDelta
 description=Might need EE Overclock at 130%.
 patch=1,EE,00198FA8,word,1460000A //1060000A
+
+[Remove Blur/Bloom]
+author=PeterDelta
+description=Removes the post-processing blur/bloom effect
+patch=1,EE,004AA378,word,00000000
+patch=1,EE,004AA370,word,01010000

--- a/patches/SLES-51870_BE44D7D5.pnach
+++ b/patches/SLES-51870_BE44D7D5.pnach
@@ -1,0 +1,14 @@
+gametitle=Disney/Pixar Buscando a Nemo (PAL-S) SLES-51870 BE44D7D5
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Renders the game in 16:9 aspect ratio
+patch=1,EE,0010AC6C,word,0C0857EA
+patch=1,EE,00215FA8,word,3C013F40
+patch=1,EE,00215FAC,word,4481F000
+patch=1,EE,00215FB0,word,461EB582
+patch=1,EE,00215FB4,word,4600A807
+patch=1,EE,00215FB8,word,0C042B1C
+patch=1,EE,0010ACB0,word,3C013F2B
+patch=1,EE,001A49C8,word,3C013F59

--- a/patches/SLES-52047_BF0D1E1A.pnach
+++ b/patches/SLES-52047_BF0D1E1A.pnach
@@ -8,7 +8,12 @@ description=Renders the game in 16:9 aspect ratio
 patch=1,EE,00293da0,word,3c013fe3 //3c013faa
 patch=1,EE,00293da4,word,34218e2a //3421aaab
 
-[50 FPS]
+[50/60 FPS]
 author=PeterDelta
 description=Might need EE Overclock at 130%.
 patch=1,EE,002A3208,word,28820001 //28820002
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,003B0A70,word,00000000

--- a/patches/SLES-52153_E94FBF35.pnach
+++ b/patches/SLES-52153_E94FBF35.pnach
@@ -1,6 +1,12 @@
 gametitle=Driv3r (PAL-M) SLES-52153 E94FBF35
 
-[50 FPS]
+[50/60 FPS]
 author=PeterDelta
-description=Might need EE Overclock at 130%.
-patch=1,EE,00297810,word,24440002 //24440001
+description=Might need EE Overclock (130%).
+patch=0,EE,00297810,word,24440002 //24440001
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=0,EE,002862B0,word,14A00006
+patch=0,EE,0029D77C,word,24060002

--- a/patches/SLES-52478_E2E67E23.pnach
+++ b/patches/SLES-52478_E2E67E23.pnach
@@ -1,16 +1,15 @@
-gametitle=Red Dead Revolver [PAL-M] SLES-52478 E2E67E23
+gametitle=Red Dead Revolver (PAL-M) SLES-52478 E2E67E23
 
 [50/60 FPS]
 author=PeterDelta
 description=Might need EE Overclock at 130%.
 patch=1,EE,001018AC,word,24030001 //24030002
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode when selecting 60 Hz
-patch=1,EE,E004F9FF,extended,007A25EC
-patch=1,EE,203CBA1C,extended,3C050000
-patch=1,EE,203CBA24,extended,3C060050
-patch=1,EE,203CBA2C,extended,3C070001
-patch=1,EE,203CBCEC,extended,3C090010
+description=NTSC mode at start.
+patch=1,EE,004FD288,word,000001C0
+patch=1,EE,004FD3A4,word,00000100
+patch=1,EE,004FD3A8,word,0000003C
+patch=1,EE,004FD3AC,word,3C888889
+patch=1,EE,007448A4,word,00000001

--- a/patches/SLES-52567_B90470B8.pnach
+++ b/patches/SLES-52567_B90470B8.pnach
@@ -1,4 +1,4 @@
-gametitle=Catwoman (E)(SLES-52567)
+gametitle=Catwoman (PAL-M) SLES-52567 B90470B8
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -10,4 +10,7 @@ author=Arapapa
 patch=1,EE,00116c64,word,3c013f80 //3c013f59
 patch=1,EE,00116c68,word,00000000 //3421999a
 
-
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,001441F8,word,24030002

--- a/patches/SLES-52733_3F0D3C94.pnach
+++ b/patches/SLES-52733_3F0D3C94.pnach
@@ -4,12 +4,10 @@ gametitle=Driven to Destruction (PAL-M) SLES-52733 3F0D3C94
 gsaspectratio=16:9
 author=PeterDelta
 description=Enable native widescreen
-patch=1,EE,003DD54C,word,00000001 //00000000
-patch=1,EE,003DD558,word,3F400000 //3F800000
-patch=1,EE,003DD560,word,00000001 //00000000
-patch=1,EE,004A7F7C,word,00000001 //00000000
-patch=1,EE,004A7F84,word,00000001 //00000000
-patch=1,EE,00524078,word,00000001 //00000000
-patch=1,EE,0052407C,word,00000001 //00000000
-patch=1,EE,00524080,word,3F800000 //00000000
-patch=1,EE,00524084,word,E3E30031 //E3E30030
+patch=1,EE,00100620,word,14400003
+
+[480p Mode]
+gsinterlacemode=1
+author=PeterDelta
+description=SDTV 480p mode at start.
+patch=1,EE,0035AE38,word,10400007

--- a/patches/SLES-52816_197641AA.pnach
+++ b/patches/SLES-52816_197641AA.pnach
@@ -15,11 +15,7 @@ description=Removes black bars in cutscenes
 patch=1,EE,00631CAC,word,00000000 //4247FFFF
 patch=1,EE,00631CB0,word,00000000 //4247FFFF
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,00104760,word,34050050
-patch=1,EE,00104764,word,24030002
-patch=1,EE,00104768,word,0000000C
-patch=1,EE,0010476C,word,03E00008
+description=NTSC mode at start.
+patch=1,EE,00173A30,word,14C00004

--- a/patches/SLES-52825_43A02228.pnach
+++ b/patches/SLES-52825_43A02228.pnach
@@ -2,15 +2,24 @@ gametitle=Serie de Catastróficas Desdichas de Lemony Snicket, Una (PAL-S) SLES-
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Arapapa
+author=Arapapa & PeterDelta
 description=Renders the game in 16:9 aspect ratio
-patch=1,EE,0019c130,word,3c013f1b //3c013f00 Zoom
-patch=1,EE,0019c17c,word,080eb428 //Y-Fov
-patch=1,EE,003ad0a0,word,46001082
-patch=1,EE,003ad0a4,word,3c013f40
-patch=1,EE,003ad0a8,word,4481f000
-patch=1,EE,003ad0ac,word,461e1082
-patch=1,EE,003ad0b0,word,08067060
+patch=1,EE,0019C130,word,3C013F1B //3c013f00 Zoom
+patch=1,EE,0019C17C,word,080EB428 //Y-Fov
+patch=1,EE,003AD0A0,word,46001082
+patch=1,EE,003AD0A4,word,3C013F40
+patch=1,EE,003AD0A8,word,4481F000
+patch=1,EE,003AD0AC,word,461E1082
+patch=1,EE,003AD0B0,word,08067060
+patch=1,EE,002EA5C4,word,080EB42D
+patch=1,EE,003AD0B4,word,C7AC0000
+patch=1,EE,003AD0B8,word,3C013FAA
+patch=1,EE,003AD0BC,word,3421AAAB
+patch=1,EE,003AD0C0,word,4481F000
+patch=1,EE,003AD0C4,word,461E6302
+patch=1,EE,003AD0C8,word,080BA972
+patch=1,EE,001C2BA4,word,3C013FAB
+patch=1,EE,0014DF08,word,3C013FAB
 
 [Remove Blackbars]
 author=Arapapa
@@ -23,10 +32,14 @@ description=Might need EE Overclock at 130%.
 patch=1,EE,0047D2C0,word,42C80000 //42480000
 patch=1,EE,0047D2C4,word,3C23D70A //3CA3D70A
 
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,002F5764,word,24020002
+patch=1,EE,003E4794,word,000001C0
+
 [480p Mode]
-gsinterlacemode=1
 author=PeterDelta
 description=SDTV 480p mode at start.
-patch=1,EE,0036C26C,word,24110000
-patch=1,EE,0036C270,word,24120050
-patch=1,EE,0036C27C,word,24130001
+patch=1,EE,002F5774,word,1400000F
+patch=1,EE,003E4794,word,000001E0

--- a/patches/SLES-53001_7A12BA1B.pnach
+++ b/patches/SLES-53001_7A12BA1B.pnach
@@ -1,0 +1,6 @@
+gametitle=NBA Street 3 (PAL-M) SLES-53001 7A12BA1B
+
+[480p Mode]
+author=PeterDelta
+description=SDTV 480p mode at start.
+patch=1,EE,00353F7C,word,14000003

--- a/patches/SLES-53020_BF6F101F.pnach
+++ b/patches/SLES-53020_BF6F101F.pnach
@@ -1,0 +1,12 @@
+gametitle=Ghost in the Shell - Stand Alone Complex (PAL-M) SLES-53020 BF6F101F
+
+[50/60 FPS]
+author=PeterDelta
+description=Might need EE Overclock (130%).
+patch=1,EE,00265820,word,24020001
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,00265804,word,24060002
+patch=1,EE,002655A0,word,240401C0

--- a/patches/SLES-53032_72DC82B5.pnach
+++ b/patches/SLES-53032_72DC82B5.pnach
@@ -19,7 +19,6 @@ patch=1,EE,E0010000,extended,01FECCF4
 patch=1,EE,0061C020,extended,00000002
 
 [480p Mode]
-gsinterlacemode=1
 author=PeterDelta
 description=Any Hz selection will output in 480p.
 patch=1,EE,0049AF94,word,00000003

--- a/patches/SLES-53124_821A0C40.pnach
+++ b/patches/SLES-53124_821A0C40.pnach
@@ -11,3 +11,8 @@ patch=1,EE,20332BBC,extended,34218E39 //3421AAAB hor fov
 author=PeterDelta
 description=Might need EE Overclock at 130%.
 patch=1,EE,002D4D94,word,2C620000 //0062102B
+
+[Remove Blur/Bloom]
+author=PeterDelta
+description=Removes the post-processing blur/bloom effect
+patch=1,EE,004E9B28,word,00000000

--- a/patches/SLES-53139_14274DC3.pnach
+++ b/patches/SLES-53139_14274DC3.pnach
@@ -1,9 +1,6 @@
 gametitle=Alien Hominid (PAL-M) SLES-53139 14274DC3
 
 [480p Mode]
-gsinterlacemode=1
 author=PeterDelta
 description=SDTV 480p mode at start.
-patch=1,EE,00199C34,word,24110000
-patch=1,EE,00199C38,word,24120050
-patch=1,EE,00199C44,word,24130001
+patch=1,EE,00175278,word,1400000D

--- a/patches/SLES-53430_6B3D50A5.pnach
+++ b/patches/SLES-53430_6B3D50A5.pnach
@@ -1,6 +1,12 @@
 gametitle=Incredible Hulk, The - Ultimate Destruction (PAL-M) SLES-53430 6B3D50A5
 
-[50 FPS]
+[50/60 FPS]
 author=PeterDelta
-description=Might need EE Overclock at 180%.
+description=Might need EE Overclock (180%).
 patch=1,EE,0046F3D0,word,24020001 //24020002
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,0046F6FC,word,240501C0
+patch=1,EE,0046F708,word,24060002

--- a/patches/SLES-53474_F3AE68FC.pnach
+++ b/patches/SLES-53474_F3AE68FC.pnach
@@ -9,11 +9,7 @@ patch=1,EE,00218F50,word,3C023F10 //3C023F40 Y-FOV
 //Hang fix by Prafull (Only needed for pcsx2, is not needed for the PS2)
 //patch=1,EE,001110E0,word,00000000 //40036000
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,00106C20,word,34050050
-patch=1,EE,00106C24,word,24030002
-patch=1,EE,00106C28,word,0000000C
-patch=1,EE,00106C2C,word,03E00008
+description=NTSC mode at start.
+patch=1,EE,00101380,word,14C00004

--- a/patches/SLES-53556_D720770D.pnach
+++ b/patches/SLES-53556_D720770D.pnach
@@ -6,7 +6,6 @@ description=Might need EE Overclock at 130%.
 patch=1,EE,003246EC,word,24440002 //24440001
 
 [480p Mode]
-gsinterlacemode=1
 author=PeterDelta
 description=SDTV 480p mode at start.
 patch=1,EE,004B5790,word,00000002 //00000001

--- a/patches/SLES-53775_36C11474.pnach
+++ b/patches/SLES-53775_36C11474.pnach
@@ -4,25 +4,13 @@ gametitle=Reservoir Dogs (PAL-M) SLES-53775 36C11474
 gsaspectratio=16:9
 author=PeterDelta
 description=Widescreen fix
-patch=1,EE,00396EF8,extended,3C013F00
-patch=1,EE,003767B8,extended,3C013F00
-patch=1,EE,E0010001,extended,004F11EC
-patch=1,EE,00396EF8,extended,3C013F25
-patch=1,EE,003767B8,extended,3C013F25
+patch=1,EE,004F11EC,word,00000001
+patch=1,EE,00396EF8,word,3C013F25
+patch=1,EE,003767B8,word,3C013F25
+patch=1,EE,01DE30C0,word,0000003C
 
-[50/60 FPS]
+[50 FPS]
 author=PeterDelta
-description=Might need EE Overclock at 130%.
-patch=1,EE,003A8E7C,extended,3C02000A //3C02004A
-patch=1,EE,00310734,extended,3C013F00 //3C013F80
-
-[480p Mode]
-gsinterlacemode=1
-author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,20444EA0,extended,34050050
-patch=1,EE,20444EA4,extended,24030002
-patch=1,EE,20444EA8,extended,0000000C
-patch=1,EE,20444EAC,extended,03E00008
-patch=1,EE,E001000A,extended,003A8E7C
-patch=1,EE,20310734,extended,3C013EA0
+description=Might need EE Overclock (130%).
+patch=0,EE,003A8E78,word,14800021
+patch=0,EE,00310734,word,3C013EAB

--- a/patches/SLES-53908_05177ECE.pnach
+++ b/patches/SLES-53908_05177ECE.pnach
@@ -81,11 +81,10 @@ patch=1,EE,0016C694,word,3C013F80
 
 [50/60 FPS]
 author=PeterDelta
-description=Might need EE Overclock at 180%.
+description=Might need EE Overclock (180%).
 patch=1,EE,00125488,word,14400003 //10400003
 
 [480p Mode]
-gsinterlacemode=1
 author=PeterDelta
 description=SDTV 480p mode at start.
 patch=1,EE,003B905C,extended,00000001

--- a/patches/SLES-53979_E71273AC.pnach
+++ b/patches/SLES-53979_E71273AC.pnach
@@ -13,11 +13,9 @@ patch=1,EE,0048DA20,word,461E0843
 patch=1,EE,0048DA24,word,E6010068
 patch=1,EE,0048DA28,word,08094ECC
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,20102CD8,extended,00069403
-patch=1,EE,E0010000,extended,0056F5BC
-patch=1,EE,20102CD8,extended,24120050
-patch=1,EE,0010471C,extended,64420000
+description=NTSC mode at start.
+patch=1,EE,0026E96C,word,24020002
+patch=1,EE,00997EA0,word,000001C0
+patch=1,EE,004BE4C0,word,0000003C

--- a/patches/SLES-54117_28241DFE.pnach
+++ b/patches/SLES-54117_28241DFE.pnach
@@ -13,11 +13,9 @@ patch=1,EE,0048de60,word,461e0843
 patch=1,EE,0048de64,word,e6010068
 patch=1,EE,0048de68,word,08094f14
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,20102CD8,extended,00069403
-patch=1,EE,E0010000,extended,0056FA3C
-patch=1,EE,20102CD8,extended,24120050
-patch=1,EE,0010471C,extended,64420000
+description=NTSC mode at start.
+patch=1,EE,0026EA8C,word,24020002
+patch=1,EE,00A87D90,word,000001C0
+patch=1,EE,004BE8C0,word,0000003C

--- a/patches/SLES-54420_859AB297.pnach
+++ b/patches/SLES-54420_859AB297.pnach
@@ -8,9 +8,6 @@ patch=1,EE,007E0438,word,3F6E6D1C
 patch=1,EE,007E0440,word,3F891A31
 
 [480p Mode]
-gsinterlacemode=1
 author=PeterDelta
 description=SDTV 480p mode at start.
-patch=1,EE,0010D294,word,24110000
-patch=1,EE,0010D298,word,24120050
-patch=1,EE,0010D2A4,word,24130001
+patch=1,EE,006AC098,word,00000057

--- a/patches/SLES-54443_CC03D5AD.pnach
+++ b/patches/SLES-54443_CC03D5AD.pnach
@@ -15,10 +15,12 @@ description=Removes black bars in cutscenes
 patch=1,EE,00100B88,word,24040000 //24040001 Upper
 patch=1,EE,00100C88,word,24040000 //24040001 Bottom
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=Forces progressive scan mode 480p at startup.
-patch=1,EE,001CED74,word,24110000
-patch=1,EE,001CED78,word,24120050
-patch=1,EE,001CED84,word,24130001
+description=NTSC mode at start.
+patch=0,EE,00232A4C,word,14400007
+
+[480p Mode]
+author=PeterDelta
+description=SDTV 480p mode at start.
+patch=0,EE,00232A6C,word,24140002

--- a/patches/SLES-54659_DAF2145C.pnach
+++ b/patches/SLES-54659_DAF2145C.pnach
@@ -15,7 +15,6 @@ patch=1,EE,E0010000,extended,01FFFA70
 patch=1,EE,20125678,extended,28420002
 
 [480p Mode]
-gsinterlacemode=1
 author=PeterDelta
 description=SDTV 480p mode at start.
 patch=1,EE,007AE984,word,00000003

--- a/patches/SLES-54674_A629A376.pnach
+++ b/patches/SLES-54674_A629A376.pnach
@@ -81,11 +81,10 @@ patch=1,EE,0016F380,word,3C013F80
 
 [50/60 FPS]
 author=PeterDelta
-description=Might need EE Overclock at 180%.
+description=Might need EE Overclock (180%).
 patch=1,EE,0012795C,word,14400003 //10400003
 
 [480p Mode]
-gsinterlacemode=1
 author=PeterDelta
 description=SDTV 480p mode at start.
 patch=1,EE,003BECEC,word,00000001

--- a/patches/SLES-55254_11C4798E.pnach
+++ b/patches/SLES-55254_11C4798E.pnach
@@ -1,0 +1,8 @@
+gametitle=The Incredible Hulk (PAL-M) SLES-55254 11C4798E
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Renders the game in 16:9 aspect ratio
+patch=1,EE,0041042C,word,3C013F22
+patch=1,EE,00368284,word,3C013FEC

--- a/patches/SLES-55499_AB761209.pnach
+++ b/patches/SLES-55499_AB761209.pnach
@@ -7,10 +7,7 @@ patch=1,EE,004B5A88,extended,00000032
 patch=1,EE,E0010001,extended,004D5F94
 patch=1,EE,204B5A88,extended,00000019
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,003A28F4,word,24110000
-patch=1,EE,003A28F8,word,24120050
-patch=1,EE,003A2904,word,24130001
+description=NTSC mode at start.
+patch=1,EE,0014A5F0,word,1400000F

--- a/patches/SLES-55502_09BF522A.pnach
+++ b/patches/SLES-55502_09BF522A.pnach
@@ -1,8 +1,13 @@
 gametitle=Disney G-Force (PAL-R) SLES-55502 09BF522A
 
-[50 FPS]
+[50/60 FPS]
 author=PeterDelta
 description=Might need EE Overclock at 130%.
 patch=1,EE,004B5900,extended,00000032
 patch=1,EE,E0010001,extended,004D5E14
 patch=1,EE,204B5900,extended,00000019
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,0014A5F0,word,1400000F

--- a/patches/SLES-55622_EA6A9029.pnach
+++ b/patches/SLES-55622_EA6A9029.pnach
@@ -9,10 +9,8 @@ description=Renders the game in 16:9 aspect ratio
 patch=1,EE,004f6ee8,word,3c033f80
 patch=1,EE,004f6ef0,word,34630000
 
-[480p Mode]
-gsinterlacemode=1
+[NTSC Mode]
 author=PeterDelta
-description=SDTV 480p mode at start.
-patch=1,EE,005346A4,word,24110000
-patch=1,EE,005346A8,word,24120050
-patch=1,EE,005346B4,word,24130001
+description=NTSC mode at start.
+patch=1,EE,0075158C,word,000001C0
+patch=1,EE,00752880,word,00067800

--- a/patches/SLUS-20576_C5473413.pnach
+++ b/patches/SLUS-20576_C5473413.pnach
@@ -32,4 +32,7 @@ description=Widescreen Hack
 
 // Commented out as it broke loading screen font and other stuff.
 
-
+[60 FPS]
+author=asasega
+description=Might need EE Overclock (130%).
+patch=1,EE,00544168,word,00000001

--- a/patches/SLUS-21065_F5C7B45F.pnach
+++ b/patches/SLUS-21065_F5C7B45F.pnach
@@ -109,3 +109,8 @@ patch=1,EE,001C3EE0,word,3C013F40
 author=kozarovv
 description=Tones down all signal lights, such as traffic light orange/yellow sources.
 patch=1,EE,001C3260,word,3C013F50
+
+[Remove Bloom]
+author=PeterDelta
+description=Removes the post-processing bloom effect
+patch=1,EE,00570178,word,01000100

--- a/patches/SLUS-21479_08C682C1.pnach
+++ b/patches/SLUS-21479_08C682C1.pnach
@@ -4,14 +4,13 @@ gametitle=Reservoir Dogs (NTSC-U) SLUS-21479 08C682C1
 gsaspectratio=16:9
 author=PeterDelta
 description=Widescreen fix
-patch=1,EE,00397770,extended,3C013F00
-patch=1,EE,00377030,extended,3C013F00
-patch=1,EE,E0010001,extended,004F1BEC
-patch=1,EE,00397770,extended,3C013F25
-patch=1,EE,00377030,extended,3C013F25
+patch=1,EE,004F1BEC,word,00000001
+patch=1,EE,00397770,word,3C013F25
+patch=1,EE,00377030,word,3C013F25
+patch=1,EE,01DE42C0,word,0000003C
 
 [60 FPS]
 author=PeterDelta
-description=Might need EE Overclock at 130%.
-patch=1,EE,003A96F4,word,3C02000A //3C02004A
-patch=1,EE,00310FAC,word,3C013F00 //3C013F80
+description=Might need EE Overclock (130%).
+patch=0,EE,003A96F0,word,14800021
+patch=0,EE,00310FAC,word,3C013EAB


### PR DESCRIPTION
Updated patches, relevant changes:

- God of War: Updated the widescreen patch to fix the menu flames.
- X-Men 2: Disabled the widescreen patch because it causes rendering errors and crashes after level 3. I haven't been able to get a proper widescreen version.
- Reservoir dogs: Removed 60Hz patch in PAL version, FMVs are not fully synchronized. Fixed frame rate in FPS patch, now it's accurate.

The rest have been tested without issue.