### PR TITLE
Patches: Add remaining patches to The Warriors

### DIFF
--- a/patches/SLES-53443_FA3C1346.pnach
+++ b/patches/SLES-53443_FA3C1346.pnach
@@ -1,4 +1,13 @@
-gametitle=Warriors, The (PAL-M) SLES-53443 FA3C1346
+gametitle=The Warriors (PAL-M) (SLES-53443)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=CRASHARKI
+description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+
+//Widescreen hack 16:9
+//Enable ingame widescreen
+patch=1,EE,007AA05C,byte,01 //00
 
 [50/60 FPS]
 author=PeterDelta

--- a/patches/SLES-53443_FA3C1346.pnach
+++ b/patches/SLES-53443_FA3C1346.pnach
@@ -3,16 +3,14 @@ gametitle=The Warriors (PAL-M) (SLES-53443)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=CRASHARKI
-description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
-
-//Widescreen hack 16:9
-//Enable ingame widescreen
+description=Enable native widescreen.
 patch=1,EE,007AA05C,byte,01 //00
 
-[50/60 FPS]
-author=PeterDelta
-description=Might need EE Overclock at 130%.
-patch=1,EE,00596D70,byte,01
+// Apparently doesn't achieve real 50/60 FPS
+//[50/60 FPS]
+//author=PeterDelta
+//description=Might need EE Overclock at 130%.
+//patch=1,EE,00596D70,byte,01
 
 [480p Mode]
 gsinterlacemode=1

--- a/patches/SLUS-21215_B99A75DE.pnach
+++ b/patches/SLUS-21215_B99A75DE.pnach
@@ -1,19 +1,34 @@
-gametitle=The Warriors (U)(SLUS-21215)
+gametitle=The Warriors (NTSC-U) (SLUS-21215)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=Arapapa
+author=CRASHARKI & arapapa
+description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
 
 //Widescreen hack 16:9
+//Enable ingame widescreen by CRASHARKI
+patch=1,EE,007AA05C,byte,01 //00
 
-//Fix '4:3 Screen'
+//Fix '4:3 Screen' by arapapa
 //patch=1,EE,00194ec4,word,3c013fe3 //3c013faa
 //patch=1,EE,00194ec8,word,34218e3e //3421aa8f
 
 
-//Fix 'Internal Widecscreen'
+//Fix 'Internal Widecscreen' by arapapa
 //d53f013c 1d552134 (2nd)
 patch=1,EE,00194e8c,word,3c013fe3 //3c013fd5
 patch=1,EE,00194e90,word,34218e3e //3421551d
 
+[50/60 FPS]
+author=PeterDelta
+description=Might need EE Overclock at 130%.
+patch=1,EE,00596D70,byte,01
 
+[480p Mode]
+gsinterlacemode=1
+author=PeterDelta
+description=SDTV 480p mode at start.
+patch=1,EE,0043CCA0,word,34050050
+patch=1,EE,0043CCA4,word,24030002
+patch=1,EE,0043CCA8,word,0000000C
+patch=1,EE,0043CCAC,word,03E00008

--- a/patches/SLUS-21215_B99A75DE.pnach
+++ b/patches/SLUS-21215_B99A75DE.pnach
@@ -19,7 +19,7 @@ patch=1,EE,007AA05C,byte,01 //00
 patch=1,EE,00194e8c,word,3c013fe3 //3c013fd5
 patch=1,EE,00194e90,word,34218e3e //3421551d
 
-[50/60 FPS]
+[60 FPS]
 author=PeterDelta
 description=Might need EE Overclock at 130%.
 patch=1,EE,00596D70,byte,01

--- a/patches/SLUS-21215_B99A75DE.pnach
+++ b/patches/SLUS-21215_B99A75DE.pnach
@@ -2,27 +2,26 @@ gametitle=The Warriors (NTSC-U) (SLUS-21215)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=CRASHARKI & arapapa
-description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
+author=CRASHARKI
+description=Enable native widescreen.
 
-//Widescreen hack 16:9
-//Enable ingame widescreen by CRASHARKI
+//Enable native widescreen by CRASHARKI
 patch=1,EE,007AA05C,byte,01 //00
 
 //Fix '4:3 Screen' by arapapa
 //patch=1,EE,00194ec4,word,3c013fe3 //3c013faa
 //patch=1,EE,00194ec8,word,34218e3e //3421aa8f
 
-
-//Fix 'Internal Widecscreen' by arapapa
+//Fix 'Internal Widescreen' by arapapa
 //d53f013c 1d552134 (2nd)
-patch=1,EE,00194e8c,word,3c013fe3 //3c013fd5
-patch=1,EE,00194e90,word,34218e3e //3421551d
+//patch=1,EE,00194e8c,word,3c013fe3 //3c013fd5
+//patch=1,EE,00194e90,word,34218e3e //3421551d
 
-[60 FPS]
-author=PeterDelta
-description=Might need EE Overclock at 130%.
-patch=1,EE,00596D70,byte,01
+// Apparently doesn't achieve real 60 FPS
+//[60 FPS]
+//author=PeterDelta
+//description=Might need EE Overclock at 130%.
+//patch=1,EE,00596D70,byte,01
 
 [480p Mode]
 gsinterlacemode=1


### PR DESCRIPTION
All patches from the PAL version were added to the NTSC-U version, along with a new patch I created to enable widescreen by default in both versions. The NTSC-U viewport width fixes turned out to be unnecessary, as the difference is barely noticeable, and the 4:3 mode itself seems slightly narrower, while 16:9 matches the PSP version's width. In addition, those fixes narrowed and misaligned the HUD, which was actually noticeable. Fortunately, the memory addresses were identical in both versions, although both were tested to confirm compatibility.