### PR TITLE
Add deinterlacing patch for Hot Shots Golf 3 (USA)(v2.00)

### DIFF
--- a/patches/SCUS-97130_9C8D0998.pnach
+++ b/patches/SCUS-97130_9C8D0998.pnach
@@ -1,0 +1,9 @@
+gametitle=Hot Shots Golf 3 (U)(v2.00)(SCUS-97130)
+
+[No Interlacing]
+author=Souzooka
+description=Removes interlacing artefacts (does not affect FMVs).
+gsinterlacemode=1
+
+// In-game/menus
+patch=0,EE,2010413C,extended,0 // daddiu v0,v0,0x8


### PR DESCRIPTION
Does what it says on the tin. There's a few FMVs (at boot and if you sit on the title screen for a bit) but I couldn't figure out how to remove interlacing artefacts in that mode.