### PR TITLE
NTSC patches (part 1)

### DIFF
--- a/patches/SLES-51249_EE3BCA71.pnach
+++ b/patches/SLES-51249_EE3BCA71.pnach
@@ -7,7 +7,7 @@ description=Widescreen hack 16:9
 patch=1,EE,002b9c78,word,3c023f40 //3c023f80 //Y-fov
 patch=1,EE,002794b8,word,3c033f40 //3c033f80 //Zoom
 
-[50 FPS]
+[50/60 FPS]
 author=Gabominated
 description=Might need EE Overclock.
 patch=1,EE,00217344,word,3C030000 //3C030001
@@ -16,3 +16,9 @@ patch=1,EE,00217344,word,3C030000 //3C030001
 author=Gabominated
 description=Disable post-processing blur effect.
 patch=1,EE,0049B5C8,word,00000000 //00080040
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC Mode at start.
+patch=0,EE,0021561C,word,10450006 //14450006
+patch=1,EE,0049B5C0,word,000001c0 //00000200

--- a/patches/SLES-52179_973793E8.pnach
+++ b/patches/SLES-52179_973793E8.pnach
@@ -1,15 +1,28 @@
-gametitle=Kaan - Barbarian's Blade (E)(SLES-52179)
+gametitle=Kaan - Barbarian's Blade PAL-M SLES-52179 973793E8
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=Arapapa
-
 //Widescreen hack 16:9
-
 //Zoom
 patch=1,EE,001849d4,word,3c023f40 //3c023f80
-
 //Y-Fov
 patch=1,EE,00177a1c,word,3c024010 //3c024040
 
-
+[NTSC Mode]
+author=Gabominated
+description=NTSC Mode at start.
+patch=0,EE,0013EF1C,word,24060002 //24060003
+patch=0,EE,001d5174,word,24060002 //24060003
+patch=1,EE,0013ef58,word,240201c0 //240201e0
+patch=1,EE,001A2430,word,240601c0 //240601E0
+patch=1,EE,00143b7c,word,3c023F4C //3c023f80 frame step Build
+patch=1,EE,00143B80,word,3442CCCD //C60002D0
+patch=1,EE,00143B84,word,C60002D0 //3C023DCC
+patch=1,EE,00143B88,word,3C023DCC //3442CCCD
+patch=1,EE,00143B8C,word,3442CCCD //46000801
+patch=1,EE,00143B90,word,46000801 //E60007A4
+patch=1,EE,00143B94,word,E60007A4 //AE0207A8
+patch=1,EE,00143B98,word,AE0207A8 //C60007A4
+patch=1,EE,00143B9C,word,C60007A4 //46020036
+patch=1,EE,00143BA0,word,46020036 //00000000

--- a/patches/SLES-52835_40033F92.pnach
+++ b/patches/SLES-52835_40033F92.pnach
@@ -1,6 +1,14 @@
-gametitle=The Mummy PAL-M SLES-52835 40033F92
+gametitle=The Mummy - The Animated Series PAL-M SLES-52835 40033F92
 
-[50 FPS]
+[50/60 FPS]
 author=Gabominated
 description=Might need EE Overclock.
 patch=1,EE,0021A59C,word,14600006
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC Mode at start.
+patch=0,EE,0021949C,word,30420000 //30420001
+patch=0,EE,00225010,word,30620000 //30620001
+patch=1,EE,005A3DD4,word,00000280 //00000200
+patch=1,EE,005A3DD8,word,000001C0 //00000200

--- a/patches/SLES-53046_EDE9DD5C.pnach
+++ b/patches/SLES-53046_EDE9DD5C.pnach
@@ -1,6 +1,13 @@
 gametitle=Counter Terrorist Special Forces - Fire for Effect PAL-M SLES-53046 EDE9DD5C
 
-[50 FPS]
+[50/60 FPS]
 author=Gabominated
 description=Might need EE Overclock.
 patch=1,EE,0021A53C,word,14600006 //10600006
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC Mode at start.
+patch=0,EE,00219420,word,10450007 //14450007
+patch=1,EE,00656AE4,word,00000280 //00000200
+patch=1,EE,00656AE8,word,000001c0 //00000200

