### PR TITLE
GTA San Andreas: Changes to postfx removal patches

### DIFF
--- a/patches/SLES-52541_A1B3F232.pnach
+++ b/patches/SLES-52541_A1B3F232.pnach
@@ -1,4 +1,4 @@
-gametitle=Grand Theft Auto - San Andreas (PAL-M5) (v1.03) SLES-52541 A1B3F232
+gametitle=Grand Theft Auto: San Andreas (PAL-M5) (v1.03) SLES-52541 A1B3F232
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -63,21 +63,24 @@ patch=1,EE,002A8904,word,3C01007C
 patch=1,EE,002A8908,word,03E00008
 patch=1,EE,002A890C,word,E42D2418
 
-[Remove ghosting effects]
-author=PeterDelta
-description=Removes the ghosting effect keeping radiosity.
-patch=1,EE,006685DC,extended,00
-patch=1,EE,00668664,extended,00
-patch=1,EE,006686A8,extended,00
-patch=1,EE,006686AC,extended,00
-patch=1,EE,006686B0,extended,00
-patch=1,EE,006686B4,extended,00
+[Remove Ghosting Effects]
+author=Silent, PeterDelta
+description=Removes the ghosting effect from radiosity and color filter post effects, preserving the slight bloom effect. Also disables the seam remover post effect.
 
+patch=0,EE,006685DC,extended,00 // CPostEffects::m_bSeamRemover
+patch=0,EE,20668664,extended,00000000 // CPostEffects::m_RadiosityFilterPasses
 
-[Remove Radiosity Filter]
-author=refractionpcsx2
-description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
-patch=1,EE,2051A0C8,extended,00000000
+// These values are read from stream.ini from the init overlay, so we have to patch them every frame
+patch=1,EE,206686A8,extended,00000000 // CPostEffects::m_colourLeftUOffset
+patch=1,EE,206686AC,extended,00000000 // CPostEffects::m_colourRightUOffset
+patch=1,EE,206686B0,extended,00000000 // CPostEffects::m_colourTopVOffset
+patch=1,EE,206686B4,extended,00000000 // CPostEffects::m_colourBottomVOffset
+
+[Remove Color Filter]
+author=Silent
+description=Removes the color filter, making the game look more like the PC version, without the yellow tint.
+
+patch=0,EE,20515658,extended,00000000 // NOP CPostEffects::ColourFilter
 
 [50 FPS]
 author=Boludoz

--- a/patches/SLES-52541_B440A8FE.pnach
+++ b/patches/SLES-52541_B440A8FE.pnach
@@ -1,4 +1,4 @@
-gametitle=Grand Theft Auto - San Andreas (PAL-M5) (v2.01) SLES-52541 B440A8FE
+gametitle=Grand Theft Auto: San Andreas (PAL-M5) (v2.01) SLES-52541 B440A8FE
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -63,20 +63,24 @@ patch=1,EE,002A8A14,word,3C01007C
 patch=1,EE,002A8A18,word,03E00008
 patch=1,EE,002A8A1C,word,E42D2FA8
 
-[Remove ghosting effects]
-author=PeterDelta
-description=Removes the ghosting effect keeping radiosity.
-patch=1,EE,00668D5C,extended,00
-patch=1,EE,00668DE4,extended,00
-patch=1,EE,00668E28,extended,00
-patch=1,EE,00668E2C,extended,00
-patch=1,EE,00668E30,extended,00
-patch=1,EE,00668E34,extended,00
+[Remove Ghosting Effects]
+author=Silent, PeterDelta
+description=Removes the ghosting effect from radiosity and color filter post effects, preserving the slight bloom effect. Also disables the seam remover post effect.
 
