### PR TITLE
Juiced: Xbox Controls Layout

### DIFF
--- a/patches/SLES-53044_D7E2EF61.pnach
+++ b/patches/SLES-53044_D7E2EF61.pnach
@@ -1,0 +1,42 @@
+gametitle=Juiced (E) (SLES-53044)
+
+[Xbox Controls Layout]
+description=Enables the full Xbox controls layout, including menus. Menu button legends will not always match reality.
+author=Silent
+
+patch=0,EE,004840E0,bytes,5F78626F782E747874 // controls_xbox.txt
+patch=0,EE,004A4938,bytes,4241434B00 // GAMEPAD_BACK
+patch=0,EE,004A4A10,bytes,4100 // GAMEPAD_A
+patch=0,EE,004A4A20,bytes,5900 // GAMEPAD_Y
+patch=0,EE,004A4A38,bytes,5800 // GAMEPAD_X
+patch=0,EE,004A4A48,bytes,4200 // GAMEPAD_B
+patch=0,EE,004A49A0,bytes,574849544500 // GAMEPAD_WHITE
+patch=0,EE,004A49B0,bytes,424C41434B00 // GAMEPAD_BLACK
+patch=0,EE,004A49C0,bytes,4C4546545F5452494747455200 // GAMEPAD_LEFT_TRIGGER
+
+// GAMEPAD_RIGHT_TRIGGER needs to be relocated
+patch=0,EE,004A4DD0,bytes,47414D455041445F52494748545F5452494747455200 // GAMEPAD_RIGHT_TRIGGER
+patch=0,EE,10346128,extended,4DD0
+
+// Make GAMEPAD_*_TRIGGER analogue
+patch=0,EE,1034582C,extended,4A30
+patch=0,EE,10345840,extended,4A40
+
+patch=0,EE,103458B8,extended,49B8
+patch=0,EE,103458CC,extended,4DD0
+patch=0,EE,10345910,extended,49B8
+patch=0,EE,10345924,extended,4DD0
+
+patch=0,EE,1034733C,extended,49B8
+patch=0,EE,10347380,extended,0131
+patch=0,EE,1034738C,extended,4DD0
+patch=0,EE,103473D0,extended,0133
+
+patch=0,EE,20346244,extended,00000000
+
+// Make gamepad analog inputs truly analog, like on Xbox (x / 255.0)
+patch=0,EE,20347BC8,extended,3C013B80 // lui at,0x3B80
+patch=0,EE,20347BCC,extended,34218081 // ori at,at,0x8081
+patch=0,EE,20347BD0,extended,44810000 // mtc1 at,f00
+patch=0,EE,20347BE4,extended,10000022 // b 0x00347C70
+patch=0,EE,20347BE8,extended,46010002 // mul.s f00,f00,f01

--- a/patches/SLES-53151_308582DE.pnach
+++ b/patches/SLES-53151_308582DE.pnach
@@ -1,0 +1,42 @@
+gametitle=Juiced (I) (SLES-53151)
+
+[Xbox Controls Layout]
+description=Enables the full Xbox controls layout, including menus. Menu button legends will not always match reality.
+author=Silent
+
+patch=0,EE,004840E0,bytes,5F78626F782E747874 // controls_xbox.txt
+patch=0,EE,004A4938,bytes,4241434B00 // GAMEPAD_BACK
+patch=0,EE,004A4A10,bytes,4100 // GAMEPAD_A
+patch=0,EE,004A4A20,bytes,5900 // GAMEPAD_Y
+patch=0,EE,004A4A38,bytes,5800 // GAMEPAD_X
+patch=0,EE,004A4A48,bytes,4200 // GAMEPAD_B
+patch=0,EE,004A49A0,bytes,574849544500 // GAMEPAD_WHITE
+patch=0,EE,004A49B0,bytes,424C41434B00 // GAMEPAD_BLACK
+patch=0,EE,004A49C0,bytes,4C4546545F5452494747455200 // GAMEPAD_LEFT_TRIGGER
+
+// GAMEPAD_RIGHT_TRIGGER needs to be relocated
+patch=0,EE,004A4DD0,bytes,47414D455041445F52494748545F5452494747455200 // GAMEPAD_RIGHT_TRIGGER
+patch=0,EE,10346128,extended,4DD0
+
+// Make GAMEPAD_*_TRIGGER analogue
+patch=0,EE,1034582C,extended,4A30
+patch=0,EE,10345840,extended,4A40
+
+patch=0,EE,103458B8,extended,49B8
+patch=0,EE,103458CC,extended,4DD0
+patch=0,EE,10345910,extended,49B8
+patch=0,EE,10345924,extended,4DD0
+
+patch=0,EE,1034733C,extended,49B8
+patch=0,EE,10347380,extended,0131
+patch=0,EE,1034738C,extended,4DD0
+patch=0,EE,103473D0,extended,0133
+
+patch=0,EE,20346244,extended,00000000
+
+// Make gamepad analog inputs truly analog, like on Xbox (x / 255.0)
+patch=0,EE,20347BC8,extended,3C013B80 // lui at,0x3B80
+patch=0,EE,20347BCC,extended,34218081 // ori at,at,0x8081
+patch=0,EE,20347BD0,extended,44810000 // mtc1 at,f00
+patch=0,EE,20347BE4,extended,10000022 // b 0x00347C70
+patch=0,EE,20347BE8,extended,46010002 // mul.s f00,f00,f01

