### PR TITLE
Fix SCES-50760_5C991F4E.pnach "60 fps & No interlacing" patch

### DIFF
--- a/patches/SCES-50760_5C991F4E.pnach
+++ b/patches/SCES-50760_5C991F4E.pnach
@@ -65,9 +65,9 @@ description=Might need EE overclocking to be stable.
 // 60 fps
 patch=1,EE,0028F4C4,word,00000001
 
-// Revert to 30 fps during Cutscenes
-//patch=1,EE,e0010001,extended,0063AA08
-//patch=1,EE,2028F4C4,extended,00000002
+// Revert to 30 fps during Cutscenes (cutscenes break when played at 60 fps)
+patch=1,EE,e0010001,extended,0063AA08
+patch=1,EE,2028F4C4,extended,00000002
 
 // No Interlacing (needed for 60 fps)
 patch=1,EE,0013CAD0,word,30420000


### PR DESCRIPTION
Restores the original 30 fps cutscene revert logic from Red-tv's implementation.

The bundled patch had the cutscene revert lines commented out, causing in-game cutscenes to run at 60 fps, which breaks animation timing and audio sync. This also resulted in visible interlacing artifacts, as the no-interlacing hack was not applied correctly after game boot.

Re-enabling the original cutscene revert restores the intended behavior:
- Gameplay runs at 60 FPS
- Cutscenes correctly revert to 30 FPS
- No-interlacing hack works as expected

Fixes #652