### PR TITLE
Correct WS patches for Armored Core 2 and the sequel

### DIFF
--- a/patches/SLES-50079_D9B48C4A.pnach
+++ b/patches/SLES-50079_D9B48C4A.pnach
@@ -2,13 +2,15 @@ gametitle=Armored Core 2 (PAL-E) (SLES-50079)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=ElHecht
+author=ElHecht, Berylskid
 
 // 16:9
-patch=1,EE,0028b02c,word,3c013f40 // 00000000 hor fov gameplay
+patch=1,EE,0028b02c,word,3c013f4d // 00000000 hor fov gameplay
+patch=1,EE,0028b030,word,3421b6dc
 patch=1,EE,0028b038,word,44810000 // 00000000
 patch=1,EE,0028b03c,word,4600c602 // 00000000
-patch=1,EE,001b3f2c,word,3c013f40 // 00000000 hor fov menu
+patch=1,EE,001b3f2c,word,3c013f4d // 00000000 hor fov menu
+patch=1,EE,001b3f30,word,3421b6dc
 patch=1,EE,001b3f3c,word,4481f000 // 00000000
 patch=1,EE,001b3f40,word,461e6b42 // 00000000
 

--- a/patches/SLES-50905_63F88A8F.pnach
+++ b/patches/SLES-50905_63F88A8F.pnach
@@ -2,13 +2,15 @@ gametitle=Armored Core 2 - Another Age (PAL-E) (SLES-50905)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=ElHecht
+author=ElHecht, Berylskid
 
 // 16:9
-patch=1,EE,002d7494,word,3c013f40 // 00000000 hor fov gameplay
+patch=1,EE,002d7494,word,3c013f4d // 00000000 hor fov gameplay
+patch=1,EE,002d7498,word,3421b6dc
 patch=1,EE,002d74a0,word,44810000 // 00000000
 patch=1,EE,002d74a4,word,4600c602 // 00000000
-patch=1,EE,001c9570,word,3c013f40 // 00000000 hor fov menu
+patch=1,EE,001c9570,word,3c013f4d // 00000000 hor fov menu
+patch=1,EE,001c9574,word,3421b6dc
 patch=1,EE,001c9588,word,4481f000 // 00000000
 patch=1,EE,001c958c,word,461e6b42 // 00000000
 

--- a/patches/SLPS-25007_F3F906DE.pnach
+++ b/patches/SLPS-25007_F3F906DE.pnach
@@ -5,10 +5,12 @@ gsaspectratio=16:9
 author=ElHecht
 
 // 16:9
-patch=1,EE,002885ec,word,3c013f40 // 00000000 hor fov gameplay
+patch=1,EE,002885ec,word,3c013f4d // 00000000 hor fov gameplay
+patch=1,EE,002885f0,word,3421b6dc
 patch=1,EE,002885f8,word,44810000 // 00000000
 patch=1,EE,002885fc,word,4600c602 // 00000000
-patch=1,EE,001b252c,word,3c013f40 // 00000000 hor fov menu
+patch=1,EE,001b252c,word,3c013f4d // 00000000 hor fov menu
+patch=1,EE,001b2530,word,3421b6dc
 patch=1,EE,001b253c,word,4481f000 // 00000000
 patch=1,EE,001b2540,word,461e6b42 // 00000000
 

--- a/patches/SLPS-25040_5F2A0E36.pnach
+++ b/patches/SLPS-25040_5F2A0E36.pnach
@@ -2,13 +2,15 @@ gametitle=Armored Core 2 - Another Age [NTSC-J] (SLPS-25040)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=ElHecht
+author=ElHecht, Berylskid
 
 // 16:9
-patch=1,EE,002c45a4,word,3c013f40 // 00000000 hor fov gameplay
+patch=1,EE,002c45a4,word,3c013f4d // 00000000 hor fov gameplay
+patch=1,EE,002c45a8,word,3421b6dc
 patch=1,EE,002c45b0,word,44810000 // 00000000
 patch=1,EE,002c45b4,word,4600c602 // 00000000
-patch=1,EE,001c7524,word,3c013f40 // 00000000 hor fov menu
+patch=1,EE,001c7524,word,3c013f4d // 00000000 hor fov menu
+patch=1,EE,001c7528,word,3421b6dc
 patch=1,EE,001c7534,word,4481f000 // 00000000
 patch=1,EE,001c7538,word,461e6b42 // 00000000
 

--- a/patches/SLUS-20014_0D168765.pnach
+++ b/patches/SLUS-20014_0D168765.pnach
@@ -2,12 +2,15 @@ gametitle=Armored Core 2 SLUS_200.14
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-description=Widescreen Hack
-patch=1,EE,202B5880,extended,43f00000
-patch=1,EE,001b4508,extended,3c013f40
-patch=1,EE,001c54e4,extended,3c013f40
-patch=1,EE,001c5614,extended,3c013f40
-
+author=Elhecht, Berylskid
+patch=1,EE,201B3DDC,extended,3C013F4D // hor fov menu
+patch=1,EE,201B3DE0,extended,3421B6DC
+patch=1,EE,201B3DEC,extended,4481F000
+patch=1,EE,201B3DF0,extended,461E6B42
+patch=1,EE,2028ADAC,extended,3C013F4D // hor fov gameplay
+patch=1,EE,201BADB0,extended,3421B6DC
+patch=1,EE,2028ADB8,extended,44810000
+patch=1,EE,2028ADBC,extended,4600C602
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.

--- a/patches/SLUS-20249_9545216B.pnach
+++ b/patches/SLUS-20249_9545216B.pnach
@@ -2,12 +2,15 @@ gametitle=Armored Core 2 Another Age SLUS_202.49
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-description=Widescreen Hack
-patch=1,EE,001c7ce8,word,3c013f40
-patch=1,EE,001dcb4c,word,3c013f40
-patch=1,EE,001dcc6c,word,3c013f40
-patch=1,EE,202FBF80,word,43f00000
-
+author=Elhecht, Berylskid
+patch=1,EE,201C740C,extended,3C013F4D //hor fov menu
+patch=1,EE,201C7410,extended,3421B6DC
+patch=1,EE,201C741C,extended,4481F000
+patch=1,EE,201C7420,extended,461E6B42
+patch=1,EE,202C4DE4,extended,3C013F4D //hor fov gameplay
+patch=1,EE,202C4DE8,extended,3421B6DC
+patch=1,EE,202C4DF0,extended,44810000
+patch=1,EE,202C4DF4,extended,4600C602
 
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.


### PR DESCRIPTION
- Imported Elhecht's WS patch to NTSC-U. Fixed unfunctionality in Arena menu level.
- Adjusted FOV based on 10:7 aspect ratio.
  - 3D graphics appear slightly stretched by previous patches because they are based on 4:3 aspect ratio.