--- a/patches/SLKA-25283_D556AE22.pnach
+++ b/patches/SLKA-25283_D556AE22.pnach
@@ -1,0 +1,42 @@
+gametitle=Juiced (K) (SLKA-25283)
+
+[Xbox Controls Layout]
+description=Enables the full Xbox controls layout, including menus. Menu button legends will not always match reality.
+author=Silent
+
+patch=0,EE,00483AE0,bytes,5F78626F782E747874 // controls_xbox.txt
+patch=0,EE,004A42C8,bytes,4241434B00 // GAMEPAD_BACK
+patch=0,EE,004A43A0,bytes,4100 // GAMEPAD_A
+patch=0,EE,004A43B0,bytes,5900 // GAMEPAD_Y
+patch=0,EE,004A43C8,bytes,5800 // GAMEPAD_X
+patch=0,EE,004A43D8,bytes,4200 // GAMEPAD_B
+patch=0,EE,004A4330,bytes,574849544500 // GAMEPAD_WHITE
+patch=0,EE,004A4340,bytes,424C41434B00 // GAMEPAD_BLACK
+patch=0,EE,004A4350,bytes,4C4546545F5452494747455200 // GAMEPAD_LEFT_TRIGGER
+
+// GAMEPAD_RIGHT_TRIGGER needs to be relocated
+patch=0,EE,004A4760,bytes,47414D455041445F52494748545F5452494747455200 // GAMEPAD_RIGHT_TRIGGER
+patch=0,EE,10345F28,extended,4760
+
+// Make GAMEPAD_*_TRIGGER analogue
+patch=0,EE,1034562C,extended,43C0
+patch=0,EE,10345640,extended,43D0
+
+patch=0,EE,103456B8,extended,4348
+patch=0,EE,103456CC,extended,4760
+patch=0,EE,10345710,extended,4348
+patch=0,EE,10345724,extended,4760
+
+patch=0,EE,1034713C,extended,4348
+patch=0,EE,10347180,extended,0131
+patch=0,EE,1034718C,extended,4760
+patch=0,EE,103471D0,extended,0133
+
+patch=0,EE,20346044,extended,00000000
+
+// Make gamepad analog inputs truly analog, like on Xbox (x / 255.0)
+patch=0,EE,203479C8,extended,3C013B80 // lui at,0x3B80
+patch=0,EE,203479CC,extended,34218081 // ori at,at,0x8081
+patch=0,EE,203479D0,extended,44810000 // mtc1 at,f00
+patch=0,EE,203479E4,extended,10000022 // b 0x00347A70
+patch=0,EE,203479E8,extended,46010002 // mul.s f00,f00,f01

