### PR TITLE
Patches: Add patches to Genki titles

### DIFF
--- a/patches/SLES-53191_F7780E06.pnach
+++ b/patches/SLES-53191_F7780E06.pnach
@@ -1,15 +1,23 @@
-gametitle=Kaido Racer PAL (SLES_531.91)
-
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=El_Patas
-description=Widescreen Hack
-//Gameplay 16:9
-patch=1,EE,20431190,extended,3F400000 //3F800000 (Increases hor. axis)
-
+gametitle=Kaido Racer [PAL] SLES-53191 F7780E06
 
 [No-Interlacing]
 gsinterlacemode=1
 author=val
 description=Attempts to disable interlaced offset rendering.
-patch=1,EE,001350F0,word,00000000
+patch=1,EE,001350F0,word,00000000 //DC241000
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=val
+patch=1,EE,00431192,short,3F40 //3F80 //3D General
+patch=1,EE,004322D2,short,3F40 //3F80 //3D Reflections
+patch=1,EE,00433412,short,3F40 //3F80 //3D Mirror
+patch=1,EE,00433F92,short,3F40 //3F80 //3D Weather
+
+[Native 10:7]
+gsaspectratio=10:7
+author=val
+patch=1,EE,00431192,short,3F6F //3F80 //3D General
+patch=1,EE,004322D2,short,3F6F //3F80 //3D Reflections
+patch=1,EE,00433412,short,3F6F //3F80 //3D Mirror
+patch=1,EE,00433F92,short,3F6F //3F80 //3D Weather

--- a/patches/SLES-53900_C7993BCC.pnach
+++ b/patches/SLES-53900_C7993BCC.pnach
@@ -1,15 +1,23 @@
-gametitle=Kaido Racer 2 PAL (SLES_539.00)
-
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=El_Patas
-author=El_Patas
-//Gameplay 16:9
-patch=1,EE,203FDFD0,extended,3F400000 //3F800000 (Increases hor. axis)
-
+gametitle=Kaido Racer 2 [PAL] SLES-53900 C7993BCC
 
 [No-Interlacing]
 gsinterlacemode=1
 author=val
 description=Attempts to disable interlaced offset rendering.
 patch=1,EE,001539E8,word,00000000
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=val
+patch=1,EE,003FDFD2,short,3F40 //3F80 //3D General
+patch=1,EE,003FF112,short,3F40 //3F80 //3D Reflections
+patch=1,EE,00400252,short,3F40 //3F80 //3D Mirror
+//patch=1,EE,003FE022,short,3F80 //3F80 //3D Weather
+
+[Native 10:7]
+gsaspectratio=10:7
+author=val
+patch=1,EE,003FDFD2,short,3F6F //3F80 //3D General
+patch=1,EE,003FF112,short,3F6F //3F80 //3D Reflections
+patch=1,EE,00400252,short,3F6F //3F80 //3D Mirror
+//patch=1,EE,003FE022,short,3F80 //3F80 //3D Weather

--- a/patches/SLPM-65246_0AD22FB5.pnach
+++ b/patches/SLPM-65246_0AD22FB5.pnach
@@ -1,13 +1,23 @@
-gametitle=Drift Racer - Kaido Battle [NTSC-J] (SLPM-65246)
-
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=nemesis2000
-author=nemesis2000
-patch=1,EE,0013bd80,word,3c023f40
+gametitle=Kaido Battle [NTSC-J] SLPM-65246 0AD22FB5
 
 [No-Interlacing]
 gsinterlacemode=1
 author=val
 description=Attempts to disable interlaced offset rendering.
-patch=1,EE,00135ABC,word,00000000
+patch=1,EE,00135ABC,word,00000000 //DC221000
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=val
+patch=1,EE,003B3CCE,short,3F40 //3F80 //3D General
+patch=1,EE,003B53CE,short,3F40 //3F80 //3D Reflections
+patch=1,EE,003B598E,short,3F40 //3F80 //3D Mirror
+patch=1,EE,003B708E,short,3F40 //3F80 //3D Weather
+
+[Native 10:7]
+gsaspectratio=10:7
+author=val
+patch=1,EE,003B3CCE,short,3F6F //3F80 //3D General
+patch=1,EE,003B53CE,short,3F6F //3F80 //3D Reflections
+patch=1,EE,003B598E,short,3F6F //3F80 //3D Mirror
+patch=1,EE,003B708E,short,3F6F //3F80 //3D Weather

