### PR TITLE
Create SLUS-21267_270F8C03.pnach

### DIFF
--- a/SLUS-21267_270F8C03.pnach
+++ b/SLUS-21267_270F8C03.pnach
@@ -1,0 +1,25 @@
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Widescreen fix
+patch=1,EE,00AAFDD4,word,00000001
+patch=1,EE,0054BA38,word,3F400000
+
+[Remove Brown Filter]
+author=fobes
+description=Disables the brownish yellow post processing filter
+patch=1,EE,00550D58,extended,20000001
+
+[Remove Blur]
+author=PeterDelta
+description=Removes the blur effect
+patch=0,EE,0055014C,word,00000000
+patch=0,EE,001FEDB8,word,24020000
+patch=0,EE,001FEDBC,word,10620004
+
+[Enable Black Edition]
+description=Black Edition content, Burger King Challenge and Castrol Ford GT always enabled
+author=Sal_89
+patch=1,EE,20574640,byte,1
+patch=1,EE,20574228,byte,1
+patch=1,EE,20574264,byte,1


### PR DESCRIPTION
Added some missing entries:
- Japanese version
- Korean version
- NTSC-U 1.01 version (same ID as 2.00 version, but different CRC

Added Black Edition, Burger King Challenge and Castrol Ford GT enablers for the new entries, and the already available ones