### PR TITLE
Burnout Revenge (USA) - Disable Motion Blur and Bloom by escape209

### DIFF
--- a/patches/SLUS-21242_D224D348.pnach
+++ b/patches/SLUS-21242_D224D348.pnach
@@ -34,6 +34,16 @@ patch=1,EE,20167844,extended,3C014F23
 patch=1,EE,21C02108,extended,43E60000
 patch=1,EE,2032677C,extended,3C013cb3
 
+[Disable Motion Blur]
+author=escape209
+description=Disables Motion Blur
+patch=1,EE,21BFE7BA,byte,00000000 // 00000001 // Disable Motion blur
+
+[Disable Bloom]
+author=escape209
+description=Disables Bloom
+patch=1,EE,21BFE7B8,byte,00000000 // 00000001 // Disable Bloom
+
 [60 FPS Menus]
 author=SuperType1/remco
 description=Makes the menus run in 60 FPS.


### PR DESCRIPTION
Disabling Motion Blur and Bloom are essential to have a smoother Burnout Revenge experience on lower end devices, and sometimes for even a better experience in general i.e disabling Motion Blur.

The original repo had all these speedhacks in one cheat ( https://forums.pcsx2.net/Thread-Burnout-Revenge-USA-Speedhack-Patch ). I separated the Motion Blur and Bloom Disabling Cheats (leaving the Fog Speedhack) as individual cheats added them in this patch.

Essential cheats, specially for someone who wants to play Hardcore RetroAchievement for this game, but faces lags with the default Motion Blur.