### PR TITLE
Create SLES-53559_CA2A1B04.pnach

### DIFF
--- a/SLES-53559_CA2A1B04.pnach
+++ b/SLES-53559_CA2A1B04.pnach
@@ -1,0 +1,28 @@
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta
+description=Widescreen fix
+patch=1,EE,00AAF954,word,00000001
+patch=1,EE,0054BD38,word,3F400000
+
+[Remove Brown Filter]
+author=fobes
+description=Disables the brownish yellow post processing filter
+patch=1,EE,00551058,extended,20000001
+
+[NTSC Mode]
+author=Felixthecat1970
+description=NTSC mode at start.
+patch=0,EE,20322DB4,extended,0000102D
+
+[Remove Blur]
+author=PeterDelta
+description=Removes the blur effect
+patch=1,EE,00550424,word,00000000
+
+[Enable Black Edition]
+description=Black Edition content, Burger King Challenge and Castrol Ford GT always enabled
+author=Sal_89
+patch=1,EE,20574940,byte,1
+patch=1,EE,20574528,byte,1
+patch=1,EE,20574564,byte,1


### PR DESCRIPTION
Added some missing entries:
- Japanese version
- Korean version
- NTSC-U 1.01 version (same ID as 2.00 version, but different CRC

Added Black Edition, Burger King Challenge and Castrol Ford GT enablers for the new entries, and the already available ones