### PR TITLE
Add patch to access Modem VS mode for Armored Core 2 Another Age NTSC-U

### DIFF
--- a/patches/SLUS-20249_9545216B.pnach
+++ b/patches/SLUS-20249_9545216B.pnach
@@ -15,4 +15,10 @@ patch=1,EE,202C4DF4,extended,4600C602
 [No-Interlacing]
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-patch=1,EE,002bbc4c,word,0000000
+patch=1,EE,202bbc4c,extended,00000000
+
+[LINKED VS -> MODEM VS]
+author=Berylskid
+description=Access MODEM VS by selecting LINKED VS at title screen
+patch=1,EE,20106450,extended,24100005 //addiu s0,zero,0x5
+patch=1,EE,20106454,extended,0C040A54 //jal 0x00102950


### PR DESCRIPTION
- Note: Currently working on same patch for sequels and planning to add them.
- Created patch for accessing unused Modem VS mode for Armored Core 2 Another Age NTSC-U.
- Also, fixed a wrong code in same file.