### PR TITLE
Allowing the patches for some games to work on the Retroachievements …

### DIFF
--- a/patches/SCUS-97124_143976AB.pnach
+++ b/patches/SCUS-97124_143976AB.pnach
@@ -1,0 +1,24 @@
+gametitle=Jak and Daxter - The Precursor Legacy (NTSC-U) [SCUS-97124]
+// This CRC corresponds to an xdelta patched version of the game, needed for RetroAchievements. This is otherwise the exact same experience as the base game.
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=ElHecht
+
+// 16:9
+patch=1,EE,202AF750,extended,3f1f3b64 // 3f000000 zoom
+patch=1,EE,202AF6FC,extended,bf1f3b64 // bf000000 hud fix for zoom
+patch=1,EE,2079F478,extended,0015120C // 0014E4C4 force native 16:9 mode
+
+
+[No-Interlacing]
+gsinterlacemode=1
+description=No Interlacing & No Blur
+
+// No Interlacing
+patch=1,EE,202B2014,word,24060000
+patch=1,EE,208781B4,word,AEE0ED00
+
+// No Blur
+patch=1,EE,007027A8,extended,000000E0
+patch=1,EE,2010FF6C,extended,30420000

--- a/patches/SCUS-97265_9E84AAF1.pnach
+++ b/patches/SCUS-97265_9E84AAF1.pnach
@@ -1,0 +1,20 @@
+gametitle=Jak II - Renegade (U)(SCUS-97265)
+// This CRC corresponds to an xdelta patched version of the game, needed for RetroAchievements. This is otherwise the exact same experience as the base game.
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=ElHecht (NTSC-U by Arapapa)
+
+//Widescreen hack 16:9
+
+//003f033c 00008344
+patch=1,EE,20367ae8,extended,3c033f1f // 3c033f00 zoom
+
+//c1781400 01321400  (PAL c1791400)
+patch=1,EE,20826E10,extended,0014A709 // 001478C1 force native 16:9 mode
+
+//menu fix
+patch=1,EE,20B63EA0,extended,43A80000 // 436DE43C
+patch=1,EE,20B66470,extended,43440000 // 4309CAD8
+
+

--- a/patches/SLUS-20230_510DA7F8.pnach
+++ b/patches/SLUS-20230_510DA7F8.pnach
@@ -1,0 +1,16 @@
+gametitle=Max Payne (NTSC-U)   SLUS-20230  510DA7F8
+//This pnach file is derived from the user-applied xdelta patch version used for retroachievements, as a measure of anticheat. This is for the actual game ELF.
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=ElHecht
+description=Widescreen Hack
+
+// 16:9
+// ELF file is called "MAIN.RUN"
+patch=1,EE,0050e030,word,3c013f40 // 00000000 hor fov
+patch=1,EE,0050e038,word,4481f000 // 00000000
+patch=1,EE,0050e03c,word,0c04821c // 00000000
+patch=1,EE,0050e040,word,00000000 // 0c04821c
+patch=1,EE,0050e044,word,461e0003 // 00000000
+patch=1,EE,0050e054,word,461e0082 // c68201f8

--- a/patches/SLUS-20230_BEB45781.pnach
+++ b/patches/SLUS-20230_BEB45781.pnach
@@ -1,0 +1,7 @@
+gametitle=Max Payne (NTSC-U)
+//These pnach files are derived from the user-applied xdelta patch version used for retroachievements, as a measure of anticheat. This is for the main ELF.
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=ElHecht
+description=Widescreen Hack


### PR DESCRIPTION
…supported counterparts

Jak and Daxter, Jak 2, and Max Payne have Patches that, while work, are not recognized by their Retroachievements enabled counterparts.

The reason for this is for the Jak games, an Xdelta patch was made to disable the debug menu, which can make it possible to cheat. For Max Payne, a patch was made to deter cheating as well.

Ultimately, in both scenarios, the CRC was changed, so this submission recognizes those CRC changes. No other changes to the base game experiences were made, and the PNACH files submitted are otherwise identical to the base game's PNACH files, but confirmed to work on the altered CRC.