--- a/patches/SLPM-66277_531B7E2E.pnach
+++ b/patches/SLPM-66277_531B7E2E.pnach
@@ -1,0 +1,42 @@
+gametitle=Juiced - Tuned Car Densetsu (J) (SLPM-66277)
+
+[Xbox Controls Layout]
+description=Enables the full Xbox controls layout, including menus. Menu button legends will not always match reality.
+author=Silent
+
+patch=0,EE,004559F0,bytes,5F78626F782E747874 // controls_xbox.txt
+patch=0,EE,00475E78,bytes,4241434B00 // GAMEPAD_BACK
+patch=0,EE,00475F50,bytes,4100 // GAMEPAD_A
+patch=0,EE,00475F60,bytes,5900 // GAMEPAD_Y
+patch=0,EE,00475F78,bytes,5800 // GAMEPAD_X
+patch=0,EE,00475F88,bytes,4200 // GAMEPAD_B
+patch=0,EE,00475EE0,bytes,574849544500 // GAMEPAD_WHITE
+patch=0,EE,00475EF0,bytes,424C41434B00 // GAMEPAD_BLACK
+patch=0,EE,00475F00,bytes,4C4546545F5452494747455200 // GAMEPAD_LEFT_TRIGGER
+
+// GAMEPAD_RIGHT_TRIGGER needs to be relocated
+patch=0,EE,00476310,bytes,47414D455041445F52494748545F5452494747455200 // GAMEPAD_RIGHT_TRIGGER
+patch=0,EE,10340E08,extended,6310
+
+// Make GAMEPAD_*_TRIGGER analogue
+patch=0,EE,1034050C,extended,5F70
+patch=0,EE,10340520,extended,5F80
+
+patch=0,EE,10340598,extended,5EF8
+patch=0,EE,103405AC,extended,6310
+patch=0,EE,103405F0,extended,5EF8
+patch=0,EE,10340604,extended,6310
+
+patch=0,EE,1034201C,extended,5EF8
+patch=0,EE,10342060,extended,0131
+patch=0,EE,1034206C,extended,6310
+patch=0,EE,103420B0,extended,0133
+
+patch=0,EE,10340F24,extended,00000000
+
+// Make gamepad analog inputs truly analog, like on Xbox (x / 255.0)
+patch=0,EE,203428A8,extended,3C013B80 // lui at,0x3B80
+patch=0,EE,203428AC,extended,34218081 // ori at,at,0x8081
+patch=0,EE,203428B0,extended,44810000 // mtc1 at,f00
+patch=0,EE,203428C4,extended,10000022 // b 0x00342950
+patch=0,EE,203428C8,extended,46010002 // mul.s f00,f00,f01

--- a/patches/SLUS-20872_C186ACA9.pnach
+++ b/patches/SLUS-20872_C186ACA9.pnach
@@ -1,0 +1,42 @@
+gametitle=Juiced (U) (SLUS-20872)
+
+[Xbox Controls Layout]
+description=Enables the full Xbox controls layout, including menus. Menu button legends will not always match reality.
+author=Silent
+
+patch=0,EE,00483AE0,bytes,5F78626F782E747874 // controls_xbox.txt
+patch=0,EE,004A42D8,bytes,4241434B00 // GAMEPAD_BACK
+patch=0,EE,004A43B0,bytes,4100 // GAMEPAD_A
+patch=0,EE,004A43C0,bytes,5900 // GAMEPAD_Y
+patch=0,EE,004A43D8,bytes,5800 // GAMEPAD_X
+patch=0,EE,004A43E8,bytes,4200 // GAMEPAD_B
+patch=0,EE,004A4340,bytes,574849544500 // GAMEPAD_WHITE
+patch=0,EE,004A4350,bytes,424C41434B00 // GAMEPAD_BLACK
+patch=0,EE,004A4360,bytes,4C4546545F5452494747455200 // GAMEPAD_LEFT_TRIGGER
+
+// GAMEPAD_RIGHT_TRIGGER needs to be relocated
+patch=0,EE,004A4770,bytes,47414D455041445F52494748545F5452494747455200 // GAMEPAD_RIGHT_TRIGGER
+patch=0,EE,10345F08,extended,4770
+
+// Make GAMEPAD_*_TRIGGER analogue
+patch=0,EE,1034560C,extended,43D0
+patch=0,EE,10345620,extended,43E0
+
+patch=0,EE,10345698,extended,4358
+patch=0,EE,103456AC,extended,4770
+patch=0,EE,103456F0,extended,4358
+patch=0,EE,10345704,extended,4770
+
+patch=0,EE,1034711C,extended,4358
+patch=0,EE,10347160,extended,0131
+patch=0,EE,1034716C,extended,4770
+patch=0,EE,103471B0,extended,0133
+
+patch=0,EE,20346024,extended,00000000
+
+// Make gamepad analog inputs truly analog, like on Xbox (x / 255.0)
+patch=0,EE,203479A8,extended,3C013B80 // lui at,0x3B80
+patch=0,EE,203479AC,extended,34218081 // ori at,at,0x8081
+patch=0,EE,203479B0,extended,44810000 // mtc1 at,f00
+patch=0,EE,203479C4,extended,10000022 // b 0x00347A50
+patch=0,EE,203479C8,extended,46010002 // mul.s f00,f00,f01


### PR DESCRIPTION
This patch enables the Xbox control layouts in all versions of Juiced. Useful for having "modern" controls with throttle/brake on triggers.