### PR TITLE
Add display related patches for many arcade/fighting games + update existing patches

### DIFF
--- a/patches/SLPM-55184_E97030DF.pnach
+++ b/patches/SLPM-55184_E97030DF.pnach
@@ -1,6 +1,7 @@
-[No-Interlacing]
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-patch=1,EE,20101594,extended,00000000
+gametitle=Melty Blood: Act Cadenza (NTSC-J) (SLPM-55184)
 
-
+[Progressive Scan]
+author=Immersion95
+description=Enables progressive scan at boot
+patch=1,EE,201EC588,extended,0C07B3AC // Calls the game's official video-mode setup directly
+patch=1,EE,201EC58C,extended,24040001 // Forces the setup argument to progressive mode

--- a/patches/SLPM-62055_4D6DBB75.pnach
+++ b/patches/SLPM-62055_4D6DBB75.pnach
@@ -1,0 +1,10 @@
+gametitle=Bloody Roar 3 (Japan) (v1.02) (NTSC-J) (SLPM-62055)
+
+[No-Interlacing]
+author=Immersion95
+description=Disables interlacing
+patch=1,EE,201CE438,extended,34030001 // Sets SMODE2 to field mode
+patch=1,EE,201CE260,extended,240200DF // Forces DISPLAY height branch A to 224 lines
+patch=1,EE,201CE308,extended,240200DF // Forces DISPLAY height branch B to 224 lines
+patch=1,EE,201CF59C,extended,00000000 // Removes gameplay vertical field offset
+patch=1,EE,201CDAB0,extended,0000282D // Stabilizes FMV/generic field offset

--- a/patches/SLPM-62055_64328775.pnach
+++ b/patches/SLPM-62055_64328775.pnach
@@ -1,33 +1,11 @@
-gametitle=Bloody roar 3 jap SLPM_620.55 Game CRC = 0x64328775
+gametitle=Bloody Roar 3 (Japan) (v2.01) (NTSC-J) (SLPM-62055)
 
-
-// causes the game to hang with a black screen see issue #439
-
-
-
-//[No-Interlacing]
-//sinterlacemode=1
-//description=Enhancement test *480p mode + no interlacing
-
-//Progressive mode + No interlacing
-//patch=0,EE,201CE12C,extended,3c060050
-//patch=0,EE,201CE134,extended,3c070001
-//patch=0,EE,201CE310,extended,24020002
-
-//patch=0,EE,201F4658,extended,00833134
-//patch=0,EE,201F465C,extended,000DF4FF
-
-//patch=0,EE,201F4680,extended,00833134
-//patch=0,EE,201F4684,extended,000DF4FF
-
-//patch=0,EE,201F8E80,extended,00833134
-//patch=0,EE,201F8E84,extended,000DF4FF
-
-//Null Int Ints.
-//patch=0,EE,201CF688,extended,03E00008
-//patch=0,EE,201CF68C,extended,00000000
-//patch=0,EE,201CF710,extended,03E00008
-//patch=0,EE,201CF714,extended,00000000
-//patch=1,EE,201F8E94,byte,00
-
-
+[No-Interlacing]
+author=Immersion95
+description=Disables interlacing
+patch=1,EE,201CE590,extended,34030001 // Sets SMODE2 to field mode
+patch=1,EE,201F465C,extended,000DF9FF // Forces DISPLAY source A to 224 lines
+patch=1,EE,201F4684,extended,000DF9FF // Forces DISPLAY source B to 224 lines
+patch=1,EE,201F8E84,extended,000DF9FF // Forces alternate DISPLAY source to 224 lines
+patch=1,EE,201CF6F4,extended,00000000 // Removes gameplay vertical field offset
+patch=1,EE,201CDC08,extended,0000282D // Stabilizes FMV/generic field offset

--- a/patches/SLPM-62227_5BC8C9E8.pnach
+++ b/patches/SLPM-62227_5BC8C9E8.pnach
@@ -1,4 +1,20 @@
-gametitle=Marvel vs. Capcom 2: New Age of Heroes [NTSC-J] (SLPM-62227)
+gametitle=Marvel vs. Capcom 2: New Age of Heroes (NTSC-J) (SLPM-62227)
+
+[Native 480p / Full Frame Mode]
+author=felixthecat1970
+description=Enables the native 480p full-frame output path at 640x448; the doubled vertical resolution causes dithering to fit within PS2 VRAM
+patch=0,EE,003EE1D8,extended,24020002
+patch=0,EE,203EE1DC,extended,AC22F3C0
+patch=0,EE,203EE1EC,extended,AC20F3DC
+patch=0,EE,203EE714,extended,0000282D
+patch=0,EE,003EE718,extended,24060050
+patch=0,EE,203EE720,extended,24070001
+patch=0,EE,203EEB3C,extended,1040FFF6
+
+[Auto-Load Memory Card Fix]
+author=Immersion95
+description=Fixes Memory Card auto-load at startup for the Japanese retail version.
+patch=0,EE,20130470,extended,24020002 // MC main status 4: state 12 -> state 2; restores beta-like mapping and prevents silent boot auto-load abort
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -10,5 +26,3 @@ patch=1,EE,003dfad4,word,3C033F40
 patch=1,EE,003dfad8,word,03E00008
 patch=1,EE,003dfadC,word,AC830000
 patch=1,EE,003df440,word,3C023FE3
-
-

