### PR TITLE
Create SLES-53558_1FA82CDF.pnach

### DIFF
--- a/SLES-53558_1FA82CDF.pnach
+++ b/SLES-53558_1FA82CDF.pnach
@@ -1,0 +1,11 @@
+[Remove Brown Filter]
+author=fobes
+description=Disables the brownish yellow post processing filter
+patch=1,EE,00551358,extended,20000001
+
+[Enable Black Edition]
+description=Black Edition content, Burger King Challenge and Castrol Ford GT always enabled
+author=Sal_89
+patch=1,EE,20574C40,byte,1
+patch=1,EE,20574828,byte,1
+patch=1,EE,20574864,byte,1


### PR DESCRIPTION
Added some missing entries:
- Japanese version
- Korean version
- NTSC-U 1.01 version (same ID as 2.00 version, but different CRC

Added Black Edition, Burger King Challenge and Castrol Ford GT enablers for the new entries, and the already available ones