### PR TITLE
Add framerate hack for Vexx (NTSC-U)

### DIFF
--- a/patches/SLUS-20383_B6580DA4.pnach
+++ b/patches/SLUS-20383_B6580DA4.pnach
@@ -1,8 +1,15 @@
-gametitle=Vexx SLUS_203.83
+gametitle=Vexx (NTSC-U) SLUS-20383 B6580DA4
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 description=Widescreen Hack
+
+//Widescreen
 patch=1,EE,0035d74c,word,3c033f40
 
+[60 FPS]
+author=FrankyBuster.
+description=Unlocks the dynamic framerate cap to 60FPS. Requires 180% overclock to be stable.
 
+//60FPS
+patch=1,EE,00431BC6,short,00003F91


### PR DESCRIPTION
Adds framerate hack to default the framerate at 60fps, so it no longer has the wait time for the cap to adjust after overclock.