### PR TITLE
Add 60fps patch for History Channel Civil War (US)

### DIFF
--- a/patches/SLUS-21474_18834BA2.pnach
+++ b/patches/SLUS-21474_18834BA2.pnach
@@ -10,3 +10,10 @@ patch=1,EE,001828dc,word,3c013fc0 //3c014000
 
 //Y-Fov
 patch=1,EE,00237d30,word,3c013f10 //3c013f40
+
+[60 FPS]
+author=Souzooka
+description=Runs game at 60 FPS.
+
+// Changes wait for 2 vblanks to 1
+patch=0,EE,20244CB8,extended,2C420001 // sltiu v0,v0,0x0001


### PR DESCRIPTION
Added a 60fps patch and tested it for a few minutes. There seem to be no immediate issues and considering there's also a 360 and PC port (with no reported 60fps issues) I assume there should be no issues here.