### PR TITLE
Added WS fixes for other versions

### DIFF
--- a/patches/SCUS-97264_062BC79E.pnach
+++ b/patches/SCUS-97264_062BC79E.pnach
@@ -1,0 +1,17 @@
+gametitle=SFOS Prototype Review Code Mar 6 2004 (NTSC-U) (SCUS-97264) 062BC79E
+
+[Widescreen 16:9]
+author=YukiXXL
+gsaspectratio=16:9
+
+//Gameplay fix
+patch=1,EE,00397C10,extended,3C043F40
+patch=1,EE,20397C14,extended,44841800
+patch=1,EE,20397C18,extended,46030003
+patch=1,EE,20397C1C,extended,460318C3
+patch=1,EE,20397C20,extended,46031840
+patch=1,EE,20397C94,extended,E603007C
+
+//FMVs fix
+patch=1,EE,1041AF1C,extended,24127600
+patch=1,EE,1041AF24,extended,24101400

--- a/patches/SCUS-97264_BFCE8450.pnach
+++ b/patches/SCUS-97264_BFCE8450.pnach
@@ -1,0 +1,17 @@
+gametitle=Syphon Filter: The Omega Strain November Demo (NTSC-U) (SCUS-97264) BFCE8450
+
+[Widescreen 16:9]
+author=YukiXXL
+gsaspectratio=16:9
+
+//Gameplay fix
+patch=1,EE,003569D0,extended,3C043F40
+patch=1,EE,203569D4,extended,44841800
+patch=1,EE,203569D8,extended,46030003
+patch=1,EE,203569DC,extended,460318C3
+patch=1,EE,203569E0,extended,46031840
+patch=1,EE,20356A54,extended,E603007C
+
+//FMVs fix
+patch=1,EE,103D5BFC,extended,24127600
+patch=1,EE,103D5C04,extended,24101400

--- a/patches/SCUS-97313_2FFA7E6F.pnach
+++ b/patches/SCUS-97313_2FFA7E6F.pnach
@@ -1,0 +1,20 @@
+gametitle=Syphon Filter: The Omega Strain Jampack Demo (NTSC-U) (SCUS-97313) 2FFA7E6F
+
+[Widescreen 16:9 (Gameplay+HUD) (720p)]
+author=YukiXXL
+description=Uses "kDefaultScreenRess"(1280x720)+custom scale fix.
+gsaspectratio=16:9
+patch=1,EE,20117D54,extended,C4C10004
+patch=1,EE,20117D58,extended,C4C20000
+patch=1,EE,0010CDB4,extended,3C024040 //HUD Scale
+
+[Widescreen 16:9 (Gameplay Only)]
+author=YukiXXL
+gsaspectratio=16:9
+patch=1,EE,0010CEAC,extended,3C033F40
+patch=1,EE,2010CEB0,extended,44831800
+patch=1,EE,2010CEB4,extended,46030003
+patch=1,EE,2010CEB8,extended,460318C3
+patch=1,EE,2010CEE0,extended,46031840
+patch=1,EE,2010CEE4,extended,0200202D
+patch=1,EE,2010CF2C,extended,E603007C

--- a/patches/SCUS-97397_C909A32E.pnach
+++ b/patches/SCUS-97397_C909A32E.pnach
@@ -1,0 +1,13 @@
+gametitle=Syphon Filter: The Omega Strain Public Beta 1 (NTSC-U) (SCUS-97397) BFCE8450
+
+[Widescreen 16:9]
+author=YukiXXL
+gsaspectratio=16:9
+
+//Gameplay fix
+patch=1,EE,00369510,extended,3C043F40
+patch=1,EE,20369514,extended,44841800
+patch=1,EE,20369518,extended,46030003
+patch=1,EE,2036951C,extended,460318C3
+patch=1,EE,20369520,extended,46031840
+patch=1,EE,20369594,extended,E603007C

--- a/patches/TCES-52033_0DDA2728.pnach
+++ b/patches/TCES-52033_0DDA2728.pnach
@@ -1,0 +1,13 @@
+gametitle=Syphon Filter: The Omega Strain Beta Trial Code (PAL-E) (TCES-52033) 0DDA2728
+
+[Widescreen 16:9]
+author=YukiXXL
+gsaspectratio=16:9
+
+//Gameplay fix
+patch=1,EE,003907D0,extended,3C043F40
+patch=1,EE,203907D4,extended,44841800
+patch=1,EE,203907D8,extended,46030003
+patch=1,EE,203907DC,extended,460318C3
+patch=1,EE,203907E0,extended,46031840
+patch=1,EE,20390854,extended,E603007C


### PR DESCRIPTION
Added WS fixes for these versions of the "Syphon Filter: The Omega Strain" game:
Public Beta 1.0
Beta Trial Code
November Demo
Jampack Demo
Review Prototype