-[Remove Radiosity Filter]
-author=refractionpcsx2
-description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
-patch=1,EE,2051A7C8,extended,00000000
+patch=0,EE,00668D5C,extended,00 // CPostEffects::m_bSeamRemover
+patch=0,EE,20668DE4,extended,00000000 // CPostEffects::m_RadiosityFilterPasses
+
+// These values are read from stream.ini from the init overlay, so we have to patch them every frame
+patch=1,EE,20668E28,extended,00000000 // CPostEffects::m_colourLeftUOffset
+patch=1,EE,20668E2C,extended,00000000 // CPostEffects::m_colourRightUOffset
+patch=1,EE,20668E30,extended,00000000 // CPostEffects::m_colourTopVOffset
+patch=1,EE,20668E34,extended,00000000 // CPostEffects::m_colourBottomVOffset
+
+[Remove Color Filter]
+author=Silent
+description=Removes the color filter, making the game look more like the PC version, without the yellow tint.
+
+patch=0,EE,20515D58,extended,00000000 // NOP CPostEffects::ColourFilter
 
 [50 FPS]
 author=Snake356

--- a/patches/SLES-52927_A3EF1321.pnach
+++ b/patches/SLES-52927_A3EF1321.pnach
@@ -1,0 +1,20 @@
+gametitle=Grand Theft Auto: San Andreas (PAL-G) (v1.00) SLES-52927 A3EF1321
+
+[Remove Ghosting Effects]
+author=Silent, PeterDelta
+description=Removes the ghosting effect from radiosity and color filter post effects, preserving the slight bloom effect. Also disables the seam remover post effect.
+
+patch=0,EE,0066855C,extended,00 // CPostEffects::m_bSeamRemover
+patch=0,EE,206685E4,extended,00000000 // CPostEffects::m_RadiosityFilterPasses
+
+// These values are read from stream.ini from the init overlay, so we have to patch them every frame
+patch=1,EE,20668628,extended,00000000 // CPostEffects::m_colourLeftUOffset
+patch=1,EE,2066862C,extended,00000000 // CPostEffects::m_colourRightUOffset
+patch=1,EE,20668630,extended,00000000 // CPostEffects::m_colourTopVOffset
+patch=1,EE,20668634,extended,00000000 // CPostEffects::m_colourBottomVOffset
+
+[Remove Color Filter]
+author=Silent
+description=Removes the color filter, making the game look more like the PC version, without the yellow tint.
+
+patch=0,EE,205155E8,extended,00000000 // NOP CPostEffects::ColourFilter

--- a/patches/SLES-52927_B61F872C.pnach
+++ b/patches/SLES-52927_B61F872C.pnach
@@ -1,4 +1,4 @@
-gametitle=Grand Theft Auto - San Andreas (PAL-G) (v2.01) SLES-52927 B61F872C
+gametitle=Grand Theft Auto: San Andreas (PAL-G) (v2.01) SLES-52927 B61F872C
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -63,20 +63,24 @@ patch=1,EE,002A89B4,word,3C01007C
 patch=1,EE,002A89B8,word,03E00008
 patch=1,EE,002A89BC,word,E42D2F28
 
-[Remove ghosting effects]
-author=PeterDelta
-description=Removes the ghosting effect keeping radiosity.
-patch=1,EE,00668CDC,extended,00
-patch=1,EE,00668D64,extended,00
-patch=1,EE,00668DA8,extended,00
-patch=1,EE,00668DAC,extended,00
-patch=1,EE,00668DB0,extended,00
-patch=1,EE,00668DB4,extended,00
+[Remove Ghosting Effects]
+author=Silent, PeterDelta
+description=Removes the ghosting effect from radiosity and color filter post effects, preserving the slight bloom effect. Also disables the seam remover post effect.
 
-[Remove Radiosity Filter]
-author=PeterDelta
-description=Removes the radiosity filter.
-patch=1,EE,2051A758,extended,00000000
+patch=0,EE,00668CDC,extended,00 // CPostEffects::m_bSeamRemover
+patch=0,EE,20668D64,extended,00000000 // CPostEffects::m_RadiosityFilterPasses
+
+// These values are read from stream.ini from the init overlay, so we have to patch them every frame
+patch=1,EE,20668DA8,extended,00000000 // CPostEffects::m_colourLeftUOffset
+patch=1,EE,20668DAC,extended,00000000 // CPostEffects::m_colourRightUOffset
+patch=1,EE,20668DB0,extended,00000000 // CPostEffects::m_colourTopVOffset
+patch=1,EE,20668DB4,extended,00000000 // CPostEffects::m_colourBottomVOffset
+
+[Remove Color Filter]
+author=Silent
+description=Removes the color filter, making the game look more like the PC version, without the yellow tint.
+
+patch=0,EE,20515CE8,extended,00000000 // NOP CPostEffects::ColourFilter
 
 [50 FPS]
 author=PeterDelta

