### PR TITLE
GTA San Andreas: revert values original in cutscenes

### DIFF
--- a/patches/SLES-52541_A1B3F232.pnach
+++ b/patches/SLES-52541_A1B3F232.pnach
@@ -10,11 +10,6 @@ patch=1,EE,0020A498,extended,AC
 patch=1,EE,0020817C,extended,AC
 patch=1,EE,002ECAB0,extended,40
 patch=1,EE,002ECB00,extended,D0
-patch=1,EE,0033DAB4,extended,3C013F80 //scenes zoom
-patch=1,EE,E0020001,extended,0066C17C
-patch=1,EE,0033DAB4,extended,3C013F40
-patch=1,EE,2021EDB4,extended,3C023FC0
-patch=1,EE,2021EDB4,extended,3C024000
 patch=1,EE,0026E12C,word,3C084280
 patch=1,EE,00269618,word,3C024280
 patch=1,EE,0026E748,word,3C024280
@@ -71,10 +66,13 @@ patch=1,EE,002A890C,word,E42D2418
 [Remove ghosting effects]
 author=PeterDelta
 description=Removes the ghosting effect keeping radiosity.
-patch=1,EE,006685DC,extended,00000000
-patch=1,EE,00668668,extended,00000000
-patch=1,EE,E0010100,extended,006FFA80
-patch=1,EE,006FFA80,extended,00000130
+patch=1,EE,006685DC,extended,00
+patch=1,EE,00668664,extended,00
+patch=1,EE,006686A8,extended,00
+patch=1,EE,006686AC,extended,00
+patch=1,EE,006686B0,extended,00
+patch=1,EE,006686B4,extended,00
+
 
 [Remove Radiosity Filter]
 author=refractionpcsx2

--- a/patches/SLES-52541_B440A8FE.pnach
+++ b/patches/SLES-52541_B440A8FE.pnach
@@ -10,11 +10,6 @@ patch=1,EE,0020A4F8,extended,AC
 patch=1,EE,002081DC,extended,AC
 patch=1,EE,002ECBE0,extended,40
 patch=1,EE,002ECC30,extended,D0
-patch=1,EE,0033DC44,extended,3C013F80 //scenes zoom
-patch=1,EE,E0020001,extended,0066C8FC
-patch=1,EE,0033DC44,extended,3C013F40
-patch=1,EE,2021EE14,extended,3C023FC0
-patch=1,EE,2021EE14,extended,3C024000
 patch=1,EE,0026E18C,word,3C084280
 patch=1,EE,00269678,word,3C024280
 patch=1,EE,0026E7A8,word,3C024280
@@ -71,10 +66,12 @@ patch=1,EE,002A8A1C,word,E42D2FA8
 [Remove ghosting effects]
 author=PeterDelta
 description=Removes the ghosting effect keeping radiosity.
-patch=1,EE,00668D5C,extended,00000000
-patch=1,EE,00668DE8,extended,00000000
-patch=1,EE,E0010100,extended,007005E0
-patch=1,EE,007005E0,extended,00000130
+patch=1,EE,00668D5C,extended,00
+patch=1,EE,00668DE4,extended,00
+patch=1,EE,00668E28,extended,00
+patch=1,EE,00668E2C,extended,00
+patch=1,EE,00668E30,extended,00
+patch=1,EE,00668E34,extended,00
 
 [Remove Radiosity Filter]
 author=refractionpcsx2

