### PR TITLE
Patches: Add SLUS-21490 and SLES-53753 60FPS

### DIFF
--- a/patches/SLES-53753_C2911A79.pnach
+++ b/patches/SLES-53753_C2911A79.pnach
@@ -1,0 +1,12 @@
+gametitle=Test Drive Unlimited (PAL-M) SLES-53753 C2911A79
+
+[50/60 FPS]
+author=PeterDelta & ijandric97
+description=Might need EE Overclock (130%).
+patch=1,EE,201B4DF8,extended,0806D3A1
+patch=1,EE,205E0000,extended,3C088889
+patch=1,EE,2038386C,extended,C4610000
+patch=1,EE,E0030000,extended,00AA5E80
+patch=1,EE,201B4DF8,extended,10400022
+patch=1,EE,205E0000,extended,00000000
+patch=1,EE,2038386C,extended,C4615880

--- a/patches/SLUS-21490_A4303F5A.pnach
+++ b/patches/SLUS-21490_A4303F5A.pnach
@@ -1,0 +1,12 @@
+gametitle=Test Drive Unlimited (NTSC-U) SLUS-21490 A4303F5A
+
+[60 FPS]
+author=PeterDelta & ijandric97
+description=Might need EE Overclock (130%).
+patch=1,EE,201B4DF8,extended,0806D3A1
+patch=1,EE,205E0000,extended,3C088889
+patch=1,EE,2038386C,extended,C4610000
+patch=1,EE,E0030000,extended,00AA5E80
+patch=1,EE,201B4DF8,extended,10400022
+patch=1,EE,205E0000,extended,00000000
+patch=1,EE,2038386C,extended,C4615880


### PR DESCRIPTION
Added Test Drive Unlimited (NTSC-U) SLUS-21490 60FPS patch (ported from the PAL version).
Retained original PAL-M SLES-53753 50/60FPS patch by PeterDelta & ijandric97.
I've tested both patches and confirmed they're working fine.

Source: https://github.com/PeterDelta/PCSX2/tree/main/patches