### PR TITLE
Widescreen Patches for MTV Pimp My Ride

### DIFF
--- a/patches/SLUS-21580_166ADC2E.pnach
+++ b/patches/SLUS-21580_166ADC2E.pnach
@@ -1,19 +1,31 @@
 gametitle=MTV Pimp My Ride NTSC-U SLUS-21580 166ADC2E
 
-[Widescreen: 16:9]
+[Widescreen 16:9]
 gsaspectratio=16:9
 description=Widescreen Hack
 author=FelkonEXE
 patch=1,EE,0045C880,word,3FE38E39
 
-[Widescreen: 16:10]
+[Widescreen 16:10]
 gsaspectratio=Stretch
 description=Widescreen Hack
 author=FelkonEXE
 patch=1,EE,0045C880,word,3FCCCCCD
 
-[Widescreen: 21:9]
+[Widescreen 21:9]
 gsaspectratio=Stretch
 description=Widescreen Hack
 author=FelkonEXE
 patch=1,EE,0045C880,word,40155555
+
+[Widescreen 15:10]
+gsaspectratio=Stretch
+description=Widescreen Hack
+author=FelkonEXE
+patch=1,EE,0045C880,word,3FA20000
+
+[Widescreen 20:9]
+gsaspectratio=Stretch
+description=Widescreen Hack
+author=FelkonEXE
+patch=1,EE,0045C880,word,400E38E1

--- a/patches/SLUS-21580_166ADC2E.pnach
+++ b/patches/SLUS-21580_166ADC2E.pnach
@@ -22,7 +22,7 @@ patch=1,EE,0045C880,word,40155555
 gsaspectratio=Stretch
 description=Widescreen Hack
 author=FelkonEXE
-patch=1,EE,0045C880,word,3FA20000
+patch=1,EE,0045C880,word,3FC00000
 
 [Widescreen 20:9]
 gsaspectratio=Stretch

--- a/patches/SLUS-21580_166ADC2E.pnach
+++ b/patches/SLUS-21580_166ADC2E.pnach
@@ -1,0 +1,19 @@
+gametitle=MTV Pimp My Ride NTSC-U SLUS-21580 166ADC2E
+
+[Widescreen: 16:9]
+gsaspectratio=16:9
+description=Widescreen Hack
+author=FelkonEXE
+patch=1,EE,0045C880,word,3FE38E39
+
+[Widescreen: 16:10]
+gsaspectratio=Stretch
+description=Widescreen Hack
+author=FelkonEXE
+patch=1,EE,0045C880,word,3FCCCCCD
+
+[Widescreen: 21:9]
+gsaspectratio=Stretch
+description=Widescreen Hack
+author=FelkonEXE
+patch=1,EE,0045C880,word,40155555


### PR DESCRIPTION
Patch that adds `16:9`, `16:10` and `21:9`.

16:9 example:
![2025-07-08_pcsx2-qt_11-21-04](https://github.com/user-attachments/assets/53f8bec5-3b66-4a7e-8ce6-4c1c427ce54f)