### PR TITLE
Urban Reign Force Progressive Scan

### DIFF
--- a/patches/SLUS-21209_BDD9BAAD.pnach
+++ b/patches/SLUS-21209_BDD9BAAD.pnach
@@ -1,0 +1,7 @@
+[Force Progressive Scan]
+author=Michael
+description=Automatically boots the game in progressive scan mode (Fixes interlacing issues such as shaking and improves visual quality). Restart the game to make it work if you are already started it.
+
+//Force Progressive Scan
+patch=1,EE,201372e0,extended,0C04DCEC 
+patch=1,EE,201372e8,extended,0C04DCEC


### PR DESCRIPTION
Automatically boots the game in progressive scan mode, so you don't have to enable it manually each time.