--- a/patches/SLPM-65494_AF95D8FC.pnach
+++ b/patches/SLPM-65494_AF95D8FC.pnach
@@ -1,10 +1,17 @@
-gametitle=Fuun Shinsengumi [NTSC-J] (SLPM-65494)
+gametitle=Fu-un Shinsen-gumi [NTSC-J] SLPM-65494 AF95D8FC
+
+[No-Interlacing]
+gsinterlacemode=1
+author=val
+description=Attempts to disable interlaced offset rendering.
+patch=1,EE,0013A494,word,00000000 //DC221000
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Little Giant
+author=val
+patch=1,EE,0033E4CE,short,3F40 //3F80 //3D General
 
-//16:9
-patch=1,EE,001476a0,word,3c023f40 //3c023f80
-
-
+[Native 10:7]
+gsaspectratio=10:7
+author=val
+patch=1,EE,0033E4CE,short,3F6F //3F80 //3D General

--- a/patches/SLPM-65514_C37C1B76.pnach
+++ b/patches/SLPM-65514_C37C1B76.pnach
@@ -1,13 +1,23 @@
-gametitle=Kaido Battle 2 - Chain Reaction [NTSC-J] (SLPM-65514)
-
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=nemesis2000
-author=nemesis2000
-patch=1,EE,00149200,word,3c023f40
+gametitle=Kaido Battle 2 - Chain Reaction [NTSC-J] SLPM-65514 C37C1B76
 
 [No-Interlacing]
 gsinterlacemode=1
 author=val
 description=Attempts to disable interlaced offset rendering.
-patch=1,EE,0013A204,word,00000000
+patch=1,EE,0013A204,word,00000000 //DC241000
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=val
+patch=1,EE,00435492,short,3F40 //3F80 //3D General
+patch=1,EE,004365D2,short,3F40 //3F80 //3D Reflections
+patch=1,EE,00437712,short,3F40 //3F80 //3D Mirror
+patch=1,EE,00438292,short,3F40 //3F80 //3D Weather
+
+[Native 10:7]
+gsaspectratio=10:7
+author=val
+patch=1,EE,00435492,short,3F6F //3F80 //3D General
+patch=1,EE,004365D2,short,3F6F //3F80 //3D Reflections
+patch=1,EE,00437712,short,3F6F //3F80 //3D Mirror
+patch=1,EE,00438292,short,3F6F //3F80 //3D Weather

--- a/patches/SLPM-65813_950241D3.pnach
+++ b/patches/SLPM-65813_950241D3.pnach
@@ -1,10 +1,17 @@
-gametitle=Fuun Bakumatsuden [NTSC-J] (SLPM-65813)
+gametitle=Fu-un Bakumatsu-den [NTSC-J] SLPM-65813 950241D3
+
+[No-Interlacing]
+gsinterlacemode=1
+author=val
+description=Attempts to disable interlaced offset rendering.
+patch=1,EE,0015586C,word,00000000 //DC441000
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Little Giant
+author=val
+patch=1,EE,004555D2,short,3F40 //3F80 //3D General
 
-//16:9
-patch=1,EE,0014a394,word,3c023f40 //3c02bf80
-
-
+[Native 10:7]
+gsaspectratio=10:7
+author=val
+patch=1,EE,004555D2,short,3F6F //3F80 //3D General

