### PR TITLE
Add NTSC Mode patch to Theme Park World

### DIFF
--- a/patches/SLES-50032_9CBA74B7.pnach
+++ b/patches/SLES-50032_9CBA74B7.pnach
@@ -1,0 +1,8 @@
+gametitle=Theme Park World (SLES-50032)
+
+[NTSC Mode]
+author=Gabominated
+description=Runs game in NTSC Mode (60hz).
+
+// Change vertical height argument to 448. The game handles the rest.
+patch=0,EE,202314FC,extended,240501C0 // addiu a1,zero,0x1C0


### PR DESCRIPTION
Adds a patch to Theme Park World (EU) which allows the game to run at 30fps.

NOTE: The game is susceptible to framerate differences. While animations seem to run at the correct speed even if the framerate is uncapped (60fps), other mechanics such as the camera speed and how fast time progresses are faster at higher framerates. I am not sure if these mechanics were touched for PAL (25fps), though I assume that 30fps is the intended speed in this case (as it is in Theme Park Roller Coaster).