--- a/patches/SLPM-55292_9E18263C.pnach
+++ b/patches/SLPM-55292_9E18263C.pnach
@@ -1,6 +1,20 @@
-[Remove Radiosity Filter]
-description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
+gametitle=Grand Theft Auto: San Andreas (NTSC-J) (v1.00) SLPM-55292 9E18263C
 
-//Remove Radiosity Filter
-patch=1,EE,2051B1B8,extended,00000000
+[Remove Ghosting Effects]
+author=Silent, PeterDelta
+description=Removes the ghosting effect from radiosity and color filter post effects, preserving the slight bloom effect. Also disables the seam remover post effect.
 
+patch=0,EE,00669D54,extended,00 // CPostEffects::m_bSeamRemover
+patch=0,EE,20669DDC,extended,00000000 // CPostEffects::m_RadiosityFilterPasses
+
+// These values are read from stream.ini from the init overlay, so we have to patch them every frame
+patch=1,EE,20669E20,extended,00000000 // CPostEffects::m_colourLeftUOffset
+patch=1,EE,20669E24,extended,00000000 // CPostEffects::m_colourRightUOffset
+patch=1,EE,20669E28,extended,00000000 // CPostEffects::m_colourTopVOffset
+patch=1,EE,20669E2C,extended,00000000 // CPostEffects::m_colourBottomVOffset
+
+[Remove Color Filter]
+author=Silent
+description=Removes the color filter, making the game look more like the PC version, without the yellow tint.
+
+patch=0,EE,20516748,extended,00000000 // NOP CPostEffects::ColourFilter

--- a/patches/SLPM-65984_60FE139C.pnach
+++ b/patches/SLPM-65984_60FE139C.pnach
@@ -1,4 +1,4 @@
-gametitle=Grand Theft Auto - San Andreas NTSC-J SLPM-65984 60FE139C
+gametitle=Grand Theft Auto: San Andreas (NTSC-J) (v1.03) SLPM-65984 60FE139C
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -12,11 +12,24 @@ patch=1,EE,001130cc,word,e78c9a90
 patch=1,EE,0021dd04,word,0c044c2f
 patch=1,EE,00242c94,word,0c044c32
 
-[Remove Radiosity Filter]
-author=refractionpcsx2
-description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
-//Remove Radiosity Filter
-patch=1,EE,2051B5E8,extended,00000000
+[Remove Ghosting Effects]
+author=Silent, PeterDelta
+description=Removes the ghosting effect from radiosity and color filter post effects, preserving the slight bloom effect. Also disables the seam remover post effect.
+
+patch=0,EE,0066A204,extended,00 // CPostEffects::m_bSeamRemover
+patch=0,EE,2066A28C,extended,00000000 // CPostEffects::m_RadiosityFilterPasses
+
+// These values are read from stream.ini from the init overlay, so we have to patch them every frame
+patch=1,EE,2066A2D0,extended,00000000 // CPostEffects::m_colourLeftUOffset
+patch=1,EE,2066A2D4,extended,00000000 // CPostEffects::m_colourRightUOffset
+patch=1,EE,2066A2D8,extended,00000000 // CPostEffects::m_colourTopVOffset
+patch=1,EE,2066A2DC,extended,00000000 // CPostEffects::m_colourBottomVOffset
+
+[Remove Color Filter]
+author=Silent
+description=Removes the color filter, making the game look more like the PC version, without the yellow tint.
+
+patch=0,EE,20516B78,extended,00000000 // NOP CPostEffects::ColourFilter
 
 [60 FPS]
 author=Gabominated

