### PR TITLE
Disable blur patch for Dog's Life

### DIFF
--- a/patches/SCES-51248_531061F2.pnach
+++ b/patches/SCES-51248_531061F2.pnach
@@ -8,5 +8,10 @@ patch=1,EE,00AB51C0,byte,01
 
 [50 FPS]
 author=PeterDelta
-description=Might need EE Overclock at 130%.
+description=Might need EE Overclock (130%).
 patch=1,EE,00791350,word,3CA3D70A
+
+[Disable Blur]
+author=Gabominated
+description=Disable DOF/blur post-processing effect.
+patch=1,EE,0081A198,word,00000000

--- a/patches/SLPM-65995_08E89523.pnach
+++ b/patches/SLPM-65995_08E89523.pnach
@@ -1,0 +1,12 @@
+gametitle=Dog's Life NTSC-J SLPM-65995 08E89523
+
+[60 FPS]
+author=Gabominated
+description=Might need EE overclock (130%).
+patch=1,EE,E0013D08,extended,007B7662
+patch=1,EE,207B7660,extended,3C88AB86
+
+[Disable Blur]
+author=Gabominated
+description=Disable DOF/blur post-processing effect.
+patch=1,EE,00822E38,word,00000000

--- a/patches/SLUS-21018_35CB5180.pnach
+++ b/patches/SLUS-21018_35CB5180.pnach
@@ -5,3 +5,8 @@ author=asasega
 description=Unlocked at 60 FPS. Might need enable 130% EE Overclock to be stable.
 patch=1,EE,D0824B82,extended,00003D08
 patch=1,EE,20824B80,extended,3C888889
+
+[Disable Blur]
+author=Gabominated
+description=Disable DOF/blur post-processing effect.
+patch=1,EE,00828368,word,00000000


### PR DESCRIPTION
**Explanation:** This patch disables the blur caused by the depth of field effect. Everything has been tested and I can confirm that it doesn't cause any problems.

Patches:
Disable Blur

- **Dog's Life PAL-M SCES-51248 531061F2** (Tested :heavy_check_mark:)
- **Dog's Life NTSC-J SLPM-65995 08E89523** (Tested :heavy_check_mark:)
- **Dog's Life NTSC-U SLUS-21018 35CB5180** (Tested :heavy_check_mark:)

Additional 60 FPS patch for **NTSC-J**

![Dog's Life_00](https://github.com/user-attachments/assets/53b175ab-71ef-4373-9eae-00ca3ca06cae)
![Dog's Life_01](https://github.com/user-attachments/assets/6e6334a8-7fef-4c34-88ae-a66e6f3e71e9)
![Dog's Life_SLPM-65995_20250531103155](https://github.com/user-attachments/assets/c69f1797-abce-430e-b6a7-c8a48a799adc)
![Dog's Life_SLPM-65995_20250531103204](https://github.com/user-attachments/assets/c0d7f50f-494b-4676-af3e-f32e24bdb939)
![Dog's Life_SLUS-21018_20250520171831](https://github.com/user-attachments/assets/def90489-a103-4f21-9b46-077d404bb95b)
![Dog's Life_SLUS-21018_20250520171859](https://github.com/user-attachments/assets/29bb2fd3-7f6e-4fc5-984b-4a930d3532f0)
![Dog's Life_SLUS-21018_20250520171927](https://github.com/user-attachments/assets/64bdf9a7-1c6c-4fec-835d-59be2e5603ee)
![Dog's Life_SLUS-21018_20250520171945](https://github.com/user-attachments/assets/f39d80c1-f0f1-46fc-bf6a-6b92fa6e95c5)
![Dog's Life_SLUS-21018_20250520172716](https://github.com/user-attachments/assets/2bdd5551-c4b4-4301-b624-b1ba37041f4f)
![Dog's Life_SLUS-21018_20250520172722](https://github.com/user-attachments/assets/799a3c18-39cc-4736-96c8-12ba65de95c4)