--- a/patches/SLES-52927_B61F872C.pnach
+++ b/patches/SLES-52927_B61F872C.pnach
@@ -1,0 +1,91 @@
+gametitle=Grand Theft Auto - San Andreas (PAL-G) (v2.01) SLES-52927 B61F872C
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Widescreen fix
+patch=1,EE,0070056F,extended,01
+patch=1,EE,0020C7BC,extended,3C0242A2
+patch=1,EE,0020A4F8,extended,3C0242AC
+patch=1,EE,002081DC,extended,3C0342AC
+patch=1,EE,002ECBD0,extended,3C044040
+patch=1,EE,002ECB80,extended,3C0440D0
+patch=1,EE,0026E12C,word,3C084280
+patch=1,EE,00269618,word,3C024280
+patch=1,EE,0026E748,word,3C024280
+patch=1,EE,0026EDF0,word,3C024280
+patch=1,EE,0026AF44,word,3C034280
+patch=1,EE,0026EF20,word,3C034280
+patch=1,EE,0026F008,word,3C034280
+patch=1,EE,002ACA98,word,3C024258
+patch=1,EE,002ACB04,word,3C024270
+patch=1,EE,002ACE38,word,3C0342C6
+patch=1,EE,002ACED0,word,3C0342C6
+patch=1,EE,002ACDEC,word,3C0341E3
+patch=1,EE,002ACE84,word,3C0341E3
+patch=1,EE,0026E13C,word,3C064280
+patch=1,EE,0026EF2C,word,3C044280
+patch=1,EE,0026F024,word,3C044280
+patch=1,EE,0026E764,word,3C024280
+patch=1,EE,0026EE00,word,3C024280
+patch=1,EE,0026AF5C,word,3C034280
+patch=1,EE,002ACAA0,word,3C034280
+patch=1,EE,002ACE00,word,3C034280
+patch=1,EE,002ACE4C,word,3C034280
+patch=1,EE,002ACE98,word,3C034280
+patch=1,EE,002ACEE4,word,3C034280
+patch=1,EE,002ACC54,word,3C0341D4
+patch=1,EE,002ACDA0,word,3C034190
+patch=1,EE,002ACDB0,word,3C0241E5
+patch=1,EE,0026D230,word,3C023F40
+patch=1,EE,002AA094,word,3C024210
+patch=1,EE,002A9FD4,word,3C024190
+patch=1,EE,002ABBE0,word,2405020D
+patch=1,EE,002ABC1C,word,2405020D
+patch=1,EE,00663F48,word,3E800000
+patch=1,EE,002ABC30,word,2405021F
+patch=1,EE,002ABC6C,word,2405021F
+patch=1,EE,002A9D24,word,3C0242A8
+patch=1,EE,002A9AA4,word,2404002F
+patch=1,EE,002A9BA4,word,2404002F
+patch=1,EE,002AB6BC,word,24050231
+patch=1,EE,002AB700,word,24050231
+patch=1,EE,002AB850,word,24050231
+patch=1,EE,002AB898,word,24050231
+patch=1,EE,002AD43C,word,C78C8384
+patch=1,EE,002AD9CC,word,3C023F40
+patch=1,EE,002A89A0,word,3C013F40
+patch=1,EE,002A89A4,word,44810000
+patch=1,EE,002A89A8,word,46006302
+patch=1,EE,002A89AC,word,3C01007C
+patch=1,EE,002A89B0,word,E42C2F24
+patch=1,EE,002A89B4,word,3C01007C
+patch=1,EE,002A89B8,word,03E00008
+patch=1,EE,002A89BC,word,E42D2F28
+
+[Remove ghosting effects]
+author=PeterDelta
+description=Removes the ghosting effect keeping radiosity.
+patch=1,EE,00668CDC,extended,00
+patch=1,EE,00668D64,extended,00
+patch=1,EE,00668DA8,extended,00
+patch=1,EE,00668DAC,extended,00
+patch=1,EE,00668DB0,extended,00
+patch=1,EE,00668DB4,extended,00
+
+[Remove Radiosity Filter]
+author=PeterDelta
+description=Removes the radiosity filter.
+patch=1,EE,2051A758,extended,00000000
+
+[50 FPS]
+author=PeterDelta
+description=Might need EE Overclock (180%).
+patch=0,EE,0039B74C,extended,24040001 //native
+
+[480p Mode]
+gsinterlacemode=1
+author=PeterDelta
+description=SDTV 480p mode at start.
+patch=1,EE,00358AAC,extended,24020050
+patch=1,EE,00549FEC,extended,00000000

--- a/patches/SLUS-20946_2C6BE434.pnach
+++ b/patches/SLUS-20946_2C6BE434.pnach
@@ -10,11 +10,6 @@ patch=1,EE,0020A4F8,extended,AC
 patch=1,EE,002081DC,extended,AC
 patch=1,EE,002ECAF0,extended,40
 patch=1,EE,002ECB40,extended,D0
-patch=1,EE,0033DB54,extended,3C013F80 //zoom in scenes
-patch=1,EE,E0020001,extended,0066C174
-patch=1,EE,0033DB54,extended,3C013F40
-patch=1,EE,2021EE14,extended,3C023FC0
-patch=1,EE,2021EE14,extended,3C024000
 //-------------------------------------------------HUD-------------------------------------------------//
 patch=0,EE,20664384,extended,3ecccccd //Wanted Width
 patch=0,EE,20664390,extended,3ef5c28f //Wanted Shadow Width

--- a/patches/SLUS-20946_399A49CA.pnach
+++ b/patches/SLUS-20946_399A49CA.pnach
@@ -10,11 +10,6 @@ patch=1,EE,0020A498,extended,AC
 patch=1,EE,0020817C,extended,AC
 patch=1,EE,002EC9C0,extended,40
 patch=1,EE,002ECA10,extended,D0
-patch=1,EE,0033D9C4,extended,3C013F80 //zoom in scenes
-patch=1,EE,E0020001,extended,0066B9F4
-patch=1,EE,0033D9C4,extended,3C013F40
-patch=1,EE,2021EDB4,extended,3C023FC0
-patch=1,EE,2021EDB4,extended,3C024000
 //-------------------------------------------------HUD-------------------------------------------------//
 //patch=0,EE,20663C00,extended,3f666666 //Wanted Height
 patch=0,EE,20663C04,extended,3ecccccd //Wanted Width


### PR DESCRIPTION
We've reverted the cutscene improvements to their original values. I'll take this opportunity to add the PAL-G version.

Fixes #551 

Note: Improved the "remove ghosting affects" patch on PAL versions.