### PR TITLE
Drive to Survive: Remove a pointless widescreen patch

### DIFF
--- a/patches/SLUS-21109_0520A26D.pnach
+++ b/patches/SLUS-21109_0520A26D.pnach
@@ -1,18 +1,20 @@
 gametitle=Drive To Survive (U)(SLUS-21109)
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=Arapapa
+// Mashed: Fully Loaded (SLES-53152) and Drive to Survive (SLUS-21109) have native widescreen
+// available in Screen options, so this patch is pointless
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=Arapapa
 
 //Widescreen hack 16:9
 
-patch=1,EE,0019a430,word,08106838
+//patch=1,EE,0019a430,word,08106838
 
-patch=1,EE,0041a0e0,word,46020002
-patch=1,EE,0041a0e4,word,3c013faa
-patch=1,EE,0041a0e8,word,3421aaab
-patch=1,EE,0041a0ec,word,4481f000
-patch=1,EE,0041a0f0,word,461e0002
-patch=1,EE,0041a0f4,word,0806690d
+//patch=1,EE,0041a0e0,word,46020002
+//patch=1,EE,0041a0e4,word,3c013faa
+//patch=1,EE,0041a0e8,word,3421aaab
+//patch=1,EE,0041a0ec,word,4481f000
+//patch=1,EE,0041a0f0,word,461e0002
+//patch=1,EE,0041a0f4,word,0806690d
 
 


### PR DESCRIPTION
The original release of **Mashed** (SLES-52446) did not have native widescreen support, but updated releases **Mashed: Fully Loaded** (SLES-53152) and **Drive to Survive** (SLUS-21109) have native WS available from the game options. This patch does the same thing visually, and stacks on top of the native support.

In-game Widescreen Off, patch enabled:
![image](https://github.com/user-attachments/assets/c3a04392-0c6b-4b58-9f83-51bf8d969474)

In-game Widescreen On, patch enabled:
![image](https://github.com/user-attachments/assets/4fe79045-ef31-4025-aef9-a1b5bdf41163)

In-game Widescreen On, patch **disabled**:
![image](https://github.com/user-attachments/assets/8b76534d-84eb-4880-938e-623c784d45b5)
