### PR TITLE
Ultimate Spider-Man update

### DIFF
--- a/patches/SLES-53390_FDD12792.pnach
+++ b/patches/SLES-53390_FDD12792.pnach
@@ -1,23 +1,25 @@
 gametitle=Ultimate Spider-Man (PAL-E) SLES-53390 FDD12792
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=Arapapa & PeterDelta
-description=Renders the game in 16:9 aspect ratio
-patch=0,EE,0058B210,word,08030000
-patch=0,EE,000C0000,word,3C030074
-patch=0,EE,000C0004,word,3C013FAA
-patch=0,EE,000C0008,word,3421AAAB
-patch=0,EE,000C000C,word,4481F000
-patch=0,EE,000C0010,word,461E18C2
-patch=0,EE,000C0014,word,08162C85
-patch=0,EE,002EF740,word,3C013FB0
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=Arapapa & PeterDelta
+//description=Renders the game in 16:9 aspect ratio
+//patch=0,EE,0058B210,word,08030000
+//patch=0,EE,000C0000,word,3C030074
+//patch=0,EE,000C0004,word,3C013FAA
+//patch=0,EE,000C0008,word,3421AAAB
+//patch=0,EE,000C000C,word,4481F000
+//patch=0,EE,000C0010,word,461E18C2
+//patch=0,EE,000C0014,word,08162C85
+//patch=0,EE,002EF740,word,3C013FB0
+//Causes problems with some textures and movement when swaying.
+//One of those problems: https://github.com/PCSX2/pcsx2/issues/13679
 
 [50 FPS]
 author=PeterDelta & asasega
 description=Might need EE Overclock (130%).
 patch=1,EE,20311F18,extended,4501FFE5
 patch=1,EE,2069FE20,extended,00000002
-patch=1,EE,E002F880,extended,007EF6E4
+patch=1,EE,E0020000,extended,0066CA94
 patch=1,EE,20311F18,extended,00000000
 patch=1,EE,2069FE20,extended,00000001

--- a/patches/SLES-53391_FDD12792.pnach
+++ b/patches/SLES-53391_FDD12792.pnach
@@ -1,23 +1,25 @@
 gametitle=Ultimate Spider-Man (PAL-M) SLES-53391 FDD12792
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=Arapapa & PeterDelta
-description=Renders the game in 16:9 aspect ratio
-patch=0,EE,0058B210,word,08030000
-patch=0,EE,000C0000,word,3C030074
-patch=0,EE,000C0004,word,3C013FAA
-patch=0,EE,000C0008,word,3421AAAB
-patch=0,EE,000C000C,word,4481F000
-patch=0,EE,000C0010,word,461E18C2
-patch=0,EE,000C0014,word,08162C85
-patch=0,EE,002EF740,word,3C013FB0
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=Arapapa & PeterDelta
+//description=Renders the game in 16:9 aspect ratio
+//patch=0,EE,0058B210,word,08030000
+//patch=0,EE,000C0000,word,3C030074
+//patch=0,EE,000C0004,word,3C013FAA
+//patch=0,EE,000C0008,word,3421AAAB
+//patch=0,EE,000C000C,word,4481F000
+//patch=0,EE,000C0010,word,461E18C2
+//patch=0,EE,000C0014,word,08162C85
+//patch=0,EE,002EF740,word,3C013FB0
+//Causes problems with some textures and movement when swaying.
+//One of those problems: https://github.com/PCSX2/pcsx2/issues/13679
 
 [50 FPS]
 author=PeterDelta & asasega
 description=Might need EE Overclock (130%).
 patch=1,EE,20311F18,extended,4501FFE5
 patch=1,EE,2069FE20,extended,00000002
-patch=1,EE,E002F880,extended,007EF6E4
+patch=1,EE,E0020000,extended,0066CA94
 patch=1,EE,20311F18,extended,00000000
 patch=1,EE,2069FE20,extended,00000001

