### PR TITLE
Add NTSC mode patch to Rayman M (v2.00)

### DIFF
--- a/patches/SLES-50457_DDA2FA6A.pnach
+++ b/patches/SLES-50457_DDA2FA6A.pnach
@@ -1,7 +1,19 @@
-gametitle=Rayman M (PAL-M 2.0) (SLES-50457)
+gametitle=Rayman M (PAL 2.0) (SLES-50457)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=CRASHARKI
 description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
 patch=1,EE,003383BC,byte,1 //0
+
+[NTSC 640x448 60Hz]
+// initialize graphics engine with 640x448 resolution (this automatically sets sceGsResetGraph to NTSC mode)
+patch=0,EE,0016AFAC,word,24060280
+patch=0,EE,0016AFB8,word,240701C0
+// patch code that sets framerate
+patch=0,EE,0016C058,word,3C024270
+// patch internal resolution variables (float and int)
+patch=0,EE,00337B9C,word,44200000
+patch=0,EE,00337BA0,word,43E00000
+patch=0,EE,00337BA4,word,00000280
+patch=0,EE,00337BA8,word,000001C0

--- a/patches/SLES-50457_DDA2FA6A.pnach
+++ b/patches/SLES-50457_DDA2FA6A.pnach
@@ -7,6 +7,8 @@ description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
 patch=1,EE,003383BC,byte,1 //0
 
 [NTSC 640x448 60Hz]
+author=Rib
+description=Run the game in NTSC 640x448 60Hz mode
 // initialize graphics engine with 640x448 resolution (this automatically sets sceGsResetGraph to NTSC mode)
 patch=0,EE,0016AFAC,word,24060280
 patch=0,EE,0016AFB8,word,240701C0


### PR DESCRIPTION
While this game has an NTSC version (Rayman Arena), there are a significant number of changes in that version which make it (IMO) inferior to the PAL release. Such changes include the removal of easter eggs, obstacles and shortcuts in race mode, as well as the addition of a freeze bullet mechanic that can be annoying. In battle mode, the Flame Tongue item was removed on the NTSC version.

This patch makes the PAL release run in NTSC mode at 640x448 internal resolution. I have tested this and the game still runs at the correct speed, with no graphical errors (there was actually a leftover function to switch to this mode, I basically recreated that). Not sure if any other patches like this currently exist, but it seems a worthwhile addition.