### PR TITLE
Create SLUS-20362_1D2818AF

### DIFF
--- a/SLUS-20362_1D2818AF
+++ b/SLUS-20362_1D2818AF
@@ -1,5 +1,7 @@
 gametitle=Need for Speed: Hot Pursuit 2 (SLUS-20362)
 
+[Widescreen 21:9]
+author=sathvik989
 
 patch=1,EE,00330188,word,44555555
 patch=1,EE,0010e994,word,46011702


### PR DESCRIPTION
Adds a ultrawide patch for Need For Speed Hot Pursuit 2.

Patch works perfectly. HUD is still distorted. 

I'd love for this to be added as I'd love to earn retroachievements whilst playing the game in 21:9.

Thank you!