--- a/patches/SLPM-62690_52CDA025.pnach
+++ b/patches/SLPM-62690_52CDA025.pnach
@@ -1,0 +1,7 @@
+gametitle=Raiden III (NTSC-J) (SLPM-62690)
+
+[No-Interlacing]
+gsinterlacemode=1
+author=Immersion95
+description=Disables interlacing
+patch=1,EE,2010CF64,extended,00000000

--- a/patches/SLPM-65047_B54C0319.pnach
+++ b/patches/SLPM-65047_B54C0319.pnach
@@ -1,4 +1,19 @@
-gametitle=Capcom vs. SNK 2: Mark of the Millennium 2001  [NTSC-J] (SLPM-65047)
+gametitle=Capcom vs. SNK 2: Millionaire Fighting 2001 (NTSC-J) (SLPM-65047)
+
+[Native 480p / Full Frame Mode]
+author=felixthecat1970
+description=Enables the native 480p full-frame output path at 640x448; the doubled vertical resolution causes dithering to fit within PS2 VRAM
+patch=0,EE,20124540,extended,241B0002
+patch=0,EE,20134E44,extended,AC3B2990
+patch=0,EE,20134E48,extended,24020002
+patch=0,EE,20134E58,extended,AC2029AC
+patch=0,EE,20135370,extended,0000282D
+patch=0,EE,00135390,extended,00000050
+patch=0,EE,00100460,extended,00000050
+patch=0,EE,1010051C,extended,260202D0
+patch=0,EE,001005A0,extended,26450033
+patch=0,EE,101005C4,extended,64E30134
+patch=0,EE,20135848,extended,1040FFF4
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -11,5 +26,3 @@ patch=1,EE,00125034,word,3C033F40
 patch=1,EE,00125038,word,03E00008
 patch=1,EE,0012503C,word,AC830000
 patch=1,EE,0012492c,word,3C023FE3
-
-

--- a/patches/SLPM-65270_AB01411F.pnach
+++ b/patches/SLPM-65270_AB01411F.pnach
@@ -1,4 +1,11 @@
-gametitle=Virtua Fighter 4 - Evolution (J)(SLPM-65270)
+gametitle=Virtua Fighter 4: Evolution (NTSC-J) (SLPM-65270)
+
+[Interlaced Field Display Fix]
+author=felixthecat1970
+description=Switches gameplay to interlaced field mode for a stable progressive-like image in PCSX2 without true progressive scan
+patch=1,EE,202F82E4,extended,0000382D
+patch=1,EE,202F7F14,extended,00A32825
+patch=1,EE,202F7FB8,extended,00A32825
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -9,5 +16,3 @@ patch=1,EE,002fb184,word,3c194455 // 3c034420 hor fov
 patch=1,EE,002fb18c,word,37395555 // 44830800 hor fov
 patch=1,EE,002fb1a4,word,44990800 // 00000000
 patch=1,EE,00214918,word,3c024456 // 3c024420 renderfix
-
-

--- a/patches/SLPM-65331_E46BD847.pnach
+++ b/patches/SLPM-65331_E46BD847.pnach
@@ -1,9 +1,14 @@
-gametitle=RockMan X7 [NTSC-J] (SLPM-65331)
+gametitle=Rockman X7 (NTSC-J) (SLPM-65331)
+
+[No-Interlacing]
+gsinterlacemode=1
+author=Immersion95
+description=Disables interlacing
+patch=1,EE,201069D4,extended,00000000
+patch=1,EE,20106C3C,extended,00000000
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=nemesis2000
 
 patch=1,EE,0014cbc4,word,3c0244a8
-
-

--- a/patches/SLPM-65496_6C711F62.pnach
+++ b/patches/SLPM-65496_6C711F62.pnach
@@ -1,0 +1,6 @@
+gametitle=Hyper Street Fighter II: The Anniversary Edition (NTSC-J) (SLPM-65496)
+
+[No-Interlacing]
+author=Immersion95
+description=Disables interlaced offset rendering
+patch=1,EE,201907D8,extended,AC20268C

--- a/patches/SLPM-65621_65A15D7C.pnach
+++ b/patches/SLPM-65621_65A15D7C.pnach
@@ -1,0 +1,11 @@
+gametitle=Street Fighter III: 3rd Strike - Fight for the Future (NTSC-J) (SLPM-65621)
+
+[384x448 Display Fix]
+author=Immersion95
+description=Sets output to 384x448, matching the doubled CPS-3 384x224 layout. Best used at native/1x resolution.
+patch=1,EE,2038458C,extended,24080002 // Select internal 384x448 display path
+patch=1,EE,203833EC,extended,24030006 // 384 path: MAGH=6
+patch=1,EE,20383038,extended,24050A7F // DISPLAY write 1: DW=0x0A7F
+patch=1,EE,20383090,extended,24030A7F // DISPLAY write 2: DW=0x0A7F
+patch=1,EE,203831C0,extended,24030A7F // DISPLAY write 3: DW=0x0A7F
+patch=1,EE,203832F8,extended,24030A7F // DISPLAY write 4: DW=0x0A7F

