### PR TITLE
Add God of War 1 and 2 Skip Cutscene Patch for More Regions and Demos

### DIFF
--- a/patches/SCKA-30002_BFCC1795.pnach
+++ b/patches/SCKA-30002_BFCC1795.pnach
@@ -6,4 +6,7 @@ description=widescreen 16:9 (NTSC-K) hack by 99skull
 //credit goes to nemesis2000
 patch=1,EE,00169308,word,3C013F22 //3C013F00, zoom
 
-
+[Skip Cutscenes]
+author=Ezedequias
+description=With Any Action Button
+patch=1,EE,0029D4FC,byte,01

--- a/patches/SCKA-30006_4340C7C6.pnach
+++ b/patches/SCKA-30006_4340C7C6.pnach
@@ -6,4 +6,7 @@ description=widescreen 16:9 (NTSC-K) hack by 99skull
 //credit goes to nemesis2000
 patch=1,EE,001770C8,word,3C013F0E //3C013F00, zoom
 
-
+[Skip Cutscenes]
+author=Ezedequias
+description=With Any Action Button
+patch=1,EE,002D9654,byte,01

--- a/patches/SCUS-97467_56EC00B5.pnach
+++ b/patches/SCUS-97467_56EC00B5.pnach
@@ -1,0 +1,7 @@
+gametitle= God of War 2 E3 Demo (NTSC-U) (SCUS-97467) 56EC00B5
+
+[Skip Cutscenes]
+author=Ezedequias
+description=With Any Action Button
+patch=1,EE,002B15BC,byte,01
+patch=1,EE,0018F7AC,word,0000

--- a/patches/SCUS-97467_DF3A5A5C.pnach
+++ b/patches/SCUS-97467_DF3A5A5C.pnach
@@ -1,0 +1,7 @@
+gametitle= God of War [Demo] (NTSC-U) (SCUS-97467) DF3A5A5C
+
+[Skip Cutscenes]
+author=Ezedequias
+description=With X
+patch=1,EE,0029358C,byte,01
+patch=1,EE,001885BC,word,0000

--- a/patches/SCUS-97482_174F7EC0.pnach
+++ b/patches/SCUS-97482_174F7EC0.pnach
@@ -1,0 +1,7 @@
+gametitle= God of War 2 The Colossus Battle [Demo] (SCUS-97482) 174F7EC0
+
+[Skip Cutscenes]
+author=Ezedequias
+description=With Any Action Button
+patch=1,EE,002D7B94,byte,01
+patch=1,EE,001916A4,word,0000

--- a/patches/SLPM-67010_CA052D22.pnach
+++ b/patches/SLPM-67010_CA052D22.pnach
@@ -1,0 +1,6 @@
+gametitle= God of War (NTSC-J) (SLPM-67010) CA052D22
+
+[Skip Cutscenes]
+author=Ezedequias
+description=With Any Action Button
+patch=1,EE,0029D91C,byte,01

--- a/patches/SLPM-67013_E96E55BD.pnach
+++ b/patches/SLPM-67013_E96E55BD.pnach
@@ -1,0 +1,6 @@
+gametitle= God of War 2 (NTSC-J) (SLPM-67013) E96E55BD
+
+[Skip Cutscenes]
+author=Ezedequias
+description=With Any Action Button
+patch=1,EE,002D9DB4,byte,01


### PR DESCRIPTION
- Well, after I made this patch for God of War 1 and 2 USA/European versions, a speedrunner asked me to do it for the other regions and also for the demos.

- So, I did.

1. SCKA-30002_BFCC1795 God of War 1 Korea version  
2. SCKA-30006_4340C7C6 God of War 2 Korea version  
3. SCUS-97467_56EC00B5 God of War 2 E3 Demo  
4. SCUS-97467_DF3A5A5C God of War 1 Demo  
5. SCUS-97482_174F7EC0 God of War 2 The Colossus Battle [Demo]  
6. SLPM-67010_CA052D22 God of War 1 Japan  
7. SLPM-67013_E96E55BD God of War 2 Japan

- These versions use the same logic as the USA and European versions. Only the God of War 1 Demo has some minor differences, but nothing significant.
