### PR TITLE
Patches: Fix 60/50 FPS patches to The Legend of Spyro The Eternal Night

### DIFF
--- a/patches/SLES-54815_8AE9536D.pnach
+++ b/patches/SLES-54815_8AE9536D.pnach
@@ -1,10 +1,11 @@
 gametitle=Legend of Spyro, The - The Eternal Night (SLES-54815)
 
 [50 FPS]
-author=asasega + CRASHARKI
+author=asasega + CRASHARKI + manakoDE
 description=Patches the game to run at 50 FPS.
 patch=1,EE,20124390,word,28420001 //28420002
 patch=1,EE,201244AC,word,28420001 //28420002
 patch=1,EE,E0020001,extended,008CC8B4
 patch=1,EE,20124390,extended,28420002
 patch=1,EE,201244AC,extended,28420002
+patch=1,EE,20946738,word,42700000 // Fixed Dragon Time duration

--- a/patches/SLUS-21607_B80CE8EC.pnach
+++ b/patches/SLUS-21607_B80CE8EC.pnach
@@ -1,10 +1,11 @@
 gametitle=Legend of Spyro, The - The Eternal Night (SLUS-21607)
 
 [60 FPS]
-author=asasega + CRASHARKI
+author=asasega + CRASHARKI + manakoDE
 description=Patches the game to run at 60 FPS.
 patch=1,EE,20124360,word,28420001 //28420002
 patch=1,EE,2012447C,word,28420001 //28420002
 patch=1,EE,E0020001,extended,008CC334
 patch=1,EE,20124360,extended,28420002
 patch=1,EE,2012447C,extended,28420002
+patch=1,EE,209461B8,word,42700000 // Fixed Dragon Time duration


### PR DESCRIPTION
A quick fix to the 60/50 FPS patches for The Legend of Spyro The Eternal Night to adjust Dragon Time duration as it was tied to the original expected framerate. It was tested and now works as it should at 60/50 FPS.