### PR TITLE
WS: Disable project zero PAL WS

### DIFF
--- a/patches/SLES-50821_22E91837.pnach
+++ b/patches/SLES-50821_22E91837.pnach
@@ -3,80 +3,80 @@ gametitle=Project Zero * SLES-50821 * PAL-M5 * 22E91837
 
 // Due to missing renderingfixes, black stripes can show up on ghosts, spirits and photos.
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=nemesis2000 & pgert
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=nemesis2000 & pgert. Breaks mirror rendering.
 
-patch=1,EE,00185B40,word,3C0145C0 // 3C014500 - HD-rendering fix for 00185B4C.
-patch=1,EE,00185B4C,word,3C013F40 // 3C013F80 - X-axis of Cutscenes (including IntroCutscenes).
-patch=1,EE,0018A2CC,word,3C013F40 // 3C013F80 - X-axis of GamePlay.
+//patch=1,EE,00185B40,word,3C0145C0 // 3C014500 - HD-rendering fix for 00185B4C.
+//patch=1,EE,00185B4C,word,3C013F40 // 3C013F80 - X-axis of Cutscenes (including IntroCutscenes).
+//patch=1,EE,0018A2CC,word,3C013F40 // 3C013F80 - X-axis of GamePlay.
 
 // Flashlight 16:9 Widescreen hack, ported by pgert from the NTSC-U pnach by nemesis2000,
 //  and modified so that the values are altered with half of the regular amount
 //  (0,875 instead of 0,75) - better.
-patch=1,EE,00135B18,word,3C01428C // 3C0142A0
-patch=1,EE,00135B80,word,3C0141A8 // 3C0141C0
-patch=1,EE,00135BC4,word,3C014128 // 3C014140
-patch=1,EE,00135BFC,word,3C01410C // 3C014120
-patch=1,EE,0013715C,word,3C013F12 // 3C013F00
+//patch=1,EE,00135B18,word,3C01428C // 3C0142A0
+//patch=1,EE,00135B80,word,3C0141A8 // 3C0141C0
+//patch=1,EE,00135BC4,word,3C014128 // 3C014140
+//patch=1,EE,00135BFC,word,3C01410C // 3C014120
+//patch=1,EE,0013715C,word,3C013F12 // 3C013F00
 
 // 16:9 Cinematics hack by nemesis2000.
-patch=1,EE,00182730,word,24027100 // 24026C00 - X-axis placement of Cinematics.
-patch=1,EE,00182740,word,24027100 // 24026C00 - X-axis placement of Cinematics.
+//patch=1,EE,00182730,word,24027100 // 24026C00 - X-axis placement of Cinematics.
+//patch=1,EE,00182740,word,24027100 // 24026C00 - X-axis placement of Cinematics.
 // - 6C00h = 27648d : width of Cinematics = 640d : 27648 + 1600 - 640/2 = 28160 : 28160d = 7100h
-patch=1,EE,00182748,word,24091E00 // 24092800 - width of Cinematics.
+//patch=1,EE,00182748,word,24091E00 // 24092800 - width of Cinematics.
 // - 2800h = 10240d : width of Cinematics = 640d : 10240 - 1600 - 640*1.5 = 7680 : 7680d = 1E00h
 
 // ==========
 
-[Widescreen/16:10]
-gsaspectratio=Stretch
-author=nemesis2000 & pgert
+//[Widescreen/16:10]
+//gsaspectratio=Stretch
+//author=nemesis2000 & pgert. Breaks mirror rendering.
 
-patch=1,EE,00185B40,word,3C0145C0 // can't be set to 3C0145AD.
-patch=1,EE,00185B4C,word,3C013F55
-patch=1,EE,0018A2CC,word,3C013F55
+//patch=1,EE,00185B40,word,3C0145C0 // can't be set to 3C0145AD.
+//patch=1,EE,00185B4C,word,3C013F55
+//patch=1,EE,0018A2CC,word,3C013F55
 
 // Flashlight 16:10 Widescreen hack, ported by pgert from the NTSC-U pnach by nemesis2000,
 //  and modified so that the values are altered with half of the regular amount
 //  (0,91666665 instead of 0,8333333) - better.
