### PR TITLE
SCUS-97213 Add kojinov's Disable Depth of Field Code

### DIFF
--- a/patches/SCUS-97213_1DF41F33.pnach
+++ b/patches/SCUS-97213_1DF41F33.pnach
@@ -6,4 +6,7 @@ author=nemesis2000
 description=Widescreen Hack
 patch=1,EE,00138d78,word,3f023f40
 
-
+[Disable Depth of Field]
+author=kojinov
+description=Disables Depth of Field fixing warping/tearing in the distance.
+patch=1,EE,0017E36C,word,100001AA

--- a/patches/SCUS-97213_1DF41F33.pnach
+++ b/patches/SCUS-97213_1DF41F33.pnach
@@ -8,5 +8,5 @@ patch=1,EE,00138d78,word,3f023f40
 
 [Disable Depth of Field]
 author=kojinov
-description=Disables Depth of Field fixing warping/tearing in the distance.
+description=Disables Depth of Field resolving distant objects warping and shimmering.
 patch=1,EE,0017E36C,word,100001AA


### PR DESCRIPTION
This patch by kojinov for Dark Cloud 2 (SCUS-97213) disables the poorly implemented Depth of Field effect that causes a very distracting warping and shimmering effect in the distance.
Purely visual change with no known issues in testing and in a ~30 hour playthrough.

Demonstration & Source:
1. https://youtu.be/xU4vV1HilhE