### PR TITLE
Patches: Add Monsters, Inc. Scare Island Widescreen to all regions

### DIFF
--- a/patches/SCES-50595_77C7F85A.pnach
+++ b/patches/SCES-50595_77C7F85A.pnach
@@ -1,8 +1,9 @@
-gametitle=Disney's Pixar - Monsters, Inc. - Scare Island (E)(SCES-50595)
+gametitle=Disney/Pixar Monsters, Inc. - Scare Island (PAL-E) (SCES-50595)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
 
 // 16:9
 patch=1,EE,0011a3f0,word,0808ad25 // c6010068 jump to code-inject 0022b494
@@ -14,5 +15,3 @@ patch=1,EE,0022b4a0,word,c602006c // 00000000
 patch=1,EE,0022b4a4,word,461e0843 // 00000000
 patch=1,EE,0022b4a8,word,e6010068 // 00000000
 patch=1,EE,0022b4ac,word,080468fd // 00000000 jump back to 0011a3f4
-
-

--- a/patches/SCES-50596_F5B07CC0.pnach
+++ b/patches/SCES-50596_F5B07CC0.pnach
@@ -1,4 +1,4 @@
-gametitle=Disney/Pixar Monsters, Inc. - Skraemmeoen (PAL-D) (SCES-50596)
+gametitle=Disney/Pixar Monsters, Inc. - Skræmmeøen (PAL-DK) (SCES-50596)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SCES-50596_F5B07CC0.pnach
+++ b/patches/SCES-50596_F5B07CC0.pnach
@@ -1,4 +1,4 @@
-gametitle=Die Monster AG - Schreckens-Insel (PAL-G) (SCES-50600)
+gametitle=Disney/Pixar Monsters, Inc. - Skraemmeoen (PAL-D) (SCES-50596)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SCES-50597_F5B07CC0.pnach
+++ b/patches/SCES-50597_F5B07CC0.pnach
@@ -1,4 +1,4 @@
-gametitle=Die Monster AG - Schreckens-Insel (PAL-G) (SCES-50600)
+gametitle=Monsters en Co - Schrik Eiland (PAL-NL) (SCES-50597)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SCES-50598_F5B07CC0.pnach
+++ b/patches/SCES-50598_F5B07CC0.pnach
@@ -1,4 +1,4 @@
-gametitle=Die Monster AG - Schreckens-Insel (PAL-G) (SCES-50600)
+gametitle=Monsterit Oy - Säikkysaari (PAL-FI) (SCES-50598)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SCES-50599_F5B07CC0.pnach
+++ b/patches/SCES-50599_F5B07CC0.pnach
@@ -1,4 +1,4 @@
-gametitle=Monstres & Cie - L'ile de l'épouvante (PAL-F) (SCES-50599)
+gametitle=Monstres & Cie - L'ile de l'epouvante (PAL-F) (SCES-50599)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SCES-50599_F5B07CC0.pnach
+++ b/patches/SCES-50599_F5B07CC0.pnach
@@ -1,9 +1,9 @@
-gametitle=Monsters Inc - Scare Island (PAL-F) (SCES-50599)
+gametitle=Monstres & Cie - L'ile de l'épouvante (PAL-F) (SCES-50599)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-description=Widescreen hack conversion
 author=Bigdemon
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
 
 // 16:9
 patch=1,EE,0011a3f0,word,0808ad25 // c6010068 jump to code-inject 0022b494

--- a/patches/SCES-50601_F5B07CC0.pnach
+++ b/patches/SCES-50601_F5B07CC0.pnach
@@ -1,4 +1,4 @@
-gametitle=Die Monster AG - Schreckens-Insel (PAL-G) (SCES-50600)
+gametitle=Monster & Co - L'Isola dello Spavento (PAL-I) (SCES-50601)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SCES-50602_F5B07CC0.pnach
+++ b/patches/SCES-50602_F5B07CC0.pnach
@@ -1,4 +1,4 @@
-gametitle=Die Monster AG - Schreckens-Insel (PAL-G) (SCES-50600)
+gametitle=Monsterbedriften - Skrekkøya (PAL-NO) (SCES-50602)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SCES-50603_F5B07CC0.pnach
+++ b/patches/SCES-50603_F5B07CC0.pnach
@@ -1,4 +1,4 @@
-gametitle=Die Monster AG - Schreckens-Insel (PAL-G) (SCES-50600)
+gametitle=Monstruos, S.A. - Isla de los sustos (PAL-S) (SCES-50603)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SCES-50604_F5B07CC0.pnach
+++ b/patches/SCES-50604_F5B07CC0.pnach
@@ -1,4 +1,4 @@
-gametitle=Die Monster AG - Schreckens-Insel (PAL-G) (SCES-50600)
+gametitle=Monsters, Inc - Skrämmarön (PAL-SW) (SCES-50604)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SCES-50605_F5B07CC0.pnach
+++ b/patches/SCES-50605_F5B07CC0.pnach
@@ -1,4 +1,4 @@
-gametitle=Die Monster AG - Schreckens-Insel (PAL-G) (SCES-50600)
+gametitle=Monstros e Companhia - Ilha Assustadora (PAL-PL) (SCES-50605)
 
 [Widescreen 16:9]
 gsaspectratio=16:9


### PR DESCRIPTION
Added the Widescreen patch to all other regions + some tidy up.
As you can tell by the CRCs, the codes are the same for all regions, still, all of them were tested just in case.