### PR TITLE
Adding patches for God of War II's Bonus Subset (RetroAchievements)

### DIFF
--- a/patches/RAUS-97481_2F123FD8.pnach
+++ b/patches/RAUS-97481_2F123FD8.pnach
@@ -1,0 +1,16 @@
+gametitle=God of War 2 (RAUS-97481) / [Subset - Bonus]
+
+// This file is a copy of SCUS-97481_2F123FD8.pnach, please keep these two in sync!
+// This game version is a dummy patch for the "Bonus" RetroAchievements subset:
+// https://retroachievements.org/game/28250
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=nemesis2000
+patch=1,EE,00234A48,word,46000406
+
+
+[Skip Cutscenes]
+author=Ezedequias
+comment=With Any Action Button
+patch=1,EE,202D8194,byte,01


### PR DESCRIPTION
Added <RAUS-97481_2F123FD8.pnach> as a copy of <SCUS-97481_2F123FD8.pnach> for RetroAchievement's GoWII Bonus Subset.