### PR TITLE
Update and at to SLUS-20565_90E66BC5.pnach "Champions of Norrath"

### DIFF
--- a/patches/SLUS-20565_90E66BC5.pnach
+++ b/patches/SLUS-20565_90E66BC5.pnach
@@ -33,17 +33,6 @@ patch=1,EE,20480568,extended,C296C8B4 // C22DC8B4 - Player2 X
 patch=1,EE,101AD7A8,extended,0000C452 // 0000C3F7 - Pedstal2 X
 
 [No-Interlacing]
-gsinterlacemode=1
-author=Agrippa
-description=EE overclock is needed to avoid infrequent frame rate drops.
-patch=1,EE,204843E0,extended,00000000
-patch=1,EE,204843E4,extended,00000001
-patch=1,EE,20484474,extended,00000001
-patch=1,EE,20190AE4,extended,10000010
-patch=1,EE,20190B48,extended,10000005
-patch=1,EE,201913D8,extended,24020001
-
-[No-Interlacing 2]
 author=Switz0018
 description=Removes interlacing. Does not Require EE overclock.
 patch=1,EE,001912CC,extended,0000102D // Don't load the vblankField byte.


### PR DESCRIPTION
Added revised widescreen patch from the forum. This includes 16:9 Inventory Fix as well, this fix can be ported to the old widescreen if there is demand. Added new No-Interlacing patch that does not require EE overclock.