--- a/patches/SLPM-65730_4FF01A82.pnach
+++ b/patches/SLPM-65730_4FF01A82.pnach
@@ -1,4 +1,13 @@
-gametitle=RockMan X8 [NTSC-J] (SLPM-65730)
+gametitle=Rockman X8 (NTSC-J) (SLPM-65730)
+
+[Progressive Scan]
+author=Immersion95
+description=Enables progressive scan at boot
+patch=1,EE,20255A2C,extended,24040002 // Forces the earliest video-mode setup argument to progressive mode
+patch=1,EE,202F047C,extended,24030002 // Forces the Capcom logo movie setup path to progressive mode
+patch=1,EE,202F071C,extended,24020002 // Keeps the Capcom logo movie loop on the progressive path
+patch=1,EE,202F08A0,extended,24040002 // Forces the boot video-mode setup argument to progressive mode
+patch=1,EE,202F0A10,extended,24020002 // Keeps the Capcom logo movie display restore on the progressive path
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -7,5 +16,3 @@ author=nemesis2000
 patch=1,EE,0010f10c,word,3c013f40 //hor value
 patch=1,EE,0010f110,word,44810000
 patch=1,EE,0010f118,word,4600c602
-
-

--- a/patches/SLPM-65998_BE34808C.pnach
+++ b/patches/SLPM-65998_BE34808C.pnach
@@ -1,0 +1,46 @@
+gametitle=Vampire: Darkstalkers Collection (NTSC-J) (SLPM-65998)
+
+[No Bilinear Filter + UV Fix - In-game]
+author=Immersion95
+description=Disables the game's final bilinear filter and fixes the final blit UVs during gameplay only, preventing the vertical and horizontal seams that would otherwise split the image into four quads. Best used at native/1x resolution.
+
+// Always-on option default: must stay outside the In-game joker because it fixes the FILTER option before the Display menu is opened
+patch=1,EE,20147230,extended,ACA00264 // Display option init: FILTER default OFF instead of ON; fixes bilinear being active until Display menu is opened
+
+// In-game / CPS-2 emulator active: [201C2600] == 0001 -> apply no bilinear + UV fix
+patch=1,EE,E0050001,extended,001C2600
+patch=1,EE,20147770,extended,240B0000 // Final blit: disables forced bilinear filtering
+patch=1,EE,201477D4,extended,24840000 // Final blit: aligns U end/right texture edge
+patch=1,EE,201477F0,extended,24840000 // Final blit: aligns V end/bottom texture edge
+patch=1,EE,20147874,extended,34020000 // Final blit: aligns U start/left texture edge
+patch=1,EE,2014787C,extended,34420000 // Final blit: aligns V start/top texture edge
+
+// Main menu / frontend active: [201C2600] == 0000 -> restore original no-bilinear/UV values
+patch=1,EE,E0050000,extended,001C2600
+patch=1,EE,20147770,extended,240B0060 // Final blit: restores original forced bilinear filtering value
+patch=1,EE,201477D4,extended,2484FFF8 // Final blit: restores original U end/right texture edge offset
+patch=1,EE,201477F0,extended,2484FFF8 // Final blit: restores original V end/bottom texture edge offset
+patch=1,EE,20147874,extended,3C020008 // Final blit: restores original U start/left texture edge offset, upper immediate
+patch=1,EE,2014787C,extended,34420008 // Final blit: restores original V start/top texture edge offset, lower immediate
+
+[CPS-2 384x448 Display Fix - In-game]
+author=Immersion95
+description=Sets CPS-2 gameplay to a pixel-perfect 384x448 output, matching the doubled 384x224 arcade layout. Best used at native/1x resolution.
+
+// In-game / CPS-2 emulator active: [201C2600] == 0001 -> apply display fix
+patch=1,EE,E0060001,extended,001C2600
+patch=1,EE,20147768,extended,240517F8 // Final blit: sets the final quad right edge to 383.5 pixels for a clean 384-wide output
+patch=1,EE,201479C8,extended,24030006 // GS DISPLAY: normal/interlace path mode value set for 384-wide output
+patch=1,EE,20147AE0,extended,24050A7F // GS DISPLAY: normal/interlace path, DW=0x0A7F with MAGH6 -> 384
+patch=1,EE,20147C04,extended,24050A7F // GS DISPLAY: alternate path, DW=0x0A7F with MAGH6 -> 384
+patch=1,EE,20147CB4,extended,2405047F // GS DISPLAY: progressive/special path, DW=0x047F with MAGH2 -> 384
+patch=1,EE,20147CC4,extended,3C050100 // GS DISPLAY: progressive/special path, fixed MAGH bits = 2 << 23 = 0x01000000
+
+// Main menu / frontend active: [201C2600] == 0000 -> restore original menu/display values
+patch=1,EE,E0060000,extended,001C2600
+patch=1,EE,20147768,extended,00052900 // Final blit: restores original computed right edge, undoing the 383.5px / clean 384-wide output override
+patch=1,EE,201479C8,extended,24030003 // GS DISPLAY: restores original normal/interlace path mode value
+patch=1,EE,20147AE0,extended,240509FF // GS DISPLAY: restores original normal DISPLAY path width value
+patch=1,EE,20147C04,extended,240509FF // GS DISPLAY: restores original alternate DISPLAY path width value
+patch=1,EE,20147CB4,extended,240504FF // GS DISPLAY: restores original progressive/special DISPLAY width value
+patch=1,EE,20147CC4,extended,3C050080 // GS DISPLAY: restores original progressive/special fixed MAGH bits = 1 << 23 = 0x00800000

