### PR TITLE
SLUS-20362: Add automatic autosave patch (bypass save prompt)

### DIFF
--- a/patches/SLUS-20362_1D2818AF.pnach
+++ b/patches/SLUS-20362_1D2818AF.pnach
@@ -314,3 +314,12 @@ patch=0,EE,202DDBEC,extended,1F160D0B
 patch=0,EE,202DDBF0,extended,2221
 patch=0,EE,202DE240,extended,21201F1E
 patch=0,EE,202DE244,extended,22
+
+[Bypass Save Prompt]
+description=Automatically saves the game after events if "autosave" is on.
+author=Souzooka
+
+// Causes save menu to progress to saving after checking memory card
+// instead of asking if user wishes to save
+patch=0,EE,20246208,extended,2402000F // addiu v0,zero,0xF
+patch=0,EE,20246224,extended,2402000F // addiu v0,zero,0xF


### PR DESCRIPTION
Added quality of life patch which actually automatically saves the game instead of prompting you after each event when autosave is enabled.

Before:

https://github.com/user-attachments/assets/aa5bc3d1-a2c5-4297-aa54-ef09fa5f2113

After:

https://github.com/user-attachments/assets/a9893e5a-40c2-4f99-92fd-5acca69229f1

