### PR TITLE
SLUS-20419: Add performance optimization patch

### DIFF
--- a/patches/SLUS-20419_5838E074.pnach
+++ b/patches/SLUS-20419_5838E074.pnach
@@ -1,7 +1,24 @@
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-patch=1,EE,20161BCC,word,24091038
-patch=1,EE,20161C34,word,24030001
+patch=0,EE,20161BCC,word,24091038
+patch=0,EE,20161C34,word,24030001
 
+[Improved Performance]
+author=Souzooka
+description=Improves performance while camera is facing the sun, slight accuracy compromise
 
+// Jump to code cave (believed to be unused Sony SDK function)
+// instead of doing sun culling collision check, which is very slow
+patch=0,EE,20161D78,extended,0C0659EA
+
+// Only call the sun cull collision check once every 4 frames (15 times/second),
+// improving behavior and also pacing with minor frame latency
+patch=0,EE,201967A8,extended,8C810010 // lw at,0x10(a0) ; this is a frame counter
+patch=0,EE,201967AC,extended,30210003 // andi at,at,0x0003
+patch=0,EE,201967B0,extended,14200003 // bne at,zero,0x001967C0
+patch=0,EE,201967B4,extended,00000000 // nop
+patch=0,EE,201967B8,extended,08058950 // j z_un_00162540 ; tail call to original function
+patch=0,EE,201967BC,extended,00000000 // nop
+patch=0,EE,201967C0,extended,03E00008 // jr ra
+patch=0,EE,201967C4,extended,00000000 // nop


### PR DESCRIPTION
I was having issues running this game at 60fps while upscaling, often dropping to ~48-60fps at seemingly arbitrary points during certain tracks. I took a look at the culprit, and it appears that the process the game uses to cull the sun is very slow. The state of the sun being culled or not persists between frames, so I implemented a hackfix just to have this process done once every four frames (15 times a second). This gives about a ~40% fps increase when the camera is facing in the direction of the sun, though may introduce slight framepacing issues and is slightly less accurate in culling the sun, but this is barely noticeable.

See the attached video below where I play a segment of a track unpatched, and then load a patched savestate at around the 0:53 mark (note the arrows in the HUD also cull the sun -- that's just the game):

https://www.youtube.com/watch?v=Go-SWagZRDY