--- a/patches/SLUS-20870_FDD12792.pnach
+++ b/patches/SLUS-20870_FDD12792.pnach
@@ -1,26 +1,25 @@
 gametitle=Ultimate Spider-Man (NTSC-U) SLUS-20870 FDD12792
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=Arapapa & PeterDelta
-description=Renders the game in 16:9 aspect ratio
-patch=0,EE,0058B210,word,08030000
-patch=0,EE,000C0000,word,3C030074
-patch=0,EE,000C0004,word,3C013FAA
-patch=0,EE,000C0008,word,3421AAAB
-patch=0,EE,000C000C,word,4481F000
-patch=0,EE,000C0010,word,461E18C2
-patch=0,EE,000C0014,word,08162C85
-patch=0,EE,002EF740,word,3C013FB0
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=Arapapa & PeterDelta
+//description=Renders the game in 16:9 aspect ratio
+//patch=0,EE,0058B210,word,08030000
+//patch=0,EE,000C0000,word,3C030074
+//patch=0,EE,000C0004,word,3C013FAA
+//patch=0,EE,000C0008,word,3421AAAB
+//patch=0,EE,000C000C,word,4481F000
+//patch=0,EE,000C0010,word,461E18C2
+//patch=0,EE,000C0014,word,08162C85
+//patch=0,EE,002EF740,word,3C013FB0
+//Causes problems with some textures and movement when swaying.
+//One of those problems: https://github.com/PCSX2/pcsx2/issues/13679
 
-
-
-//causes issues see https://github.com/PCSX2/pcsx2/issues/13679
-//[60 FPS]
-//author=PeterDelta & asasega
-//description=Might need EE Overclock (130%).
-//patch=1,EE,20311F18,extended,4501FFE5
-//patch=1,EE,2069FE20,extended,00000002
-//patch=1,EE,E002F880,extended,007EF6E4
-//patch=1,EE,20311F18,extended,00000000
-//patch=1,EE,2069FE20,extended,00000001
+[60 FPS]
+author=PeterDelta & asasega
+description=Might need EE Overclock (130%).
+patch=1,EE,20311F18,extended,4501FFE5
+patch=1,EE,2069FE20,extended,00000002
+patch=1,EE,E0020000,extended,0066CA94
+patch=1,EE,20311F18,extended,00000000
+patch=1,EE,2069FE20,extended,00000001

--- a/patches/SLUS-21285_FDD12792.pnach
+++ b/patches/SLUS-21285_FDD12792.pnach
@@ -1,23 +1,25 @@
 gametitle=Ultimate Spider-Man [Limited Edition] (NTSC-U) SLUS-21285 FDD12792
 
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=Arapapa & PeterDelta
-description=Renders the game in 16:9 aspect ratio
-patch=0,EE,0058B210,word,08030000
-patch=0,EE,000C0000,word,3C030074
-patch=0,EE,000C0004,word,3C013FAA
-patch=0,EE,000C0008,word,3421AAAB
-patch=0,EE,000C000C,word,4481F000
-patch=0,EE,000C0010,word,461E18C2
-patch=0,EE,000C0014,word,08162C85
-patch=0,EE,002EF740,word,3C013FB0
+//[Widescreen 16:9]
+//gsaspectratio=16:9
+//author=Arapapa & PeterDelta
+//description=Renders the game in 16:9 aspect ratio
+//patch=0,EE,0058B210,word,08030000
+//patch=0,EE,000C0000,word,3C030074
+//patch=0,EE,000C0004,word,3C013FAA
+//patch=0,EE,000C0008,word,3421AAAB
+//patch=0,EE,000C000C,word,4481F000
+//patch=0,EE,000C0010,word,461E18C2
+//patch=0,EE,000C0014,word,08162C85
+//patch=0,EE,002EF740,word,3C013FB0
+//Causes problems with some textures and movement when swaying.
+//One of those problems: https://github.com/PCSX2/pcsx2/issues/13679
 
 [60 FPS]
 author=PeterDelta & asasega
 description=Might need EE Overclock (130%).
 patch=1,EE,20311F18,extended,4501FFE5
 patch=1,EE,2069FE20,extended,00000002
-patch=1,EE,E002F880,extended,007EF6E4
+patch=1,EE,E0020000,extended,0066CA94
 patch=1,EE,20311F18,extended,00000000
 patch=1,EE,2069FE20,extended,00000001


### PR DESCRIPTION
In this issue: https://github.com/PCSX2/pcsx2/issues/13679 
It's been reported that there's a problem with the FPS patch, but my research suggests the patch works perfectly (I only fixed the conditional for sync in FMV).
The problem is caused by widescreen, which definitely needs to be disabled since no better solution has been found.

The video shows that the car looks good and you can have a good time with this FPS patch enabled and without the widescreen patch.

https://github.com/user-attachments/assets/f4955a5a-7f8a-46ea-89ae-7b39fcef52c2