--- a/patches/SLES-53553_22DC8EAC.pnach
+++ b/patches/SLES-53553_22DC8EAC.pnach
@@ -19,3 +19,14 @@ patch=1,EE,00405638,word,dfbf0040 //c7b40060
 patch=1,EE,0040563c,word,c7b40060 //03e00008
 patch=1,EE,00405640,word,03e00008 //27bd0070
 patch=1,EE,00405644,word,27bd0070 //00000000
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=0,EE,002e266c,word,240201c0 //24020200
+
+[480p Mode]
+author=Gabominated
+description=SDTV 480p mode at start.
+patch=0,EE,00335D10,word,10640005 //14640005
+patch=0,EE,002e266c,word,240201c0 //24020200

--- a/patches/SLES-53797_A0DC603B.pnach
+++ b/patches/SLES-53797_A0DC603B.pnach
@@ -1,0 +1,6 @@
+gametitle=FIFA Street 2 PAL-M SLES-53797 A0DC603B
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=0,EE,002A2BCC,word,24100000 //24100001

--- a/patches/SLES-54031_CC39A3E6.pnach
+++ b/patches/SLES-54031_CC39A3E6.pnach
@@ -2,11 +2,17 @@ gametitle=The Da Vinci Code (PAL-M) SLES-54031 CC39A3E6
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=PeterDelta
+author=sergx12
 description=Widescreen Hack
 patch=1,EE,003AE5D8,word,3C023F40 //3C023F80
 
-[50 FPS]
+[50/60 FPS]
 author=asasega
-description=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+description=Might need EE Overclock (130%).
 patch=1,EE,001AD428,word,00000001
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=1,EE,003BC53C,word,24060002 //24060003
+patch=1,EE,003BBF50,word,240901c0 //24090200

--- a/patches/SLES-54126_E393DFE5.pnach
+++ b/patches/SLES-54126_E393DFE5.pnach
@@ -1,4 +1,4 @@
-gametitle=Family Guy (SLES-54126)
+gametitle=Family Guy - The Video Game PAL-M SLES-54126 E393DFE5
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -8,7 +8,12 @@ patch=1,EE,0011B3A8,word,00000000 //10400009
 patch=1,EE,0011B3BC,word,3C013F80 //3C013F59
 patch=1,EE,0011B3C0,word,34210000 //3421999A
 
-[50 FPS]
+[50/60 FPS]
 author=CRASHARKI
 description=Patches the game to run at 50 FPS. (Original NTSC-U pnach by asasega)
 patch=1,EE,2025989C,word,00000001 //00000002
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=0,EE,0014E0D8,word,14600002 //10600002

--- a/patches/SLES-54150_85495C17.pnach
+++ b/patches/SLES-54150_85495C17.pnach
@@ -7,7 +7,13 @@ description=Enable native widescreen.
 patch=1,EE,00388D04,word,3C013F10 //3C013F00 zoom fix
 patch=1,EE,0065F798,word,00000001 //00000000
 
-[50 FPS]
+[50/60 FPS]
 author=Gabominated
 description=Might need EE Overclock.
 patch=1,EE,001C9674,word,24020002 //24020004
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC Mode at start.
+patch=0,EE,0042CF00,word,24020005 //24020004
+patch=0,EE,0042CF08,word,240300E0 //24030100

--- a/patches/SLES-54159_3E9B19C2.pnach
+++ b/patches/SLES-54159_3E9B19C2.pnach
@@ -1,4 +1,4 @@
-gametitle=Eragon (E)(SLES-54159) 3E9B19C2
+gametitle=Eragon PAL-M SLES-54159 3E9B19C2
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -12,7 +12,14 @@ patch=1,EE,001b6348,word,461e0842 //4618a843
 //Render fix
 patch=1,EE,001afc44,word,3c023f2b //3c023f00
 
-[50 FPS]
+[50/60 FPS]
 author=user234
-description=Unlocked at 50 FPS. Might need enable 180% EE Overclock to be stable.
+description=Might need EE Overclock (180%).
 patch=1,EE,00399A30,word,00000000 //00000001
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=0,EE,001BD818,word,14400003 //10400003
+patch=0,EE,001BD52C,word,54400002 //50400002
+patch=0,EE,001BD538,word,54400002 //50400002

