### PR TITLE
SLES-54587: Add NTSC Mode patch to Raw Danger (EU)

### DIFF
--- a/patches/SLES-54587_A98B5AD6.pnach
+++ b/patches/SLES-54587_A98B5AD6.pnach
@@ -15,3 +15,14 @@ author=Souzooka
 comment=Removes a problematic color grading filter effect that causes an incredible performance increase on both software and hardware rendering modes and also gives a sharper image to the game.
 patch=0,EE,202283C0,extended,03E00008
 patch=0,EE,202283C4,extended,00000000
+
+[NTSC Mode]
+author=Souzooka
+description=Runs game at 30FPS.
+
+// Point to a NTSC video config for boot
+patch=0,EE,2016E74C,extended,24637EE0 // addiu v1,v1,0x7EE0
+
+// Affects the position of pages for the color correction filter (ScrEffHue)
+patch=0,EE,20228D94,extended,2444008C // addiu a0,v0,0x8C
+patch=0,EE,20228D9C,extended,24450118 // addiu a1,v0,0x118


### PR DESCRIPTION
This PR converts an xdelta I had made a while back to run the PAL version of Raw Danger in NTSC Mode. The game logic targets 30fps, so this doesn't cause the game to feel "fast" (in contrast, the unmodified PAL game is "slow").

I do notice there is a minor screen position issue which causes a black area to appear on the very right of the image, however going into the options and setting Screen Position to X+01 correctly positions the game. I assume that the default screen position is slightly different between NTSC and PAL, so I might investigate this later and make an addendum to the patch when I do so.