### PR TITLE
Add Simpsons Skateboarding 60fps patch

### DIFF
--- a/patches/SLUS-20114_6D0D9F1F.pnach
+++ b/patches/SLUS-20114_6D0D9F1F.pnach
@@ -1,0 +1,10 @@
+gametitle=Simpsons Skateboarding, The (NTSC-U) (SLUS-20114)
+
+[60 FPS]
+author=Souzooka
+description=Removes framerate cap.
+
+// This makes a check that the framerate cap boolean is 0
+// always true -- this variable is initialized at 1918C4, but I've
+// just made this branch always true so it works without a restart.
+patch=0,EE,201011D8,extended,1000000F // beq zero,zero,0x00101218


### PR DESCRIPTION
Does what it says on the tin -- there's a boolean set to 1 which tells the game to implement a framerate cap, and this patch makes the game treat that boolean as if it is always 0.