### PR TITLE
Add Enable Skip Cutscenes Patch for God of War 1 And 2

### DIFF
--- a/patches/SCES-53133_FB0E6D72.pnach
+++ b/patches/SCES-53133_FB0E6D72.pnach
@@ -146,3 +146,8 @@ patch=1,EE,20331330,extended,3FE38E39
 //description=SDTV 480p mode at start. Cannot be conditioned, FMV no sync, gameplay is fine
 //patch=1,EE,0029DACC,extended,00000001
 //patch=1,EE,2029D284,extended,3F555550
+
+[Skip Cutscenes]
+author=Ezedequias
+description=With Any Action button
+patch=1,EE,0029D47C,byte,01

--- a/patches/SCES-54206_44A8A22A.pnach
+++ b/patches/SCES-54206_44A8A22A.pnach
@@ -7,3 +7,7 @@ description=Widescreen Converted from NTSC hack by nemesis2000
 patch=1,EE,002348a0,word,46000406
 
 
+[Skip Cutscenes]
+author=Ezedequias
+description=With Any Action Button
+patch=1,EE,002D7B24,byte,01

--- a/patches/SCUS-97399_D6385328.pnach
+++ b/patches/SCUS-97399_D6385328.pnach
@@ -148,3 +148,8 @@ patch=1,EE,201692b8,extended,3c013f40
 patch=1,EE,e0020001,extended,0029cc50
 patch=1,EE,e0010000,extended,0029cc90
 patch=1,EE,201692b8,extended,3c013f40
+
+[Skip Cutscenes]
+author=Ezedequias
+description=With Any Action Button
+patch=1,EE,2029C83C,byte,01

--- a/patches/SCUS-97481_2F123FD8.pnach
+++ b/patches/SCUS-97481_2F123FD8.pnach
@@ -6,3 +6,7 @@ author=nemesis2000
 patch=1,EE,00234A48,word,46000406
 
 
+[Skip Cutscenes]
+author=Ezedequias
+comment=With Any Action Button
+patch=1,EE,202D8194,byte,01


### PR DESCRIPTION
This patch adds the option to skip cutscenes, which is especially useful for speedrunners. It has been tested on Vulkan with version 2.2.0, and no bugs or crashes were observed.
God of War PAL-M  (SCES-53133_FB0E6D72)
God of War 1 USA  (SCUS-97399_D6385328)
God of War 2 USA  (SCUS-97481_2F123FD8)
God of War 2 PAL-M  (SCES-54206_44A8A22A)

Details:
Enables cutscene skipping by pressing the action button
To God of War 1 and God of War 2 (USA and EU versions).
Saves approximately 1 hour and 15 minutes in God of War 2.
Saves approximately 51 minutes in God of War 1.
Improves gameplay flow without affecting game stability.
[Patchs.txt](https://github.com/user-attachments/files/20402877/Patchs.txt)

