### PR TITLE
Create SLKA-25334_60EC6A5C.pnach

### DIFF
--- a/patches/SLKA-25334_60EC6A5C.pnach
+++ b/patches/SLKA-25334_60EC6A5C.pnach
@@ -1,0 +1,5 @@
+[Enable Burger King Challenge]
+description=Burger King Challenge and Castrol Ford GT always enabled
+author=Sal_89
+patch=1,EE,20574314,byte,1
+patch=1,EE,20574350,byte,1


### PR DESCRIPTION
Added some missing entries:
- Japanese version
- Korean version
- NTSC-U 1.01 version (same ID as 2.00 version, but different CRC

Added Black Edition, Burger King Challenge and Castrol Ford GT enablers for the new entries, and the already available ones