-patch=1,EE,00135B18,word,3C014293
-patch=1,EE,00135B80,word,3C0141B0
-patch=1,EE,00135BC4,word,3C014130
-patch=1,EE,00135BFC,word,3C014113
-patch=1,EE,0013715C,word,3C013F0C
+//patch=1,EE,00135B18,word,3C014293
+//patch=1,EE,00135B80,word,3C0141B0
+//patch=1,EE,00135BC4,word,3C014130
+//patch=1,EE,00135BFC,word,3C014113
+//patch=1,EE,0013715C,word,3C013F0C
 
 // Cinematics hack by nemesis2000, ported to 16:10 by pgert.
-patch=1,EE,00182730,word,24027080
-patch=1,EE,00182740,word,24027080
+//patch=1,EE,00182730,word,24027080
+//patch=1,EE,00182740,word,24027080
 // - 7100h = 28160d : 28160 + 640 = 28800 : 28800d = 7080h
-patch=1,EE,00182748,word,24091F00 // 24092800 - width of Cinematics.
+//patch=1,EE,00182748,word,24091F00 // 24092800 - width of Cinematics.
 // - 1E00h = 7680d : 7680 + 256 = 7936 : 7936d = 1F00h
 
 // ==========
 
-[Widescreen/15:10]
-gsaspectratio=Stretch
-author=nemesis2000 & pgert
+//[Widescreen/15:10]
+//gsaspectratio=Stretch
+//author=nemesis2000 & pgert. Breaks mirror rendering.
 
-patch=1,EE,00185B40,word,3C0145C0
-patch=1,EE,00185B4C,word,3C013F64
-patch=1,EE,0018A2CC,word,3C013F64
+//patch=1,EE,00185B40,word,3C0145C0
+//patch=1,EE,00185B4C,word,3C013F64
+//patch=1,EE,0018A2CC,word,3C013F64
 
 // Flashlight 15:10 Widescreen hack, ported by pgert from the NTSC-U pnach by nemesis2000,
 //  and modified so that the values are altered with half of the regular amount
 //  (0,94444445 instead of 0,8888889) - better.
-patch=1,EE,00135B18,word,3C014297
-patch=1,EE,00135B80,word,3C0141B5
-patch=1,EE,00135BC4,word,3C014135
-patch=1,EE,00135BFC,word,3C014117
-patch=1,EE,0013715C,word,3C013F08
+//patch=1,EE,00135B18,word,3C014297
+//patch=1,EE,00135B80,word,3C0141B5
+//patch=1,EE,00135BC4,word,3C014135
+//patch=1,EE,00135BFC,word,3C014117
+//patch=1,EE,0013715C,word,3C013F08
 
 // Cinematics hack by nemesis2000, ported to 15:10 by pgert.
-patch=1,EE,00182730,word,240270AB
-patch=1,EE,00182740,word,240270AB
+//patch=1,EE,00182730,word,240270AB
+//patch=1,EE,00182740,word,240270AB
 // - 7100h = 28160d : 28160 + (640*(16/15)) = 28843 : 28760d = 70ABh
-patch=1,EE,00182748,word,24091F11 // 24092800 - width of Cinematics.
+//patch=1,EE,00182748,word,24091F11 // 24092800 - width of Cinematics.
 // - 1E00h = 7680d : 7680 + (256*(16/15)) = 7953 : 7953d = 1F11h
 
 // ==========


### PR DESCRIPTION
Appears to break mirror rendering.

With:
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/6165c3ab-1fed-4615-ada5-e96cf634ba0d" />

Without WS:
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/88f687b7-f410-4af6-add4-21ff49b66843" />