### PR TITLE
Fatal Zero hack disabling

### DIFF
--- a/patches/SCPS-56008_BCF04BF3.pnach
+++ b/patches/SCPS-56008_BCF04BF3.pnach
@@ -13,7 +13,9 @@ patch=1,EE,001856D4,word,3C013F40 // 3C013F80
 
 // Cut-scene Render fix
 // 0045013c 00208144 280040e6
-patch=1,EE,001856c8,word,3c0145C0 // 3c014500
+//patch=1,EE,001856c8,word,3c0145C0 // 3c014500
+// Appears not to be needed on later builds.
+// It also wracks up the mirror rendering in the Cutscenes.
 
 // FMV fix by nemesis2000
 patch=1,EE,001822B8,word,24027100

--- a/patches/SLPS-25074_9883194E.pnach
+++ b/patches/SLPS-25074_9883194E.pnach
@@ -13,7 +13,9 @@ patch=1,EE,001828ec,word,3C013F40 // 3C013F80
 
 // Cut-scene Render fix
 // 0045013c 00208144 280040e6
-patch=1,EE,001828e0,word,3c0145C0 // 3c014500
+//patch=1,EE,001828e0,word,3c0145C0 // 3c014500
+// Appears not to be needed on later builds.
+// It also wracks up the mirror rendering in the Cutscenes.
 
 // FMV fix
 patch=1,EE,0017f520,word,24027100


### PR DESCRIPTION
Disables the Cutscene Render fix for the NTSC-J & NTSC-K versions of the disc.
The NTSC-U disc does not have this hack.

With the PAL disc, this hack wracks some rendering of the game.
After testing, it turned out that the hack wasn't needed anymore anyway,
 and was thus disabled. See more here: #591.

It's resonable to assume that the hack causes the same wracking
 with the NTSC-J & NTSC-K discs and isn't needed anymore anyway
 (as with the PAL disc), however testing is appreciated.
