### PR TITLE
Revert "Drive to Survive: Remove a pointless widescreen patch (#539)"

### DIFF
--- a/patches/SLUS-21109_0520A26D.pnach
+++ b/patches/SLUS-21109_0520A26D.pnach
@@ -1,20 +1,18 @@
 gametitle=Drive To Survive (U)(SLUS-21109)
 
-// Mashed: Fully Loaded (SLES-53152) and Drive to Survive (SLUS-21109) have native widescreen
-// available in Screen options, so this patch is pointless
-//[Widescreen 16:9]
-//gsaspectratio=16:9
-//author=Arapapa
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Arapapa
 
 //Widescreen hack 16:9
 
-//patch=1,EE,0019a430,word,08106838
+patch=1,EE,0019a430,word,08106838
 
-//patch=1,EE,0041a0e0,word,46020002
-//patch=1,EE,0041a0e4,word,3c013faa
-//patch=1,EE,0041a0e8,word,3421aaab
-//patch=1,EE,0041a0ec,word,4481f000
-//patch=1,EE,0041a0f0,word,461e0002
-//patch=1,EE,0041a0f4,word,0806690d
+patch=1,EE,0041a0e0,word,46020002
+patch=1,EE,0041a0e4,word,3c013faa
+patch=1,EE,0041a0e8,word,3421aaab
+patch=1,EE,0041a0ec,word,4481f000
+patch=1,EE,0041a0f0,word,461e0002
+patch=1,EE,0041a0f4,word,0806690d
 
 


### PR DESCRIPTION
This reverts commit 0e484342c8daf0068b498a3d32ceedf39bf8b1c6.

I recently removed this widescreen patch as the game has native widescreen, **but** it turns out it's broken on the first boot. Even though this patch is imperfect as it reinvents widescreen instead of toggling the in-game option, I'm reinstating it for now until I get some time to investigate the actual issue and replace it with a proper toggle.