--- a/patches/SLUS-20946_2C6BE434.pnach
+++ b/patches/SLUS-20946_2C6BE434.pnach
@@ -87,18 +87,24 @@ patch=0,EE,20234A74,extended,c78c8b68 //Hook Menu Items Width to Subtitles width
 patch=0,EE,20235558,extended,c78c8b68 //Hook Menu Items Width to Subtitles width
 patch=0,EE,202421F0,extended,3c023ecc //Set Menu Labels Width
 
-[Remove Radiosity Filter]
-description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
-//Remove Radiosity Filter
-patch=1,EE,2051A6D8,extended,00000000
-
 [Remove Ghosting Effects]
-author=PeterDelta
-description=Removes the ghosting effect without affecting the lighting
-patch=1,EE,00668C5C,extended,00000000
-patch=1,EE,00668CE8,extended,00000000
-patch=1,EE,E0010100,extended,007004E0
-patch=1,EE,007004E0,extended,00000130
+author=Silent, PeterDelta
+description=Removes the ghosting effect from radiosity and color filter post effects, preserving the slight bloom effect. Also disables the seam remover post effect.
+
+patch=0,EE,00668C5C,extended,00 // CPostEffects::m_bSeamRemover
+patch=0,EE,20668CE4,extended,00000000 // CPostEffects::m_RadiosityFilterPasses
+
+// These values are read from stream.ini from the init overlay, so we have to patch them every frame
+patch=1,EE,20668D28,extended,00000000 // CPostEffects::m_colourLeftUOffset
+patch=1,EE,20668D2C,extended,00000000 // CPostEffects::m_colourRightUOffset
+patch=1,EE,20668D30,extended,00000000 // CPostEffects::m_colourTopVOffset
+patch=1,EE,20668D34,extended,00000000 // CPostEffects::m_colourBottomVOffset
+
+[Remove Color Filter]
+author=Silent
+description=Removes the color filter, making the game look more like the PC version, without the yellow tint.
+
+patch=0,EE,20515C68,extended,00000000 // NOP CPostEffects::ColourFilter
 
 [60 FPS]
 author=someother1ne

--- a/patches/SLUS-20946_399A49CA.pnach
+++ b/patches/SLUS-20946_399A49CA.pnach
@@ -171,19 +171,24 @@ description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,2054986C,word,00000000
 
-[Remove Radiosity Filter]
-description=Removes the radiosity filter which causes a ghosting effect on the people and environment.
-
-//Remove Radiosity Filter
-patch=1,EE,20519FD8,extended,00000000
-
 [Remove Ghosting Effects]
-author=PeterDelta
-description=Removes the ghosting effect without affecting the lighting
-patch=1,EE,006684DC,extended,00000000
-patch=1,EE,00668568,extended,00000000
-patch=1,EE,E0010100,extended,006FF980
-patch=1,EE,006FF980,extended,00000130
+author=Silent, PeterDelta
+description=Removes the ghosting effect from radiosity and color filter post effects, preserving the slight bloom effect. Also disables the seam remover post effect.
+
+patch=0,EE,006684DC,extended,00 // CPostEffects::m_bSeamRemover
+patch=0,EE,20668564,extended,00000000 // CPostEffects::m_RadiosityFilterPasses
+
+// These values are read from stream.ini from the init overlay, so we have to patch them every frame
+patch=1,EE,206685A8,extended,00000000 // CPostEffects::m_colourLeftUOffset
+patch=1,EE,206685AC,extended,00000000 // CPostEffects::m_colourRightUOffset
+patch=1,EE,206685B0,extended,00000000 // CPostEffects::m_colourTopVOffset
+patch=1,EE,206685B4,extended,00000000 // CPostEffects::m_colourBottomVOffset
+
+[Remove Color Filter]
+author=Silent
+description=Removes the color filter, making the game look more like the PC version, without the yellow tint.
+
+patch=0,EE,20515568,extended,00000000 // NOP CPostEffects::ColourFilter
 
 [60 FPS]
 author=asasega


