### PR TITLE
Patches: Add Widescreen patch to Dragon's Lair 3D

### DIFF
--- a/patches/SLES-51696_B0D0007A.pnach
+++ b/patches/SLES-51696_B0D0007A.pnach
@@ -1,0 +1,7 @@
+gametitle=Dragon's Lair 3D - Special Edition (PAL-M) (SLES-51696)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+patch=1,EE,004093E8,byte,1 //0


### PR DESCRIPTION
Enables the native widescreen option. Tested.