--- a/patches/SLPM-66409_5E8C2465.pnach
+++ b/patches/SLPM-66409_5E8C2465.pnach
@@ -1,0 +1,43 @@
+gametitle=Street Fighter Zero: Fighters' Generation (NTSC-J) (SLPM-66409)
+
+[No Bilinear Filter + UV Fix - In-game]
+author=Immersion95
+description=Disables the game's final bilinear filter and fixes the final blit UVs during gameplay only, preventing the vertical and horizontal seams that would otherwise split the image into four quads. Best used at native/1x resolution.
+
+// In-game / CPS-2 emulator active: [201DC2B0] == 0001 -> apply no bilinear + UV fix
+patch=1,EE,E0050001,extended,001DC2B0
+patch=1,EE,201499C0,extended,240B0000 // Final blit: disables forced bilinear filtering
+patch=1,EE,20149A24,extended,24840000 // Final blit: aligns U end/right texture edge
+patch=1,EE,20149A40,extended,24840000 // Final blit: aligns V end/bottom texture edge
+patch=1,EE,20149AC4,extended,34020000 // Final blit: aligns U start/left texture edge
+patch=1,EE,20149ACC,extended,34420000 // Final blit: aligns V start/top texture edge
+
+// Main menu / frontend active: [201DC2B0] == 0000 -> restore original no-bilinear/UV values
+patch=1,EE,E0050000,extended,001DC2B0
+patch=1,EE,201499C0,extended,240B0060 // Final blit: restores original forced bilinear filtering value
+patch=1,EE,20149A24,extended,2484FFF8 // Final blit: restores original U end/right texture edge offset
+patch=1,EE,20149A40,extended,2484FFF8 // Final blit: restores original V end/bottom texture edge offset
+patch=1,EE,20149AC4,extended,3C020008 // Final blit: restores original U start/left texture edge offset, upper immediate
+patch=1,EE,20149ACC,extended,34420008 // Final blit: restores original V start/top texture edge offset, lower immediate
+
+[CPS-2 384x448 Display Fix - In-game]
+author=Immersion95
+description=Sets CPS-2 gameplay to a pixel-perfect 384x448 output, matching the doubled 384x224 arcade layout. Best used at native/1x resolution.
+
+// In-game / CPS-2 emulator active: [201DC2B0] == 0001 -> apply display fix
+patch=1,EE,E0060001,extended,001DC2B0
+patch=1,EE,201499B8,extended,240517F8 // Final blit: sets the final quad right edge to 383.5 pixels for a clean 384-wide output
+patch=1,EE,20149C18,extended,24030006 // GS DISPLAY: normal/interlace path mode value set for 384-wide output
+patch=1,EE,20149D2C,extended,24060A7F // GS DISPLAY: normal/interlace path, DW=0x0A7F with MAGH6 -> 384
+patch=1,EE,20149E70,extended,24050A7F // GS DISPLAY: alternate path, DW=0x0A7F with MAGH6 -> 384
+patch=1,EE,20149F20,extended,2405047F // GS DISPLAY: progressive/special path, DW=0x047F with MAGH2 -> 384
+patch=1,EE,20149F30,extended,3C050100 // GS DISPLAY: progressive/special path, fixed MAGH bits = 2 << 23 = 0x01000000
+
+// Main menu / frontend active: [201DC2B0] == 0000 -> restore original menu/display values
+patch=1,EE,E0060000,extended,001DC2B0
+patch=1,EE,201499B8,extended,00052900 // Final blit: restores original computed right edge, undoing the 383.5px / clean 384-wide output override
+patch=1,EE,20149C18,extended,24030003 // GS DISPLAY: restores original normal/interlace path mode value
+patch=1,EE,20149D2C,extended,2506FFFF // GS DISPLAY: restores original normal path width computation
+patch=1,EE,20149E70,extended,240509FF // GS DISPLAY: restores original alternate DISPLAY path width value
+patch=1,EE,20149F20,extended,240504FF // GS DISPLAY: restores original progressive/special DISPLAY width value
+patch=1,EE,20149F30,extended,3C050080 // GS DISPLAY: restores original progressive/special fixed MAGH bits = 1 << 23 = 0x00800000

--- a/patches/SLPM-68008_916E2EAA.pnach
+++ b/patches/SLPM-68008_916E2EAA.pnach
@@ -1,0 +1,8 @@
+gametitle=Virtua Fighter: 10th Anniversary (NTSC-J) (SLPM-68008)
+
+[No-Interlacing]
+gsinterlacemode=1
+author=Immersion95
+description=Disables interlacing
+patch=1,EE,201002E0,extended,24040000
+patch=1,EE,2010033C,extended,24040000

--- a/patches/SLPS-20003_63642E9F.pnach
+++ b/patches/SLPS-20003_63642E9F.pnach
@@ -1,4 +1,16 @@
-gametitle=Street Fighter EX3 (J)(SLPS-20003)
+gametitle=Street Fighter EX3 (NTSC-J) (SLPS-20003)
+
+[No-Interlacing]
+gsinterlacemode=1
+author=Immersion95
+description=Attempts to disable interlaced offset rendering.
+patch=1,EE,202678B0,extended,0000382D // Forces first sceGsSetHalfOffset field argument to 0
+patch=1,EE,202678F0,extended,0000382D // Forces second sceGsSetHalfOffset2 field argument to 0
+
+[Blur Removal]
+author=Immersion95
+description=Disables the fullscreen alpha blend pass
+patch=1,EE,20268358,extended,DF8297F0 // Disables alpha blending on the final fullscreen pass
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -6,5 +18,3 @@ author=nemesis2000
 patch=1,EE,002097dc,word,3c013f40 //00000000
 patch=1,EE,002097e0,word,44810000 //00000000
 patch=1,EE,002097e8,word,4600c602 //00000000
