### PR TITLE
Fix potential softlock with Skippable Cutscenes patch in Jimmy Neutron: Attack of the Twonkies (US)

### DIFF
--- a/patches/SLUS-20887_058849D1.pnach
+++ b/patches/SLUS-20887_058849D1.pnach
@@ -22,7 +22,7 @@ patch=1,EE,00158dc4,word,3c023f2b //3c023f00
 
 [Skippable Cutscenes]
 author=Souzooka
-description=Press the START or X Button to skip cutscenes.
+description=Press the START or X Button to skip cutscenes. Cutscenes can be skipped after about a second of playtime.
 // NOTE: This works by setting the cutscene length to 0, which is only checked every second or so.
 
 // Set up a call site to a code cave slightly above the cutscene length check
@@ -38,6 +38,7 @@ patch=0,EE,202C3020,extended,14400119 // bne v0,zero,0x002C3488 ; Code cave now 
 patch=0,EE,202C3024,extended,C60100A4 // lwc1 f01,0xA4(s0) ; restore spoiled f01
 
 // Code cave (at sceDmaSendI / 0x102480)
+// Check inputs
 patch=0,EE,20102480,extended,3C010049 // lui at,0x0049
 patch=0,EE,20102484,extended,8024B7C2 // lb a0,-0x483E(at)
 patch=0,EE,20102488,extended,30840008 // andi a0,a0,0x0008 ; check START Button
@@ -45,14 +46,23 @@ patch=0,EE,2010248C,extended,00801021 // addu v0,a0,zero
 patch=0,EE,20102490,extended,8024B7C3 // lb a0,-0x483D(at)
 patch=0,EE,20102494,extended,30840040 // andi a0,a0,0x0040 ; check X Button
 patch=0,EE,20102498,extended,00441025 // or v0,v0,a0
-patch=0,EE,2010249C,extended,54400001 // bnel v0,zero,0x001024A4
-patch=0,EE,201024A0,extended,AE0000AC // sw zero,0xAC(s0) ; Set cutscene length to 0 if either were pressed. Checked every second or so.
-// The below recreates a condition overwritten at the call site
-patch=0,EE,201024A4,extended,C60100A4 // lwc1 f01,0xA4(s0)
-patch=0,EE,201024A8,extended,C60000A8 // lwc1 f00,0xA8(s0)
+patch=0,EE,2010249C,extended,10400006 // beq v0,zero,0x001024B8 ; If neither pressed, skip over next check
+// Check that the cutscene has been running at least for a second or so, to prevent softlocks
+patch=0,EE,201024A0,extended,3C013F00 // lui at,0x3F00 ; 0.5 units. This isn't seconds, but it corresponds to about a second.
+patch=0,EE,201024A4,extended,44810000 // mtc1 at,f00
+patch=0,EE,201024A8,extended,C60100A4 // lwc1 f01,0xA4(s0) ; load how long cutscene has been running for
 patch=0,EE,201024AC,extended,46010036 // c.le.s f00,f01
-patch=0,EE,201024B0,extended,00001021 // addu v0,zero,zero
-patch=0,EE,201024B4,extended,45020001 // bc1fl 0x001024BC
-patch=0,EE,201024B8,extended,24020001 // addiu v0,zero,0x1
-patch=0,EE,201024BC,extended,03E00008 // jr ra
-patch=0,EE,201024C0,extended,00000000 // nop
+patch=0,EE,201024B0,extended,45030001 // bc1tl 0x001024B8
+// Set cutscene length to 0 if either were pressed,
+// and cutscene has been allowed to run for a bit.
+// Cutscene length is checked every second or so.
+patch=0,EE,201024B4,extended,AE0000AC // sw zero,0xAC(s0)
+// The below recreates a condition overwritten at the call site
+patch=0,EE,201024B8,extended,C60100A4 // lwc1 f01,0xA4(s0)
+patch=0,EE,201024BC,extended,C60000A8 // lwc1 f00,0xA8(s0)
+patch=0,EE,201024C0,extended,46010036 // c.le.s f00,f01
+patch=0,EE,201024C4,extended,00001021 // addu v0,zero,zero
+patch=0,EE,201024C8,extended,45020001 // bc1fl 0x001024BC
+patch=0,EE,201024CC,extended,24020001 // addiu v0,zero,0x1
+patch=0,EE,201024D0,extended,03E00008 // jr ra
+patch=0,EE,201024D4,extended,00000000 // nop


### PR DESCRIPTION
Holding X/Start when inventing could cause the player to get stuck in the Inventerface, so this forces the cutscene to play for a bit before allowing skipping.

Addresses https://github.com/PCSX2/pcsx2_patches/issues/704