--- a/patches/SLPM-65897_1C087362.pnach
+++ b/patches/SLPM-65897_1C087362.pnach
@@ -1,32 +1,27 @@
-gametitle=Racing Battle C1 Grand Prix (J)(SLPM-65897)
-
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=wxvu & igorciz777
-
-//Rendering: General
-patch=0,EE,20167318,extended,3C043F10 //3C043F40
-
-//Rendering: Reflections
-patch=0,EE,2016783C,extended,3C033F10 //3C033F40
-
-//Rendering: Rear View Mirror
-patch=0,EE,20167A58,extended,3C043F10 //3C043F40
-
-[Widescreen 16:10]
-gsaspectratio=Stretch
-author=wxvu & igorciz777
-
-//Rendering: General
-patch=0,EE,20167318,extended,3C043F20 //3C043F40
-
-//Rendering: Reflections
-patch=0,EE,2016783C,extended,3C033F20 //3C033F40
-
-//Rendering: Rear View Mirror
-patch=0,EE,20167A58,extended,3C043F20 //3C043F40
+gametitle=Racing Battle - C1 Grand Prix [NTSC-J] SLPM-65897 1C087362
 
 [No-Interlacing]
 gsinterlacemode=1
 author=Tokman5
 patch=1,EE,2014AC58,extended,24022000
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=val, igorciz777
+patch=1,EE,00167318,short,3F10 //3F40 //3D General
+patch=1,EE,0016783C,short,3F10 //3F40 //3D Reflections
+patch=1,EE,00167A58,short,3F10 //3F40 //3D Mirror
+
+[Widescreen 16:10]
+gsaspectratio=Stretch
+author=val, igorciz777
+patch=1,EE,00167318,short,3F20 //3F40 //3D General
+patch=1,EE,0016783C,short,3F20 //3F40 //3D Reflections
+patch=1,EE,00167A58,short,3F20 //3F40 //3D Mirror
+
+[Native 10:7]
+gsaspectratio=10:7
+author=val, igorciz777
+patch=1,EE,00167318,short,3F33 //3F40 //3D General
+patch=1,EE,0016783C,short,3F33 //3F40 //3D Reflections
+patch=1,EE,00167A58,short,3F33 //3F40 //3D Mirror

--- a/patches/SLPM-65897_9C4C9611.pnach
+++ b/patches/SLPM-65897_9C4C9611.pnach
@@ -1,32 +1,27 @@
-gametitle=Racing Battle C1 Grand Prix (J)(SLPM-65897) (English Patched)
-
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=wxvu & igorciz777
-
-//Rendering: General
-patch=0,EE,20167318,extended,3C043F10 //3C043F40
-
-//Rendering: Reflections
-patch=0,EE,2016783C,extended,3C033F10 //3C033F40
-
-//Rendering: Rear View Mirror
-patch=0,EE,20167A58,extended,3C043F10 //3C043F40
-
-[Widescreen 16:10]
-gsaspectratio=Stretch
-author=wxvu & igorciz777
-
-//Rendering: General
-patch=0,EE,20167318,extended,3C043F20 //3C043F40
-
-//Rendering: Reflections
-patch=0,EE,2016783C,extended,3C033F20 //3C033F40
-
-//Rendering: Rear View Mirror
-patch=0,EE,20167A58,extended,3C043F20 //3C043F40
+gametitle=Racing Battle - C1 Grand Prix [NTSC-J] SLPM-65897 9C4C9611 [English Patch v8.1 Final]
 
 [No-Interlacing]
 gsinterlacemode=1
 author=Tokman5
 patch=1,EE,2014AC58,extended,24022000
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=val, igorciz777
+patch=1,EE,00167318,short,3F10 //3F40 //3D General
+patch=1,EE,0016783C,short,3F10 //3F40 //3D Reflections
+patch=1,EE,00167A58,short,3F10 //3F40 //3D Mirror
+
+[Widescreen 16:10]
+gsaspectratio=Stretch
+author=val, igorciz777
+patch=1,EE,00167318,short,3F20 //3F40 //3D General
+patch=1,EE,0016783C,short,3F20 //3F40 //3D Reflections
+patch=1,EE,00167A58,short,3F20 //3F40 //3D Mirror
+
+[Native 10:7]
+gsaspectratio=10:7
+author=val, igorciz777
+patch=1,EE,00167318,short,3F33 //3F40 //3D General
+patch=1,EE,0016783C,short,3F33 //3F40 //3D Reflections
+patch=1,EE,00167A58,short,3F33 //3F40 //3D Mirror

