### PR TITLE
Ultimate Spider-man update patches

### DIFF
--- a/patches/SLES-53390_FDD12792.pnach
+++ b/patches/SLES-53390_FDD12792.pnach
@@ -1,26 +1,23 @@
-gametitle=Ultimate Spider-Man (E)(SLES-53390)
+gametitle=Ultimate Spider-Man (PAL-E) SLES-53390 FDD12792
 
-//[Widescreen 16:9]
-//gsaspectratio=16:9
-//author=Arapapa
-//description=Widescreen Hack
-//X-Fov
-//7400033c 3c10e14b
-//patch=1,EE,0058b210,word,08030000
-
-//patch=1,EE,000c0000,word,3c030074
-//patch=1,EE,000c0004,word,3c013faa
-//patch=1,EE,000c0008,word,3421aaab
-//patch=1,EE,000c000c,word,4481f000
-//patch=1,EE,000c0010,word,461e18c2
-//patch=1,EE,000c0014,word,08162c85
-//Disable due to missing rendering fix in non-4:3 area
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Arapapa & PeterDelta
+description=Renders the game in 16:9 aspect ratio
+patch=0,EE,0058B210,word,08030000
+patch=0,EE,000C0000,word,3C030074
+patch=0,EE,000C0004,word,3C013FAA
+patch=0,EE,000C0008,word,3421AAAB
+patch=0,EE,000C000C,word,4481F000
+patch=0,EE,000C0010,word,461E18C2
+patch=0,EE,000C0014,word,08162C85
+patch=0,EE,002EF740,word,3C013FB0
 
 [50 FPS]
-author=PeterDelta and asasega
-description=Might need EE Overclock at 130%.
-patch=1,EE,00311F18,word,00000000
-patch=1,EE,0069FE20,word,00000001
-patch=1,EE,E0020001,extended,01C83460
+author=PeterDelta & asasega
+description=Might need EE Overclock (130%).
 patch=1,EE,20311F18,extended,4501FFE5
 patch=1,EE,2069FE20,extended,00000002
+patch=1,EE,E002F880,extended,007EF6E4
+patch=1,EE,20311F18,extended,00000000
+patch=1,EE,2069FE20,extended,00000001

--- a/patches/SLES-53391_FDD12792.pnach
+++ b/patches/SLES-53391_FDD12792.pnach
@@ -1,26 +1,23 @@
-gametitle=Ultimate Spider-Man (E)(SLES-53391)
+gametitle=Ultimate Spider-Man (PAL-M) SLES-53391 FDD12792
 
-//[Widescreen 16:9]
-//gsaspectratio=16:9
-//author=Arapapa
-//description=Widescreen Hack
-//X-Fov
-//7400033c 3c10e14b
-//patch=1,EE,0058b210,word,08030000
-
-//patch=1,EE,000c0000,word,3c030074
-//patch=1,EE,000c0004,word,3c013faa
-//patch=1,EE,000c0008,word,3421aaab
-//patch=1,EE,000c000c,word,4481f000
-//patch=1,EE,000c0010,word,461e18c2
-//patch=1,EE,000c0014,word,08162c85
-//Disable due to missing rendering fix in non-4:3 area
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Arapapa & PeterDelta
+description=Renders the game in 16:9 aspect ratio
+patch=0,EE,0058B210,word,08030000
+patch=0,EE,000C0000,word,3C030074
+patch=0,EE,000C0004,word,3C013FAA
+patch=0,EE,000C0008,word,3421AAAB
+patch=0,EE,000C000C,word,4481F000
+patch=0,EE,000C0010,word,461E18C2
+patch=0,EE,000C0014,word,08162C85
+patch=0,EE,002EF740,word,3C013FB0
 
 [50 FPS]
-author=PeterDelta and asasega
-description=Might need EE Overclock at 130%.
-patch=1,EE,00311F18,word,00000000
-patch=1,EE,0069FE20,word,00000001
-patch=1,EE,E0020001,extended,01C83460
+author=PeterDelta & asasega
+description=Might need EE Overclock (130%).
 patch=1,EE,20311F18,extended,4501FFE5
 patch=1,EE,2069FE20,extended,00000002
+patch=1,EE,E002F880,extended,007EF6E4
+patch=1,EE,20311F18,extended,00000000
+patch=1,EE,2069FE20,extended,00000001

--- a/patches/SLPM-66404_ADFF13DF.pnach
+++ b/patches/SLPM-66404_ADFF13DF.pnach
@@ -1,25 +1,23 @@
-gametitle=Ultimate Spider-Man (J)(SLPM-66404)
+gametitle=Ultimate Spider-Man (NTSC-J) SLPM-66404 ADFF13DF
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Arapapa
+author=Arapapa & PeterDelta
+description=Renders the game in 16:9 aspect ratio
+patch=0,EE,0058B7A0,word,081820D4
+patch=0,EE,00608350,word,3C030074
+patch=0,EE,00608354,word,3C013FAA
+patch=0,EE,00608358,word,3421AAAB
+patch=0,EE,0060835C,word,4481F000
+patch=0,EE,00608360,word,461E18C2
+patch=0,EE,00608364,word,08162DE9
+patch=0,EE,002EF7DC,word,3C013FB0
 
-//Widescreen hack 16:9
-
-
-//X-Fov
-//7400033c 3c10e14b
-patch=1,EE,0058b7a0,word,081820d4
-
-patch=1,EE,00608350,word,3c030074
-patch=1,EE,00608354,word,3c013faa
-patch=1,EE,00608358,word,3421aaab
-patch=1,EE,0060835c,word,4481f000
-patch=1,EE,00608360,word,461e18c2
-patch=1,EE,00608364,word,08162de9
-
-////////////////////
-//Zoom
-//patch=1,EE,005f8d60,word,3c013f40 //3c013f80
-
-
+[60 FPS]
+author=PeterDelta & asasega
+description=Might need EE Overclock (130%).
+patch=1,EE,20311FB4,extended,4501FFE5
+patch=1,EE,206A0C20,extended,00000002
+patch=1,EE,E0020880,extended,007F06E4
+patch=1,EE,20311FB4,extended,00000000
+patch=1,EE,206A0C20,extended,00000001

