### PR TITLE
Mr. Bean progression softlock failsafe bugfix (don't execute failsafe upon loading checkpoint)

### DIFF
--- a/patches/SLES-54666_EDCBBC68.pnach
+++ b/patches/SLES-54666_EDCBBC68.pnach
@@ -51,8 +51,8 @@ patch=0,EE,20147ED0,extended,02E02821 // addu a1,s7,zero
 patch=0,EE,20147ED4,extended,00000000 // nop
 patch=0,EE,20147ED8,extended,00000000 // nop
 
-// s0 = function argument 0
-// s1 = function argument 1
+// s0 = function argument 0 (pointer to entity information)
+// s1 = function argument 1 (boolean indicating if this is the first load of the level (0=checkpoint/1=level entry))
 // s2 = profile id
 // s3 = level id
 // s4 = jigsaws collected for level + closed chests + force closed chests
@@ -77,86 +77,94 @@ patch=0,EE,202540B8,extended,7FBE0090 // sq fp,0x90(sp)
 patch=0,EE,202540BC,extended,00808021 // addu s0,a0,zero
 patch=0,EE,202540C0,extended,00A08821 // addu s1,a1,zero
 
+// We don't want to do anything if this is a checkpoint (branch to epilogue if s1=0)
+patch=0,EE,202540C4,extended,1220003E // beq s1,zero,0x002541C0
+
 // Grab all the info we need before looping over entities to determine if there's enough chests left
-patch=0,EE,202540C4,extended,3C01003B // lui at,0x003B
-patch=0,EE,202540C8,extended,8C32B000 // lw s2,-0x5000(at) ; s2 = profile ID
-patch=0,EE,202540CC,extended,8C33B004 // lw s3,-0x4FFC(at) ; s3 = level ID
-patch=0,EE,202540D0,extended,3C040001 // lui a0,0x0001
-patch=0,EE,202540D4,extended,34841FF0 // ori a0,a0,0x1FF0 ; 0x11FF0 = size of save profile data
-patch=0,EE,202540D8,extended,02442018 // mult a0,s2,a0
-patch=0,EE,202540DC,extended,24051CC0 // addiu a1,zero,0x1CC0 ; 0x1CC0 = size of level data
-patch=0,EE,202540E0,extended,02652818 // mult a1,s3,a1
-patch=0,EE,202540E4,extended,3C060032 // lui a2,0x0032
-patch=0,EE,202540E8,extended,34C6B460 // ori a2,a2,0xB460
-patch=0,EE,202540EC,extended,00C43021 // addu a2,a2,a0
-patch=0,EE,202540F0,extended,00C53021 // addu a2,a2,a1
-patch=0,EE,202540F4,extended,8CD41D04 // lw s4,0x1D04(a2) ; s4 = jigsaws collected for level
-patch=0,EE,202540F8,extended,00132180 // sll a0,s3,0x06 ; 0x40 = size of level params (for max jigsaw count)
-patch=0,EE,202540FC,extended,3C05003A // lui a1,0x003A
-patch=0,EE,20254100,extended,34A5DEB0 // ori a1,a1,0xDEB0
-patch=0,EE,20254104,extended,00A42821 // addu a1,a1,a0
-patch=0,EE,20254108,extended,8CB5000C // lw s5,0xC(a1)
+patch=0,EE,202540C8,extended,3C01003B // lui at,0x003B
+patch=0,EE,202540CC,extended,8C32B000 // lw s2,-0x5000(at) ; s2 = profile ID
+patch=0,EE,202540D0,extended,8C33B004 // lw s3,-0x4FFC(at) ; s3 = level ID
+// if level ID > 0x9, then we'd be reading out of bounds for save data.
+// This occurs in the hub level, and shouldn't actually cause any practical issues, but
+// we'll include this check just in case.
+patch=0,EE,202540D4,extended,2E61000A // sltiu at,s3,0x000A
+patch=0,EE,202540D8,extended,10200039 // beq at,zero,0x002541C0
+patch=0,EE,202540DC,extended,3C040001 // lui a0,0x0001
+patch=0,EE,202540E0,extended,34841FF0 // ori a0,a0,0x1FF0 ; 0x11FF0 = size of save profile data
+patch=0,EE,202540E4,extended,02442018 // mult a0,s2,a0
+patch=0,EE,202540E8,extended,24051CC0 // addiu a1,zero,0x1CC0 ; 0x1CC0 = size of level data
+patch=0,EE,202540EC,extended,02652818 // mult a1,s3,a1
+patch=0,EE,202540F0,extended,3C060032 // lui a2,0x0032
+patch=0,EE,202540F4,extended,34C6B460 // ori a2,a2,0xB460
+patch=0,EE,202540F8,extended,00C43021 // addu a2,a2,a0
+patch=0,EE,202540FC,extended,00C53021 // addu a2,a2,a1
+patch=0,EE,20254100,extended,8CD41D04 // lw s4,0x1D04(a2) ; s4 = jigsaws collected for level
+patch=0,EE,20254104,extended,00132180 // sll a0,s3,0x06 ; 0x40 = size of level params (for max jigsaw count)
+patch=0,EE,20254108,extended,3C05003A // lui a1,0x003A
+patch=0,EE,2025410C,extended,34A5DEB0 // ori a1,a1,0xDEB0
+patch=0,EE,20254110,extended,00A42821 // addu a1,a1,a0
+patch=0,EE,20254114,extended,8CB5000C // lw s5,0xC(a1)
 
 // First pass over entities (to determine how many chests are closed)
-patch=0,EE,2025410C,extended,8E0203F0 // lw v0,0x3F0(s0) // [s0+0x3F0] = count of entities
-patch=0,EE,20254110,extended,18400028 // blez v0,0x002541B4 ; no entities for this level...? just branch to epilogue
-patch=0,EE,20254114,extended,0000B021 // addu s6,zero,zero
+patch=0,EE,20254118,extended,8E0203F0 // lw v0,0x3F0(s0) // [s0+0x3F0] = count of entities
+patch=0,EE,2025411C,extended,18400028 // blez v0,0x002541C0 ; no entities for this level...? just branch to epilogue
+patch=0,EE,20254120,extended,0000B021 // addu s6,zero,zero
 // loop body
-patch=0,EE,20254118,extended,260403F0 // addiu a0,s0,0x3F0
-patch=0,EE,2025411C,extended,0C096BEA // jal z_un_0025afa8 ; function call to retrieve a level entity given an index
-patch=0,EE,20254120,extended,02C02821 // addu a1,s6,zero
-patch=0,EE,20254124,extended,8C440000 // lw a0,0x0(v0) ; load the entity type
-patch=0,EE,20254128,extended,2405000F // addiu a1,zero,0xF ; 0xF = Treasure chest
-patch=0,EE,2025412C,extended,14850005 // bne a0,a1,0x00254144 ; branch to loop epilogue if not chest
-patch=0,EE,20254130,extended,00000000 // nop
-patch=0,EE,20254134,extended,8C44068C // lw a0,0x68C(v0)
-patch=0,EE,20254138,extended,24050001 // addiu a1,zero,0x1 ; 0x1 = Closed state
-patch=0,EE,2025413C,extended,50850001 // beql a0,a1,0x00254144
-patch=0,EE,20254140,extended,26940001 // addiu s4,s4,0x1 ; Increment potential jigsaw pieces count if chest is closed
+patch=0,EE,20254124,extended,260403F0 // addiu a0,s0,0x3F0
+patch=0,EE,20254128,extended,0C096BEA // jal z_un_0025afa8 ; function call to retrieve a level entity given an index
+patch=0,EE,2025412C,extended,02C02821 // addu a1,s6,zero
+patch=0,EE,20254130,extended,8C440000 // lw a0,0x0(v0) ; load the entity type
+patch=0,EE,20254134,extended,2405000F // addiu a1,zero,0xF ; 0xF = Treasure chest
+patch=0,EE,20254138,extended,14850005 // bne a0,a1,0x00254150 ; branch to loop epilogue if not chest
+patch=0,EE,2025413C,extended,00000000 // nop
+patch=0,EE,20254140,extended,8C44068C // lw a0,0x68C(v0)
+patch=0,EE,20254144,extended,24050001 // addiu a1,zero,0x1 ; 0x1 = Closed state
+patch=0,EE,20254148,extended,50850001 // beql a0,a1,0x00254150
+patch=0,EE,2025414C,extended,26940001 // addiu s4,s4,0x1 ; Increment potential jigsaw pieces count if chest is closed
 // loop epilogue
-patch=0,EE,20254144,extended,26D60001 // addiu s6,s6,0x1
-patch=0,EE,20254148,extended,8E0403F0 // lw a0,0x3F0(s0)
-patch=0,EE,2025414C,extended,02C4202A // slt a0,s6,a0
-patch=0,EE,20254150,extended,1480FFF1 // bne a0,zero,0x00254118
-patch=0,EE,20254154,extended,00000000 // nop
+patch=0,EE,20254150,extended,26D60001 // addiu s6,s6,0x1
+patch=0,EE,20254154,extended,8E0403F0 // lw a0,0x3F0(s0)
+patch=0,EE,20254158,extended,02C4202A // slt a0,s6,a0
+patch=0,EE,2025415C,extended,1480FFF1 // bne a0,zero,0x00254124 ; continue looping if we haven't exhausted the entity list
+patch=0,EE,20254160,extended,00000000 // nop
 
 // Second pass over entities (to close enough chests needed so that we have enough potential jigsaws)
-patch=0,EE,20254158,extended,02B42023 // subu a0,s5,s4 ; calculate difference in potential and max jigsaw pieces
-patch=0,EE,2025415C,extended,18800015 // blez a0,0x002541B4 ; There are enough potential jigsaw pieces, so go to epilogue
-patch=0,EE,20254160,extended,0000B021 // addu s6,zero,zero
+patch=0,EE,20254164,extended,02B42023 // subu a0,s5,s4 ; calculate difference in potential and max jigsaw pieces
+patch=0,EE,20254168,extended,18800015 // blez a0,0x002541C0 ; There are enough potential jigsaw pieces, so go to epilogue
+patch=0,EE,2025416C,extended,0000B021 // addu s6,zero,zero
 // loop body
-patch=0,EE,20254164,extended,260403F0 // addiu a0,s0,0x3F0
-patch=0,EE,20254168,extended,0C096BEA // jal z_un_0025afa8 ; function call to retrieve a level entity given an index
-patch=0,EE,2025416C,extended,02C02821 // addu a1,s6,zero
-patch=0,EE,20254170,extended,8C440000 // lw a0,0x0(v0) ; load the entity type
-patch=0,EE,20254174,extended,2405000F // addiu a1,zero,0xF ; 0xF = Treasure chest
-patch=0,EE,20254178,extended,14850007 // bne a0,a1,0x00254198 ; branch to loop epilogue if not chest
-patch=0,EE,2025417C,extended,00000000 // nop
-patch=0,EE,20254180,extended,8C44068C // lw a0,0x68C(v0) ; load chest state
-patch=0,EE,20254184,extended,24050005 // addiu a1,zero,0x5 ; 0x5 = open state
-patch=0,EE,20254188,extended,14A40003 // bne a1,a0,0x00254198 ; if not open, continue
-patch=0,EE,2025418C,extended,24040001 // addiu a0,zero,0x1 ; 0x1 = closed state
-patch=0,EE,20254190,extended,AC44068C // sw a0,0x68C(v0) ; close the chest
-patch=0,EE,20254194,extended,26940001 // addiu s4,s4,0x1 ; increment potential jigsaw pieces
+patch=0,EE,20254170,extended,260403F0 // addiu a0,s0,0x3F0
+patch=0,EE,20254174,extended,0C096BEA // jal z_un_0025afa8 ; function call to retrieve a level entity given an index
+patch=0,EE,20254178,extended,02C02821 // addu a1,s6,zero
+patch=0,EE,2025417C,extended,8C440000 // lw a0,0x0(v0) ; load the entity type
+patch=0,EE,20254180,extended,2405000F // addiu a1,zero,0xF ; 0xF = Treasure chest
+patch=0,EE,20254184,extended,14850007 // bne a0,a1,0x002541A4 ; if not chest, continue
+patch=0,EE,20254188,extended,00000000 // nop
+patch=0,EE,2025418C,extended,8C44068C // lw a0,0x68C(v0) ; load chest state
+patch=0,EE,20254190,extended,24050005 // addiu a1,zero,0x5 ; 0x5 = open state
+patch=0,EE,20254194,extended,14A40003 // bne a1,a0,0x002541A4 ; if not open, continue
+patch=0,EE,20254198,extended,24040001 // addiu a0,zero,0x1 ; 0x1 = closed state
+patch=0,EE,2025419C,extended,AC44068C // sw a0,0x68C(v0) ; close the chest
+patch=0,EE,202541A0,extended,26940001 // addiu s4,s4,0x1 ; increment potential jigsaw pieces
 // loop epilogue
-patch=0,EE,20254198,extended,02B42023 // subu a0,s5,s4
-patch=0,EE,2025419C,extended,18800005 // blez a0,0x002541B8 ; leave loop if there's enough potential pieces
-patch=0,EE,202541A0,extended,26D60001 // addiu s6,s6,0x1
-patch=0,EE,202541A4,extended,8E0403F0 // lw a0,0x3F0(s0)
-patch=0,EE,202541A8,extended,02C4202A // slt a0,s6,a0
-patch=0,EE,202541AC,extended,1480FFED // bne a0,zero,0x00254164 ; leave loop if entire entity list was exhausted
-patch=0,EE,202541B0,extended,00000000 // nop
+patch=0,EE,202541A4,extended,02B42023 // subu a0,s5,s4
+patch=0,EE,202541A8,extended,18800005 // blez a0,0x002541C0 ; leave loop if there's enough potential pieces
+patch=0,EE,202541AC,extended,26D60001 // addiu s6,s6,0x1
+patch=0,EE,202541B0,extended,8E0403F0 // lw a0,0x3F0(s0)
+patch=0,EE,202541B4,extended,02C4202A // slt a0,s6,a0
+patch=0,EE,202541B8,extended,1480FFED // bne a0,zero,0x00254170 ; continue looping if we haven't exhausted the entity list
+patch=0,EE,202541BC,extended,00000000 // nop
 
 // Epilogue
-patch=0,EE,202541B4,extended,7BBE0090 // lq fp,0x90(sp)
-patch=0,EE,202541B8,extended,7BB70080 // lq s7,0x80(sp)
-patch=0,EE,202541BC,extended,7BB60070 // lq s6,0x70(sp)
-patch=0,EE,202541C0,extended,7BB50060 // lq s5,0x60(sp)
-patch=0,EE,202541C4,extended,7BB40050 // lq s4,0x50(sp)
-patch=0,EE,202541C8,extended,7BB30040 // lq s3,0x40(sp)
-patch=0,EE,202541CC,extended,7BB20030 // lq s2,0x30(sp)
-patch=0,EE,202541D0,extended,7BB10020 // lq s1,0x20(sp)
-patch=0,EE,202541D4,extended,7BB00010 // lq s0,0x10(sp)
-patch=0,EE,202541D8,extended,DFBF0000 // ld ra,0x0(sp)
-patch=0,EE,202541DC,extended,03E00008 // jr ra
-patch=0,EE,202541E0,extended,27BD0200 // addiu sp,sp,0x200
+patch=0,EE,202541C0,extended,7BBE0090 // lq fp,0x90(sp)
+patch=0,EE,202541C4,extended,7BB70080 // lq s7,0x80(sp)
+patch=0,EE,202541C8,extended,7BB60070 // lq s6,0x70(sp)
+patch=0,EE,202541CC,extended,7BB50060 // lq s5,0x60(sp)
+patch=0,EE,202541D0,extended,7BB40050 // lq s4,0x50(sp)
+patch=0,EE,202541D4,extended,7BB30040 // lq s3,0x40(sp)
+patch=0,EE,202541D8,extended,7BB20030 // lq s2,0x30(sp)
+patch=0,EE,202541DC,extended,7BB10020 // lq s1,0x20(sp)
+patch=0,EE,202541E0,extended,7BB00010 // lq s0,0x10(sp)
+patch=0,EE,202541E4,extended,DFBF0000 // ld ra,0x0(sp)
+patch=0,EE,202541E8,extended,03E00008 // jr ra
+patch=0,EE,202541EC,extended,27BD0200 // addiu sp,sp,0x200


### PR DESCRIPTION
This PR is an addendum to https://github.com/PCSX2/pcsx2_patches/pull/707. I had not realized that LEVEL_PLATFORM::Load (which this custom code hooks into) also gets executed when returning to a checkpoint within a level. We don't want to execute the failsafe in this case because this causes earlier chests in the level to get reclosed. Thankfully the custom function already accepts an argument which indicates whether or not this is the first load of a level, or a checkpoint. I also added in a bounds check for level ID to make sure this code isn't getting executed when in the hub level.

The checkpoint check is on line 81, and the level ID check is on lines 90-91.

