### PR TITLE
Create SLUS-21267_0518D275.pnach

### DIFF
--- a/SLUS-21267_0518D275.pnach
+++ b/SLUS-21267_0518D275.pnach
@@ -1,0 +1,6 @@
+[Enable Black Edition]
+description=Black Edition content, Burger King Challenge and Castrol Ford GT always enabled
+author=Sal_89
+patch=1,EE,20574640,byte,1
+patch=1,EE,20574228,byte,1
+patch=1,EE,20574264,byte,1


### PR DESCRIPTION
Added some missing entries:
- Japanese version
- Korean version
- NTSC-U 1.01 version (same ID as 2.00 version, but different CRC

Added Black Edition, Burger King Challenge and Castrol Ford GT enablers for the new entries, and the already available ones