### PR TITLE
Changes to SLUS-20973 Champions Return to Arms for online.

### DIFF
--- a/patches/SLUS-20973_4028A55F.pnach
+++ b/patches/SLUS-20973_4028A55F.pnach
@@ -3,24 +3,24 @@ gametitle=Champions: Return to Arms * NTSC-U * SLUS-20973 * 4028A55F
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=No.47 & Switz0018
-patch=1,EE,0018A2F0,word,3C013F3F // 3C013F7F
-patch=1,EE,001949D4,word,3C013F3F // 3C013F7F
-patch=1,EE,0018A280,word,3C013FE2 // 3C013FAA
-patch=1,EE,0018A284,word,3421FC95 // 34213D70
-patch=1,EE,00199C3C,word,3C013FE2 // 3C013FAA
-patch=1,EE,00199C40,word,3421FC95 // 34213D70
-patch=1,EE,00199C70,word,3C013FE2 // 3C013FAA
-patch=1,EE,00199C74,word,3421FC95 // 34213D70
-patch=1,EE,0019A038,word,3C013FE2 // 3C013FAA
-patch=1,EE,0019A03C,word,3421FC95 // 34213D70
-patch=1,EE,0019A520,word,3C013FE2 // 3C013FAA
-patch=1,EE,0019A524,word,3421FC95 // 34213D70
-patch=1,EE,0019B5C8,word,3C013FE2 // 3C013FAA
-patch=1,EE,0019B5CC,word,3421FC95 // 34213D70
-patch=1,EE,002A8914,word,3C013FE2 // 3C013FAA
-patch=1,EE,002A8918,word,3421FC95 // 34213D70
-patch=1,EE,002A8948,word,3C013FE2 // 3C013FAA
-patch=1,EE,002A894C,word,3421FC95 // 34213D70
+patch=1,EE,2018A2F0,extended,3C013F3F // 3C013F7F
+patch=1,EE,201949D4,extended,3C013F3F // 3C013F7F
+patch=1,EE,2018A280,extended,3C013FE2 // 3C013FAA
+patch=1,EE,2018A284,extended,3421FC95 // 34213D70
+patch=1,EE,20199C3C,extended,3C013FE2 // 3C013FAA
+patch=1,EE,20199C40,extended,3421FC95 // 34213D70
+patch=1,EE,20199C70,extended,3C013FE2 // 3C013FAA
+patch=1,EE,20199C74,extended,3421FC95 // 34213D70
+patch=1,EE,2019A038,extended,3C013FE2 // 3C013FAA
+patch=1,EE,2019A03C,extended,3421FC95 // 34213D70
+patch=1,EE,2019A520,extended,3C013FE2 // 3C013FAA
+patch=1,EE,2019A524,extended,3421FC95 // 34213D70
+patch=1,EE,2019B5C8,extended,3C013FE2 // 3C013FAA
+patch=1,EE,2019B5CC,extended,3421FC95 // 34213D70
+patch=1,EE,202A8914,extended,3C013FE2 // 3C013FAA
+patch=1,EE,202A8918,extended,3421FC95 // 34213D70
+patch=1,EE,202A8948,extended,3C013FE2 // 3C013FAA
+patch=1,EE,202A894C,extended,3421FC95 // 34213D70
 
 // Widescreen Inventory Fix by Switz0018 (UnstableZero)
 // Fixes the position of the pedestal and player characters in the inventory screen.
@@ -30,10 +30,15 @@ patch=1,EE,101C0AEC,extended,0000C268 // 0000C22D - Player2 X
 patch=1,EE,101C1040,extended,0000C423 // 0000C3F7 - Pedestal2 X
 
 [No-Interlacing]
-author=Switz0018
-description=Disables interlacing. No EE overclock needed.
+author=Agrippa, updated by Switz0018
+description=Disables interlacing. Improves online play.
 gsinterlacemode=1
-patch=1,EE,2019D9B0,extended,0000102D // Don't load the vblankField Byte
-patch=1,EE,2044FD40,extended,00000001 // Tripple-buffering
-patch=1,EE,2044FD44,extended,00000000 // Progressive Mode (FullFrameMode Internally)
-patch=1,EE,2044FDB4,extended,00000001 // Another FullFrameMode flag, does not do progressive.
+patch=1,EE,0044FD40,extended,00000000 // Tripple-buffering
+patch=1,EE,0044FD44,extended,00000001 // Progressive Mode (FullFrameMode Internally)
+patch=1,EE,0044FDB4,extended,00000001 // Another FullFrameMode flag, does not do progressive.
+
+[Online Loading Fix]
+author=Adam & Switz0018
+description=Patches the compression algorithm used for online.
+patch=2,EE,201BE0E0,extended,24100004
+patch=2,EE,201BE188,extended,26100001


### PR DESCRIPTION
Update widescreen to PNACH2.0.

The old no-interlacing patch helps online stability when modified to not meddle with game code, runs at 60FPS just fine in testing. (Lava lakes and many particle and heat wave effects don't lag.) Bosses known to have lag online, run fine with this.

A bug was found in this games compression method used to send character data online. Adam, the creator of the emulator server and I are providing the patch for it here.