--- a/patches/SLPM-66022_EC33CA0D.pnach
+++ b/patches/SLPM-66022_EC33CA0D.pnach
@@ -1,12 +1,23 @@
-gametitle=Kaido - Touge no Densetsu [NTSC-J] (SLPM-66022)
+gametitle=Kaido Battle: Touge no Densetsu [NTSC-J] SLPM-66022 EC33CA0D
+
+[No-Interlacing]
+gsinterlacemode=1
+author=Strawberry Shortcake
+description=Attempts to disable interlaced offset rendering.
+patch=1,EE,201532C4,extended,30840000
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=nemesis2000
-patch=1,EE,0016323c,word,3c043f40 //GamePlay
-patch=1,EE,0036663c,word,3c033f40 //Garage
+author=val
+patch=1,EE,003F3112,short,3F40 //3F80 //3D General
+patch=1,EE,003F4252,short,3F40 //3F80 //3D Reflections
+patch=1,EE,003F5392,short,3F40 //3F80 //3D Mirror
+//patch=1,EE,003F3162,short,3F80 //3F80 //3D Weather
 
-[No-Interlacing]
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-patch=1,EE,201532C4,extended,30840000
+[Native 10:7]
+gsaspectratio=10:7
+author=val
+patch=1,EE,003F3112,short,3F6F //3F80 //3D General
+patch=1,EE,003F4252,short,3F6F //3F80 //3D Reflections
+patch=1,EE,003F5392,short,3F6F //3F80 //3D Mirror
+//patch=1,EE,003F3162,short,3F80 //3F80 //3D Weather

--- a/patches/SLUS-21236_07A4E535.pnach
+++ b/patches/SLUS-21236_07A4E535.pnach
@@ -1,13 +1,23 @@
-gametitle=Tokyo Xtreme Racer: Drift (SLUS-21236)
+gametitle=Tokyo Xtreme Racer: Drift [NTSC-U] SLUS-21236 07A4E535
+
+[No-Interlacing]
+gsinterlacemode=1
+author=gladiator
+description=Attempts to disable interlaced offset rendering.
+patch=1,EE,201093F0,extended,30630000
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=nemesis2000
-patch=1,EE,001196f4,word,3c043f40
+author=val
+patch=1,EE,003BC6CE,short,3F40 //3F80 //3D General
+patch=1,EE,003BDDCE,short,3F40 //3F80 //3D Reflections
+patch=1,EE,003BE38E,short,3F40 //3F80 //3D Mirror
+patch=1,EE,003BFA8E,short,3F40 //3F80 //3D Weather
 
-
-[No-Interlacing]
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-author=gladiator
-patch=1,EE,201093F0,extended,30630000
+[Native 10:7]
+gsaspectratio=10:7
+author=val
+patch=1,EE,003BC6CE,short,3F6F //3F80 //3D General
+patch=1,EE,003BDDCE,short,3F6F //3F80 //3D Reflections
+patch=1,EE,003BE38E,short,3F6F //3F80 //3D Mirror
+patch=1,EE,003BFA8E,short,3F6F //3F80 //3D Weather

--- a/patches/SLUS-21394_B32E018E.pnach
+++ b/patches/SLUS-21394_B32E018E.pnach
@@ -1,13 +1,9 @@
-gametitle=Tokyo Xtreme Racer: Drift 2 (NTSC-U - SLUS-21394)
-
-[Widescreen 16:9]
-gsaspectratio=16:9
-author=nemesis2000
-patch=1,EE,203f59d0,extended,3f400000
+gametitle=Tokyo Xtreme Racer: Drift 2 [NTSC-U] SLUS-21394 B32E018E
 
 [No-Interlacing]
-description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
+author=asasega
+description=Attempts to disable interlaced offset rendering.
 patch=1,EE,20153B90,extended,00000000
 patch=1,EE,E002FFFC,extended,0065581C
 patch=1,EE,20153AB4,extended,34050001