### PR DESCRIPTION
# Description

This PR introduces two changes to GTA San Andreas patches:
1. `Remove Radiosity Filter` patch in fact broke all the post effects, including the color filter, radiosity, heat haze, night and thermal vision, motion blur, and the underwater ripple effect. We have better alternatives now, so it makes no sense to keep a cheat that breaks the game.
   It's possible, however, that some people were using this patch to remove the yellow tint and make the game look more like the PC port. For this reason, I introduced a new `Remove Color Filter` patch that does the removal properly. The new patch **doesn't** remove the ghosting effect caused by radiosity, but it can safely be used with the other patch to also remove that, if users desire so.
2. The current `Remove Ghosting Effects` patch from @PeterDelta is near perfect, as it removes the ghosting effect without impacting the other post effects. However, it removes radiosity by removing its render passes entirely, which very slightly washes out the colors as radiosity normally produces a slight bloom effect. I introduced a new patch `Remove Radiosity Filter Pass` that keeps the render passes, but removes the filter passes, thus removing the offset. This preserves the colors perfectly, but removes the blurriness.

# Screenshots

All screens are done with 4x scaling. Best to open in a new tab and switch back and forth to see the difference.

<details>
<summary>Stock</summary>

![Grand Theft Auto - San Andreas_SLUS-20946_20250510130237](https://github.com/user-attachments/assets/cb8c426a-ad35-4b79-b1e6-8e375bdfc27a)
![Grand Theft Auto - San Andreas_SLUS-20946_20250510130303](https://github.com/user-attachments/assets/d9bb3f14-10cd-49ce-ab82-f3e6821263a4)
![Grand Theft Auto - San Andreas_SLUS-20946_20250510130317](https://github.com/user-attachments/assets/759c8894-e7ae-464e-bda4-9f1018233f1b)

</details>

<details>
<summary>PeterDelta's radiosity removal - sharp, but with colors slightly washed out</summary>

![Grand Theft Auto - San Andreas_SLUS-20946_20250510130639](https://github.com/user-attachments/assets/0c95bae8-4359-459a-aa60-4493fd254d58)
![Grand Theft Auto - San Andreas_SLUS-20946_20250510130716](https://github.com/user-attachments/assets/e494faa6-ea08-420f-8b66-d64710e5afee)
![Grand Theft Auto - San Andreas_SLUS-20946_20250510130802](https://github.com/user-attachments/assets/69f9aa1a-5a9a-4084-8d9a-51756fc0f269)

</details>

<details>
<summary>My radiosity removal - sharp and with colors intact</summary>

![Grand Theft Auto - San Andreas_SLUS-20946_20250510131204](https://github.com/user-attachments/assets/f6b44f8b-dc1d-45e0-96ac-39c183690cc4)
![Grand Theft Auto - San Andreas_SLUS-20946_20250510131555](https://github.com/user-attachments/assets/0d788319-0506-46ac-a41b-8485fba31cc4)
![Grand Theft Auto - San Andreas_SLUS-20946_20250510131636](https://github.com/user-attachments/assets/35c7e22c-8f83-42e5-a3dd-834ab744b107)

</details>

<details>
<summary>Color filter removal</summary>

![Grand Theft Auto - San Andreas_SLUS-20946_20250510132741](https://github.com/user-attachments/assets/9182c344-3a11-4c65-9e0e-1fe908044a68)
![Grand Theft Auto - San Andreas_SLUS-20946_20250510132759](https://github.com/user-attachments/assets/b5111887-03a3-4682-93c2-b7cac57720c1)
![Grand Theft Auto - San Andreas_SLUS-20946_20250510132817](https://github.com/user-attachments/assets/d9893837-8e7a-4d49-bb0d-4ad6d90c15de)

</details>

# To Do

- [x] Test the patch more.
- [x] Figure out if `Remove Ghosting Effects` should be cut.
- [x] Port to other versions.