-
-

--- a/patches/SLPS-25026_82C02240.pnach
+++ b/patches/SLPS-25026_82C02240.pnach
@@ -1,4 +1,10 @@
-gametitle=Dead or Alive 2 - Hard*Core (SLPS_25026)
+gametitle=Dead or Alive 2: Hardcore (NTSC-J) (SLPS-25026)
+
+[No-Interlacing]
+gsinterlacemode=1
+author=Immersion95
+description=Disables interlacing
+patch=1,EE,203A5D2C,extended,24040000
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -7,5 +13,4 @@ patch=1,EE,204588D0,word,3F400000
 patch=1,EE,20459140,word,3F400000
 patch=1,EE,204599B0,word,3F400000
 patch=1,EE,2045A220,word,3F400000
-
 

--- a/patches/SLPS-25316_94834BD3.pnach
+++ b/patches/SLPS-25316_94834BD3.pnach
@@ -1,0 +1,6 @@
+gametitle=SNK vs. Capcom: SVC Chaos (NTSC-J) (SLPS-25316)
+
+[Progressive Scan]
+author=felixthecat1970
+description=Enables progressive scan at boot
+patch=0,EE,202E8C20,extended,24025000

--- a/patches/SLPS-25503_1D223324.pnach
+++ b/patches/SLPS-25503_1D223324.pnach
@@ -1,0 +1,7 @@
+gametitle=NeoGeo Online Collection Vol. 2: Bakumatsu Roman Gekka no Kenshi 1-2 (NTSC-J) (SLPS-25503)
+
+[240p Progressive Scan]
+author=felixthecat1970, Immersion95
+description=Forces progressive output for the menu and the gameplay
+patch=1,EE,E00182F0,extended,01FFEF20
+patch=1,EE,2013D9F8,extended,0000282D

--- a/patches/SLPS-25505_75C01A04.pnach
+++ b/patches/SLPS-25505_75C01A04.pnach
@@ -1,4 +1,10 @@
-gametitle=Namco x Capcom (NTSC-J)
+gametitle=Namco x Capcom (NTSC-J) (SLPS-25505)
+
+[No-Interlacing]
+gsinterlacemode=1
+author=felixthecat1970
+description=Disables interlacing
+patch=1,EE,201047F4,extended,00000000
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -23,5 +29,3 @@ patch=1,EE,00192DE0,word,24E772A0 //battles background // 24E76C00
 patch=1,EE,00192E54,word,250872A0 //battles background // 25086C00
 patch=1,EE,00192ECC,word,25086680 //battles background // 25086C00
 patch=1,EE,00192F3C,word,25296680 //battles background // 25296C00
-
-

--- a/patches/SLPS-25559_DB6BDD3C.pnach
+++ b/patches/SLPS-25559_DB6BDD3C.pnach
@@ -1,0 +1,11 @@
+gametitle=Samurai Spirits: Tenkaichi Kenkakuden (NTSC-J) (SLPS-25559)
+
+[240p Progressive Output]
+author=felixthecat1970
+description=Forces 640x224 progressive output; menus and backgrounds originally use a 640x448 framebuffer, so they are downscaled
+patch=0,EE,20303264,extended,34021400
+patch=0,EE,2030164C,extended,3C050000
+patch=0,EE,20301654,extended,3C060050
+patch=0,EE,2030165C,extended,3C070001
+patch=0,EE,20302D20,extended,03E00008
+patch=0,EE,20302D24,extended,00000000

--- a/patches/SLPS-25605_619E610B.pnach
+++ b/patches/SLPS-25605_619E610B.pnach
@@ -1,0 +1,9 @@
+gametitle=The King of Fighters Collection: The Orochi Saga (NTSC-J) (SLPS-25605)
+
+[No-Interlacing]
+gsinterlacemode=1
+author=umechan
+description=Disables interlacing
+patch=1,EE,202A8094,extended,00000000
+patch=1,EE,202A811C,extended,00000000
+patch=1,EE,2019F3B4,extended,35EF0000

--- a/patches/SLPS-25661_59A9AFA2.pnach
+++ b/patches/SLPS-25661_59A9AFA2.pnach
@@ -1,0 +1,7 @@
+gametitle=The King of Fighters NESTS Collection - KOF 2001 NeoGeo Version (NTSC-J) (SLPS-25661)
+
+[No-Interlacing - KOF 2001 NeoGeo Version]
+gsinterlacemode=1
+author=Immersion95
+description=No interlace
+patch=1,EE,2010202C,extended,00000000 // Removes vertical field offset

--- a/patches/SLPS-25661_709D7990.pnach
+++ b/patches/SLPS-25661_709D7990.pnach
@@ -1,0 +1,7 @@
+gametitle=The King of Fighters NESTS Collection - KOF 2000 NeoGeo Version (NTSC-J) (SLPS-25661)
+
+[No-Interlacing - KOF 2000 NeoGeo Version]
+gsinterlacemode=1
+author=Immersion95
+description=No interlace
+patch=1,EE,2010202C,extended,00000000 // Removes vertical field offset