--- a/patches/SLUS-20870_FDD12792.pnach
+++ b/patches/SLUS-20870_FDD12792.pnach
@@ -1,26 +1,23 @@
-gametitle=Ultimate Spider-Man (U)(SLUS-20870) and (E)(SLES-53391) // Ultimate Spider-Man [Limited Edition] (U)(SLUS-21285)
+gametitle=Ultimate Spider-Man (NTSC-U) SLUS-20870 FDD12792
 
-//[Widescreen 16:9]
-//gsaspectratio=16:9
-//author=Arapapa
-//description=Widescreen Hack
-//X-Fov
-//7400033c 3c10e14b
-//patch=1,EE,0058b210,word,08030000
-
-//patch=1,EE,000c0000,word,3c030074
-//patch=1,EE,000c0004,word,3c013faa
-//patch=1,EE,000c0008,word,3421aaab
-//patch=1,EE,000c000c,word,4481f000
-//patch=1,EE,000c0010,word,461e18c2
-//patch=1,EE,000c0014,word,08162c85
-//Disable due to missing rendering fix in non-4:3 area
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Arapapa & PeterDelta
+description=Renders the game in 16:9 aspect ratio
+patch=0,EE,0058B210,word,08030000
+patch=0,EE,000C0000,word,3C030074
+patch=0,EE,000C0004,word,3C013FAA
+patch=0,EE,000C0008,word,3421AAAB
+patch=0,EE,000C000C,word,4481F000
+patch=0,EE,000C0010,word,461E18C2
+patch=0,EE,000C0014,word,08162C85
+patch=0,EE,002EF740,word,3C013FB0
 
 [60 FPS]
-author=PeterDelta and asasega
-description=Might need EE Overclock at 130%.
-patch=1,EE,00311F18,word,00000000
-patch=1,EE,0069FE20,word,00000001
-patch=1,EE,E0020001,extended,01C82AA0
+author=PeterDelta & asasega
+description=Might need EE Overclock (130%).
 patch=1,EE,20311F18,extended,4501FFE5
 patch=1,EE,2069FE20,extended,00000002
+patch=1,EE,E002F880,extended,007EF6E4
+patch=1,EE,20311F18,extended,00000000
+patch=1,EE,2069FE20,extended,00000001

--- a/patches/SLUS-21285_FDD12792.pnach
+++ b/patches/SLUS-21285_FDD12792.pnach
@@ -1,26 +1,23 @@
-gametitle=Ultimate Spider-Man (U)(SLUS-20870) and (E)(SLES-53391) // Ultimate Spider-Man [Limited Edition] (U)(SLUS-21285)
+gametitle=Ultimate Spider-Man [Limited Edition] (NTSC-U) SLUS-21285 FDD12792
 
-//[Widescreen 16:9]
-//gsaspectratio=16:9
-//author=Arapapa
-//description=Widescreen Hack
-//X-Fov
-//7400033c 3c10e14b
-//patch=1,EE,0058b210,word,08030000
-
-//patch=1,EE,000c0000,word,3c030074
-//patch=1,EE,000c0004,word,3c013faa
-//patch=1,EE,000c0008,word,3421aaab
-//patch=1,EE,000c000c,word,4481f000
-//patch=1,EE,000c0010,word,461e18c2
-//patch=1,EE,000c0014,word,08162c85
-//Disable due to missing rendering fix in non-4:3 area
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Arapapa & PeterDelta
+description=Renders the game in 16:9 aspect ratio
+patch=0,EE,0058B210,word,08030000
+patch=0,EE,000C0000,word,3C030074
+patch=0,EE,000C0004,word,3C013FAA
+patch=0,EE,000C0008,word,3421AAAB
+patch=0,EE,000C000C,word,4481F000
+patch=0,EE,000C0010,word,461E18C2
+patch=0,EE,000C0014,word,08162C85
+patch=0,EE,002EF740,word,3C013FB0
 
 [60 FPS]
-author=PeterDelta and asasega
-description=Might need EE Overclock at 130%.
-patch=1,EE,00311F18,word,00000000
-patch=1,EE,0069FE20,word,00000001
-patch=1,EE,E0020001,extended,01C82AA0
+author=PeterDelta & asasega
+description=Might need EE Overclock (130%).
 patch=1,EE,20311F18,extended,4501FFE5
 patch=1,EE,2069FE20,extended,00000002
+patch=1,EE,E002F880,extended,007EF6E4
+patch=1,EE,20311F18,extended,00000000
+patch=1,EE,2069FE20,extended,00000001


### PR DESCRIPTION
Updated patches. I found the rendering solution for widescreen a while ago. The only thing missing are the flashes that appear in the game when an enemy fires lightning bolts or in the storm where we fight Venom at the beginning and end of the game. These flashes are in 4:3. I don't think they're very relevant, and all things considered, the positives outweigh the negatives.
I think it's a good time to add it to the repository so we can enjoy it.

Fixes #556 

![Ultimate Spider-Man_SLES-53391_20250512112758](https://github.com/user-attachments/assets/0fa7815d-f2d0-417e-bd46-935ded3e147f)
![Ultimate Spider-Man_SLES-53391_20250512112809](https://github.com/user-attachments/assets/c028f560-2cee-4ebb-afbe-e110d59eff77)
