### PR TITLE
Black: No blur while reloading weapons.

### DIFF
--- a/patches/SLES-53886_ADDFF505.pnach
+++ b/patches/SLES-53886_ADDFF505.pnach
@@ -25,3 +25,8 @@ patch=1,EE,00125128,word,2410003C //2410001E
 author=Gabominated
 description=Always display standard-480p video selector.
 patch=1,EE,003BE824,word,00000001
+
+[No Blur While Reload]
+author=Gabominated
+description=No blur while reloading weapons.
+patch=1,EE,005721D4,word,00000000

--- a/patches/SLES-54030_CAA04879.pnach
+++ b/patches/SLES-54030_CAA04879.pnach
@@ -25,3 +25,8 @@ patch=1,EE,001250a8,word,2410003c //2410001e
 author=Gabominated
 description=Always display standard-480p video selector.
 patch=1,EE,003BE7A4,word,00000001
+
+[No Blur While Reload]
+author=Gabominated
+description=No blur while reloading weapons.
+patch=1,EE,005719D4,word,00000000

--- a/patches/SLPM-66354_B3A9F9ED.pnach
+++ b/patches/SLPM-66354_B3A9F9ED.pnach
@@ -25,3 +25,8 @@ patch=1,EE,001251A0,word,2410003c //2410001e
 author=Gabominated
 description=Always display standard-480p video selector.
 patch=1,EE,003BE924,word,00000001
+
+[No Blur While Reload]
+author=Gabominated
+description=No blur while reloading weapons.
+patch=1,EE,005721D4,word,00000000

--- a/patches/SLUS-21376_5C891FF1.pnach
+++ b/patches/SLUS-21376_5C891FF1.pnach
@@ -25,3 +25,8 @@ patch=1,EE,00125078,word,2410003c //2410001e
 author=Gabominated
 description=Always display standard-480p video selector.
 patch=1,EE,003BE7A4,word,00000001
+
+[No Blur While Reload]
+author=Gabominated
+description=No blur while reloading weapons.
+patch=1,EE,005719D4,word,00000000


### PR DESCRIPTION
Patch for those looking to avoid blur when reloading weapons, patch tested and working without issues.

Regions:
**NTSC-U (Tested :heavy_check_mark:)
NTSC-J (Tested :heavy_check_mark:)
PAL-M (Tested :heavy_check_mark:)
PAL-E (Tested :heavy_check_mark:)**

<img width="796" height="448" alt="1" src="https://github.com/user-attachments/assets/90b1e294-09d8-42fe-94e8-bd18b476c516" />
<img width="796" height="448" alt="2" src="https://github.com/user-attachments/assets/05a19ac0-999b-4a19-81db-439fb7475358" />
<img width="796" height="448" alt="3" src="https://github.com/user-attachments/assets/d32c07ab-36b2-4b3a-a063-dc998ccb230a" />
<img width="796" height="448" alt="4" src="https://github.com/user-attachments/assets/96c6648e-970e-474d-af6f-9029eb60a54f" />
<img width="796" height="448" alt="5" src="https://github.com/user-attachments/assets/64eb7e29-dbc2-4368-9546-d4ffe312e83b" />
<img width="796" height="448" alt="6" src="https://github.com/user-attachments/assets/6868bb93-c21c-4ee1-b752-d8b606ba2fc6" />
<img width="796" height="448" alt="7" src="https://github.com/user-attachments/assets/9ae71774-9e78-48b5-bc44-52f0a6f9705d" />
<img width="796" height="448" alt="8" src="https://github.com/user-attachments/assets/3c6d1d6d-cd51-4381-86f0-590b8090b38f" />
<img width="796" height="448" alt="9" src="https://github.com/user-attachments/assets/120cd11c-5769-4217-b60c-b403366eb69d" />
<img width="796" height="448" alt="10" src="https://github.com/user-attachments/assets/a5ef0e31-29c2-486c-aa11-13e8fec74aad" />
<img width="796" height="448" alt="11" src="https://github.com/user-attachments/assets/1616140a-b64d-417a-a5ee-7658deee5a2b" />
<img width="796" height="448" alt="12" src="https://github.com/user-attachments/assets/e56545dd-26c2-4215-99a2-bf82a8fd8ad0" />
