### PR TITLE
Patches: SpongeBob Movie add spanish version + tidy up

### DIFF
--- a/patches/SLES-52895_536FEB77.pnach
+++ b/patches/SLES-52895_536FEB77.pnach
@@ -1,6 +1,10 @@
+gametitle=Spongebob Squarepants Movie Game (PAL) (SLES-52895)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
-description=Spongebob Squarepants Movie Game (PAL) (SLES-52895) Widescreen Hack (nemesis2000) (gamemasterplc)
+author=nemesis2000 & gamemasterplc
+description=Forces the game to run at 16:9 aspect ratio
+
 patch=1,EE,00437714,word,46010083 //Multiply Aspect
 patch=1,EE,00437718,word,E7A20028 //Store Multiplied Aspect
 patch=1,EE,0043771C,word,46010002 //Set Height

--- a/patches/SLES-52986_34DA05D2.pnach
+++ b/patches/SLES-52986_34DA05D2.pnach
@@ -1,0 +1,18 @@
+gametitle=Nickelodeon Bob Esponja - La Película (PAL-S) (SLES-52986)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=Bigdemon
+description=Widescreen Hack Conversion
+
+patch=1,EE,00437f74,word,46010083 //Multiply Aspect
+patch=1,EE,00437f78,word,E7A20028 //Store Multiplied Aspect
+patch=1,EE,00437f7c,word,46010002 //Set Height
+patch=1,EE,00437f80,word,0C0655BC //Jump to RWCameraSetView
+patch=1,EE,00437f84,word,E7A0002C //Store Height (Delay Slot)
+patch=1,EE,00437f88,word,DFBF0010 //Restore RA
+patch=1,EE,00437f8c,word,7BB00000 //Restore S0
+patch=1,EE,00437f90,word,03E00008 //Jump to RA
+patch=1,EE,00437f94,word,27BD0030 //Restore Stack (Delay Slot)
+
+


### PR DESCRIPTION
Changes:
- Add Widescreen patch to SpongeBob The Movie (Spanish version) to run the game at 16:9 Widescreen Aspect Ratio. It uses the same CRC as another regional version already included, but I tested it just in case.
- Tidy up.