--- a/patches/SLPS-25661_9FACED85.pnach
+++ b/patches/SLPS-25661_9FACED85.pnach
@@ -1,0 +1,7 @@
+gametitle=The King of Fighters NESTS Collection - KOF '99 NeoGeo Version (NTSC-J) (SLPS-25661)
+
+[No-Interlacing - KOF '99 NeoGeo Version]
+gsinterlacemode=1
+author=Immersion95
+description=No interlace
+patch=1,EE,2010202C,extended,00000000 // Removes vertical field offset

--- a/patches/SLUS-20130_72B3802A.pnach
+++ b/patches/SLUS-20130_72B3802A.pnach
@@ -1,4 +1,9 @@
-gametitle=Street Fighter EX 3 (SLUS-201301)
+gametitle=Street Fighter EX3 (NTSC-U) (SLUS-20130)
+
+[Blur Removal]
+author=Immersion95
+description=Disables the fullscreen alpha blend pass
+patch=1,EE,20145B8C,extended,DF89CE28 // Disables alpha blending on the final fullscreen pass
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -7,11 +12,9 @@ patch=1,EE,002e34d4,word,3c013f40
 patch=1,EE,002e34d8,word,44810000
 patch=1,EE,002e34e0,word,4600c602
 
-
 [No-Interlacing]
+author=asasega
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
 patch=1,EE,202E11FC,extended,00000000
 patch=1,EE,202E1284,extended,00000000
-
-

--- a/patches/SLUS-20246_15149318.pnach
+++ b/patches/SLUS-20246_15149318.pnach
@@ -1,4 +1,12 @@
-gametitle=Capcom vs SNK 2 (NTSC) (SLUS-20246)
+gametitle=Capcom vs. SNK 2: Mark of the Millennium 2001 (USA) (SLUS-20246)
+
+[Full Frame Mode]
+author=felixthecat1970
+description=Enables the native full-frame output path at 640x448; the doubled vertical resolution causes dithering to fit within PS2 VRAM
+patch=0,EE,20134DB4,extended,24020002
+patch=0,EE,20134DB8,extended,AC22EDD0
+patch=0,EE,20134DC8,extended,AC20EDEC
+patch=0,EE,0039A5B0,extended,02010206
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -138,12 +146,3 @@ author=gamemasterplc
 //patch=1,EE,103BAF58,extended,000000E0 //ADX Logo Copyright Symbol X Position (224)
 //patch=1,EE,103BAF6C,extended,00000168 //ADX Logo Copyright Text X Position (360)
 //patch=1,EE,103BAFC4,extended,000002A0 //Capcom vs SNK Demo Logo X Position (672)
-
-
-[No-Interlacing]
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-patch=1,EE,20101B74,extended,00000000
-patch=1,EE,20101DDC,extended,00000000
-
-

--- a/patches/SLUS-20486_4D228733.pnach
+++ b/patches/SLUS-20486_4D228733.pnach
@@ -1,4 +1,15 @@
-gametitle=Marvel vs. Capcom 2: New Age of Heroes (SLUS204.86;1)
+gametitle=Marvel vs. Capcom 2: New Age of Heroes (NTSC-U) (SLUS-20486)
+
+[Native 480p / Full Frame Mode]
+author=felixthecat1970
+description=Enables the native 480p full-frame output path at 640x448; the doubled vertical resolution causes dithering to fit within PS2 VRAM
+patch=0,EE,003EC218,extended,24020002
+patch=0,EE,203EC21C,extended,AC22BC00
+patch=0,EE,203EC22C,extended,AC20BC1C
+patch=0,EE,203EC754,extended,0000282D
+patch=0,EE,003EC758,extended,24060050
+patch=0,EE,203EC760,extended,24070001
+patch=0,EE,203ECB7C,extended,1040FFF6
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -10,12 +21,3 @@ patch=1,EE,003DDB14,word,3C033F40
 patch=1,EE,003DDB18,word,03E00008
 patch=1,EE,003DDB1C,word,AC830000
 patch=1,EE,003DD480,word,3C023FE3
-
-
-[No-Interlacing]
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-patch=1,EE,20101E5C,extended,00000000
-patch=1,EE,201020C4,extended,00000000
-
-

--- a/patches/SLUS-21317_72CE7A78.pnach
+++ b/patches/SLUS-21317_72CE7A78.pnach
@@ -1,0 +1,43 @@
+gametitle=Street Fighter Alpha Anthology (NTSC-U) (SLUS-21317)
+
+[No Bilinear Filter + UV Fix - In-game]
+author=Immersion95
+description=Disables the game's final bilinear filter and fixes the final blit UVs during gameplay only, preventing the vertical and horizontal seams that would otherwise split the image into four quads. Best used at native/1x resolution.
+
+// In-game / CPS-2 emulator active: [201DC2B0] == 0001 -> apply no bilinear + UV fix
+patch=1,EE,E0050001,extended,001DC2B0
+patch=1,EE,201499C0,extended,240B0000 // Final blit: disables forced bilinear filtering
+patch=1,EE,20149A24,extended,24840000 // Final blit: aligns U end/right texture edge
+patch=1,EE,20149A40,extended,24840000 // Final blit: aligns V end/bottom texture edge
+patch=1,EE,20149AC4,extended,34020000 // Final blit: aligns U start/left texture edge
+patch=1,EE,20149ACC,extended,34420000 // Final blit: aligns V start/top texture edge
+
+// Main menu / frontend active: [201DC2B0] == 0000 -> restore original no-bilinear/UV values
+patch=1,EE,E0050000,extended,001DC2B0
+patch=1,EE,201499C0,extended,240B0060 // Final blit: restores original forced bilinear filtering value
+patch=1,EE,20149A24,extended,2484FFF8 // Final blit: restores original U end/right texture edge offset
+patch=1,EE,20149A40,extended,2484FFF8 // Final blit: restores original V end/bottom texture edge offset
+patch=1,EE,20149AC4,extended,3C020008 // Final blit: restores original U start/left texture edge offset, upper immediate
+patch=1,EE,20149ACC,extended,34420008 // Final blit: restores original V start/top texture edge offset, lower immediate
+
+[CPS-2 384x448 Display Fix - In-game]
+author=Immersion95
+description=Sets CPS-2 gameplay to a pixel-perfect 384x448 output, matching the doubled 384x224 arcade layout. Best used at native/1x resolution.
+
+// In-game / CPS-2 emulator active: [201DC2B0] == 0001 -> apply display fix
+patch=1,EE,E0060001,extended,001DC2B0
+patch=1,EE,201499B8,extended,240517F8 // Final blit: sets the final quad right edge to 383.5 pixels for a clean 384-wide output
+patch=1,EE,20149C18,extended,24030006 // GS DISPLAY: normal/interlace path mode value set for 384-wide output
+patch=1,EE,20149D2C,extended,24060A7F // GS DISPLAY: normal/interlace path, DW=0x0A7F with MAGH6 -> 384
+patch=1,EE,20149E70,extended,24050A7F // GS DISPLAY: alternate path, DW=0x0A7F with MAGH6 -> 384
+patch=1,EE,20149F20,extended,2405047F // GS DISPLAY: progressive/special path, DW=0x047F with MAGH2 -> 384
+patch=1,EE,20149F30,extended,3C050100 // GS DISPLAY: progressive/special path, fixed MAGH bits = 2 << 23 = 0x01000000
+
+// Main menu / frontend active: [201DC2B0] == 0000 -> restore original menu/display values
+patch=1,EE,E0060000,extended,001DC2B0
+patch=1,EE,201499B8,extended,00052900 // Final blit: restores original computed right edge, undoing the 383.5px / clean 384-wide output override
+patch=1,EE,20149C18,extended,24030003 // GS DISPLAY: restores original normal/interlace path mode value
+patch=1,EE,20149D2C,extended,2506FFFF // GS DISPLAY: restores original normal path width computation
+patch=1,EE,20149E70,extended,240509FF // GS DISPLAY: restores original alternate DISPLAY path width value
+patch=1,EE,20149F20,extended,240504FF // GS DISPLAY: restores original progressive/special DISPLAY width value
+patch=1,EE,20149F30,extended,3C050080 // GS DISPLAY: restores original progressive/special fixed MAGH bits = 1 << 23 = 0x00800000


### PR DESCRIPTION
# PR summary

This PR adds several display-related patches for PS2 arcade/fighting titles.

The additions include mostly no-interlacing fixes, progressive scan modes, and CPS pixel-perfect 384x448 display fixes.

I spent a lot of time making and testing these `.pnach` patches, and I am very satisfied with the final results :).