@@ -15,6 +11,22 @@ patch=1,EE,20153A9C,extended,34051400
 patch=1,EE,E002FFFA,extended,0065581C
 patch=1,EE,20153AB4,extended,DCC50008
 patch=1,EE,20153A9C,extended,DCC50020
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=val
+patch=1,EE,003F59D2,short,3F40 //3F80 //3D General
+patch=1,EE,003F6B12,short,3F40 //3F80 //3D Reflections
+patch=1,EE,003F7C52,short,3F40 //3F80 //3D Mirror
+//patch=1,EE,003F5A22,short,3F80 //3F80 //3D Weather
+
+[Native 10:7]
+gsaspectratio=10:7
+author=val
+patch=1,EE,003F59D2,short,3F6F //3F80 //3D General
+patch=1,EE,003F6B12,short,3F6F //3F80 //3D Reflections
+patch=1,EE,003F7C52,short,3F6F //3F80 //3D Mirror
+//patch=1,EE,003F5A22,short,3F80 //3F80 //3D Weather
 
 [Convert units from mph to km/h]
 description=Changes the ingame speedometer and gear menu to km/h


### PR DESCRIPTION
### Description of Changes
Adds patches to various later Genki titles.
Continuation of #195.
Detailed changes listed below:

##

### Adds No-Interlacing patches to the following titles:
- Fu-un Shinsen-gumi
- Fu-un Bakumatsu-den

##

### Adds Widescreen 16:9 patches to the following titles:
- Kaido Battle _(Tokyo Xtreme Racer Drift)_
- Kaido Battle 2 - Chain Reaction _(Kaido Racer)_
- Kaido - Touge no Densetsu _(Tokyo Xtreme Racer Drift 2, Kaido Racer 2)_
- Racing Battle - C1 Grand Prix
- Fu-un Shinsen-gumi
- Fu-un Bakumatsu-den

Updates existing and adds missing Widescreen 16:9 patches for these titles.
For titles with existing Widescreen 16:9 patches, this PR replaces them with a different patch that properly scales more assets.

#### Kaido Battle 2 (Old)
<img width="1592" height="896" alt="Kaidō Battle 2 - Chain Reaction_SLPM-65514_20260126213437" src="https://github.com/user-attachments/assets/da848173-26e9-47fa-9118-1e82122ae748" />

#### Kaido Battle 2 (PR)
<img width="1592" height="896" alt="Kaidō Battle 2 - Chain Reaction_SLPM-65514_20260126213512" src="https://github.com/user-attachments/assets/94429c2f-969a-4e76-b49a-1dfa36db08eb" />

##

### Adds Native 10:7 patches to the following titles:
- Kaido Battle _(Tokyo Xtreme Racer Drift)_
- Kaido Battle 2 - Chain Reaction _(Kaido Racer)_
- Kaido - Touge no Densetsu _(Tokyo Xtreme Racer Drift 2, Kaido Racer 2)_
- Racing Battle - C1 Grand Prix
- Fu-un Shinsen-gumi
- Fu-un Bakumatsu-den

Adds Native 10:7 versions of the aforementioned Widescreen 16:9 patches.
These Genki titles run at 640x448, a 10:7 aspect ratio. They properly scale 3D rendering to account for this but leave 2D assets unscaled, giving 2D graphics a 'squished' appearance at a standard 4:3 aspect ratio.
This patch forces the aspect ratio to 10:7 and scales 3D rendering appropriately, giving a 'perfect pixel' look.

#### Kaido Battle 2 (4:3, unpatched)
<img width="1280" height="960" alt="Kaidō Battle 2 - Chain Reaction_SLPM-65514_20260126210731" src="https://github.com/user-attachments/assets/b43d61c3-f8ff-40dc-bec4-5ba8543c7ef1" />

#### Kaido Battle 2 (10:7, patched)
<img width="1280" height="896" alt="Kaidō Battle 2 - Chain Reaction_SLPM-65514_20260126210738" src="https://github.com/user-attachments/assets/d45da72f-52f7-4d49-9cbc-c8d30f2993b1" />


