### PR TITLE
Test Drive Unlimited: Trigger controls mapping

### DIFF
--- a/patches/SLES-50731_1D2818AF.pnach
+++ b/patches/SLES-50731_1D2818AF.pnach
@@ -23,7 +23,7 @@ patch=0,EE,2032F298,extended,72723C2E
 patch=0,EE,2016F908,extended,0000102D
 patch=0,EE,201EEC0C,extended,0000102D
 
-[Trigger control mapppings]
+[Trigger control mappings]
 author=Silent
 description=Adds extra controller setups, mirroring the scrapped prototype trigger-based setup, two Underground-like setups, and an Xbox HP2-like setup.
 

--- a/patches/SLES-53753_C2911A79.pnach
+++ b/patches/SLES-53753_C2911A79.pnach
@@ -11,7 +11,7 @@ patch=1,EE,201B4DF8,extended,10400022
 patch=1,EE,205E0000,extended,00000000
 patch=1,EE,2038386C,extended,C4615880
 
-[Trigger controls mappping]
+[Trigger controls mapping]
 description=Throttle/brake mapped to triggers
 author=Silent
 

--- a/patches/SLES-54466_C2911A79.pnach
+++ b/patches/SLES-54466_C2911A79.pnach
@@ -11,7 +11,7 @@ patch=1,EE,201B4DF8,extended,10400022
 patch=1,EE,205E0000,extended,00000000
 patch=1,EE,2038386C,extended,C4615880
 
-[Trigger controls mappping]
+[Trigger controls mapping]
 description=Throttle/brake mapped to triggers
 author=Silent
 

--- a/patches/SLUS-20362_1D2818AF.pnach
+++ b/patches/SLUS-20362_1D2818AF.pnach
@@ -22,7 +22,7 @@ author=asasega
 description=Patches the game to run at 60 FPS (EE Overclock should be set to 130%. Higher values are usable but may cause hanging).
 patch=1,EE,20113E2C,extended,2C420001
 
-[Trigger control mapppings]
+[Trigger control mappings]
 author=Silent
 description=Adds extra controller setups, mirroring the scrapped prototype trigger-based setup, two Underground-like setups, and an Xbox HP2-like setup.
 

--- a/patches/SLUS-21490_A4303F5A.pnach
+++ b/patches/SLUS-21490_A4303F5A.pnach
@@ -11,7 +11,7 @@ patch=1,EE,201B4DF8,extended,10400022
 patch=1,EE,205E0000,extended,00000000
 patch=1,EE,2038386C,extended,C4615880
 
-[Trigger controls mappping]
+[Trigger controls mapping]
 description=Throttle/brake mapped to triggers
 author=Silent
 


### PR DESCRIPTION
A cheat code re-enabling a previously unused control mapping in Test Drive Unlimited, and swapping L1/R1 buttons for L2/R2 triggers. With this change, this mapping matches “modern” controls of the X360 and PC versions of Test Drive Unlimited.

Also added support for `SLES-54466`, as it has the same executable as `SLES-53753`, just a different serial.