_Those Bloody Roar 3 patches were horrendous to make :p._

## Codes added

### New files

| File | Game | Added |
|---|---|---|
| `SLPM-62055_4D6DBB75.pnach` | Bloody Roar 3 v1.02 JP | No interlace |
| `SLPM-65496_6C711F62.pnach` | Hyper Street Fighter II JP | No interlace offset (especially needed for higher resolution where it's noticeable) |
| `SLPS-25503_1D223324.pnach` | NeoGeo Online Collection Vol. 2: Last Blade 1-2 JP | 240p progressive scan |
| `SLPM-62690_52CDA025.pnach` | Raiden III JP | No interlace |
| `SLPS-25559_DB6BDD3C.pnach` | Samurai Spirits: Tenkaichi Kenkakuden JP | 240p progressive scan |
| `SLPS-25316_94834BD3.pnach` | SNK vs. Capcom: SVC Chaos JP | Official progressive scan |
| `SLUS-21317_72CE7A78.pnach` | Street Fighter Alpha Anthology US | No bilinear filter + UV fix + 384x448 CPS pixel-perfect display fix |
| `SLPM-65621_65A15D7C.pnach` | Street Fighter III: 3rd Strike JP | 384x448 CPS pixel-perfect display fix |
| `SLPM-66409_5E8C2465.pnach` | Street Fighter Zero: Fighters’ Generation JP | No bilinear filter + UV fix + 384x448 CPS pixel-perfect display fix |
| `SLPS-25605_619E610B.pnach` | The King of Fighters Collection: The Orochi Saga JP | No interlace |
| `SLPS-25661_9FACED85.pnach` | The King of Fighters NESTS Collection - KOF ’99 NeoGeo Version JP | No interlace offset (especially needed for higher resolution where it's noticeable) |
| `SLPS-25661_709D7990.pnach` | The King of Fighters NESTS Collection - KOF 2000 NeoGeo Version JP | No interlace offset (especially needed for higher resolution where it's noticeable) |
| `SLPS-25661_59A9AFA2.pnach` | The King of Fighters NESTS Collection - KOF 2001 NeoGeo Version JP | No interlace offset (especially needed for higher resolution where it's noticeable) |
| `SLPM-65998_BE34808C.pnach` | Vampire: Darkstalkers Collection JP | No bilinear filter + UV fix + 384x448 CPS pixel-perfect display fix |
| `SLPM-68008_916E2EAA.pnach` | Virtua Fighter: 10th Anniversary JP | No interlace |

### Existing files modified

| File | Game | Added / changed |
|---|---|---|
| `SLPM-62055_64328775.pnach` | Bloody Roar 3 v2.01 JP | No interlace |
| `SLPM-65047_B54C0319.pnach` | Capcom vs. SNK 2 JP | Native 480p / full frame mode |
| `SLUS-20246_15149318.pnach` | Capcom vs. SNK 2 US | Full frame mode |
| `SLPS-25026_82C02240.pnach` | Dead or Alive 2: Hardcore JP | No interlace |
| `SLPM-62227_5BC8C9E8.pnach` | Marvel vs. Capcom 2 JP | Native 480p / full frame mode + auto-load memory card fix |
| `SLUS-20486_4D228733.pnach` | Marvel vs. Capcom 2 US | Native 480p / full frame mode |
| `SLPM-55184_E97030DF.pnach` | Melty Blood: Act Cadenza JP | Official progressive scan |
| `SLPS-25505_75C01A04.pnach` | Namco x Capcom JP | No interlace |
| `SLPM-65331_E46BD847.pnach` | Rockman X7 JP | No interlace |
| `SLPM-65730_4FF01A82.pnach` | Rockman X8 JP | Official progressive scan |
| `SLPS-20003_63642E9F.pnach` | Street Fighter EX3 JP | No interlace + blur removal |
| `SLUS-20130_72B3802A.pnach` | Street Fighter EX3 US | Blur removal |
| `SLPM-65270_AB01411F.pnach` | Virtua Fighter 4: Evolution JP | Interlaced field display fix |

## CPS pixel-perfect 384x448 fixes

The 384x448 fixes are intended to make the CPS-based games render with their pixel-perfect 384x224 presentation.

These fixes are especially useful for:

- Street Fighter Alpha Anthology
- Street Fighter III: 3rd Strike
- Street Fighter Zero: Fighters’ Generation
- Vampire: Darkstalkers Collection

These games use a 640x448 PS2 output resolution, which makes it impossible to get a proper pixel-perfect result at native resolution. On top of that, these titles also show visible artifacts when upscaled in PCSX2, so neither native resolution nor regular upscaling provides a good gameplay experience. The 384x448 display fixes give a much cleaner result by matching the original CPS-style image more accurately and avoiding the usual scaling artifacts.

## Marvel vs. Capcom 2 - Memory Card Auto-loading fix

The Japanese retail version of Marvel vs. Capcom 2 has a Memory Card auto-loading issue. This bug is only present in the Japanese retail release; it does not happen in the USA or European retail versions, and it is also not present in the Japanese beta. During startup, the game can think the Memory Card loading step is already finished too early, so the save data is not loaded automatically. This patch fixes that startup state so the game waits for the proper Memory Card result and auto-loads the save correctly.

## Official progressive scan patches

Official progressive scan support was added for:

- Melty Blood: Act Cadenza
- Rockman X8
- SNK vs. Capcom: SVC Chaos

No need to press Triangle+Cross at startup :).

## Codes removed

| File | Game | Removed |
|---|---|---|
| `SLUS-20246_15149318.pnach` | Capcom vs. SNK 2 US | Old no-interlacing hack removed and replaced with full frame mode |
| `SLUS-20486_4D228733.pnach` | Marvel vs. Capcom 2 US | Old no-interlacing hack removed and replaced with native 480p / full frame mode |
| `SLPM-55184_E97030DF.pnach` | Melty Blood: Act Cadenza JP | Old no-interlacing hack removed and replaced with official progressive scan |

## Thanks

Special thanks to felixthecat1970 and umechan for their existing patches.

I especially want to thank [felixthecat1970](https://github.com/felixthecat1970), because his codes were very instructive and helped me understand how to approach several of these display and progressive-scan fixes.

### felixthecat1970

- `SLPM-65047_B54C0319.pnach` - Capcom vs. SNK 2 JP - Native 480p / full frame mode
- `SLUS-20246_15149318.pnach` - Capcom vs. SNK 2 US - Full frame mode
- `SLPM-62227_5BC8C9E8.pnach` - Marvel vs. Capcom 2 JP - Native 480p / full frame mode
- `SLUS-20486_4D228733.pnach` - Marvel vs. Capcom 2 US - Native 480p / full frame mode
- `SLPS-25505_75C01A04.pnach` - Namco x Capcom JP - No interlace
- `SLPS-25503_1D223324.pnach` - NeoGeo Online Collection Vol. 2: Last Blade 1-2 JP - 240p progressive scan
- `SLPS-25559_DB6BDD3C.pnach` - Samurai Spirits: Tenkaichi Kenkakuden JP - 240p progressive output
- `SLPS-25316_94834BD3.pnach` - SNK vs. Capcom: SVC Chaos JP - Official progressive scan
- `SLPM-65270_AB01411F.pnach` - Virtua Fighter 4: Evolution JP - Interlaced field display fix

### umechan

- `SLPS-25605_619E610B.pnach` - The King of Fighters Collection: The Orochi Saga JP - No interlace