--- a/patches/SLES-54364_5415FA68.pnach
+++ b/patches/SLES-54364_5415FA68.pnach
@@ -1,4 +1,4 @@
-gametitle=Curious George [PAL-M7] (SLES_543.64)
+gametitle=Curious George PAL-M7 SLES-54364 5415FA68
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -8,4 +8,8 @@ author=El_Patas
 patch=1,EE,00199214,word,3C013CAD //3C013C8E Zoom
 patch=1,EE,001B2114,word,3C013C6E //3C013C8E Y-FOV
 
-
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=0,EE,0039c9e4,word,00000003 //00000001
+patch=0,EE,00211F0C,word,24020002 //24020001

--- a/patches/SLES-54757_F654BFDC.pnach
+++ b/patches/SLES-54757_F654BFDC.pnach
@@ -1,0 +1,13 @@
+gametitle=Transformers - The Game PAL-G-I SLES-54757 F654BFDC
+
+[50/60 FPS]
+author=Gabominated
+description=Might need EE Overclock (180%).
+patch=1,EE,004b1550,word,00000002 //uncapped frame limit 60 FPS
+patch=1,EE,004363A0,word,3C014248 //framerate PAL 50Hrz
+patch=1,EE,004363B0,word,3c014270 //framerate NTSC 60Hrz
+
+[NTSC Mode]
+author=PeterDelta
+description=NTSC mode at start.
+patch=1,EE,004A4660,word,00000000

--- a/patches/SLES-55448_528C8054.pnach
+++ b/patches/SLES-55448_528C8054.pnach
@@ -1,6 +1,11 @@
 gametitle=Indiana Jones and the Staff of Kings (PAL-M) SLES-55448 528C8054
 
-[50 FPS]
+[50/60 FPS]
 author=asasega
-description=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+description=Might need EE Overclock (130%).
 patch=1,EE,201505B4,extended,2C620000
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=0,EE,0014E964,word,3C040002 //3C040001

--- a/patches/SLES-55546_B6BA0E59.pnach
+++ b/patches/SLES-55546_B6BA0E59.pnach
@@ -1,4 +1,4 @@
-gametitle=The Secret Saturdays - Beasts of the 5th Sun (U&PAL)(SLUS-21896,SLES-55546)
+gametitle=The Secret Saturdays - Beasts of the 5th Sun PAL-M SLES-55546 B6BA0E59
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -8,7 +8,13 @@ description=Widescreen hack
 patch=1,EE,0011a67c,word,3c013f4d //3c013f89
 patch=1,EE,0011a680,word,3421b6d4 //34212493
 
-[50 FPS]
-author=asasega
-description=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
-patch=1,EE,20285F78,extended,00000001
+//[50 FPS]
+//author=asasega
+//description=Unlocked at 50 FPS. Might need enable 130% EE Overclock to be stable.
+//patch=1,EE,20285F78,extended,00000001
+//disabled because it causes break in jump
+
+[NTSC Mode]
+author=Gabominated
+description=NTSC mode at start.
+patch=0,EE,00150B8C,word,14600002


### PR DESCRIPTION
**Tested NTSC Patches** :heavy_check_mark: 
- Castleween PAL-M SLES-51249 EE3BCA71
- Kaan - Barbarian's Blade PAL-M SLES-52179 973793E8
- The Mummy - The Animated Series PAL-M SLES-52835 40033F92
- Counter Terrorist Special Forces - Fire for Effect PAL-M SLES-53046 EDE9DD5C
- 007 - From Russia with Love PAL-M SLES-53553 22DC8EAC
- FIFA Street 2 PAL-M SLES-53797 A0DC603B
- The Da Vinci Code PAL-M SLES-54031 CC39A3E6
- Family Guy - The Video Game PAL-M SLES-54126 E393DFE5
- Bionicle Heroes PAL-M SLES-54150 85495C17
- Eragon PAL-M SLES-54159 3E9B19C2
- Curious George PAL-M SLES-54364 5415FA68
- Transformers - The Game PAL-G SLES-54757 F654BFDC
- Indiana Jones and the Staff of Kings PAL-M SLES-55448 528C8054
- The Secret Saturdays - Beasts of the 5th Sun PAL-M SLES-55546 B6BA0E59

Added 50/60 FPS patch for **Transformers - The Game PAL-G** and disabled 50 FPS patch on **The Secret Saturdays - Beasts of the 5th Sun PAL-M** because it breaks the jump system and makes a full walkthrough impossible.