### PR TITLE
Remove GTA Stories No-Interlacing patches

### DIFF
--- a/patches/SLES-54135_D693D4CF.pnach
+++ b/patches/SLES-54135_D693D4CF.pnach
@@ -65,3 +65,9 @@ patch=1,EE,203D8DAA,byte,1
 author=Snake356
 description=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
 patch=1,EE,202D9384,word,00000000 //14820017
+
+[No-Interlacing]
+author=Mensa; ported by CRASHARKI
+description=Attempts to disable interlaced offset rendering.
+gsinterlacemode=1
+patch=1,EE,2035F394,word,00000000 //64420008

--- a/patches/SLES-54135_D693D4CF.pnach
+++ b/patches/SLES-54135_D693D4CF.pnach
@@ -66,8 +66,9 @@ author=Snake356
 description=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
 patch=1,EE,202D9384,word,00000000 //14820017
 
-[No-Interlacing]
-author=Mensa; ported by CRASHARKI
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-patch=1,EE,2035F394,word,00000000 //64420008
+//The following patch was discarded as it was deemed unnecessary:
+//[No-Interlacing]
+//author=Mensa; ported by CRASHARKI
+//description=Attempts to disable interlaced offset rendering.
+//gsinterlacemode=1
+//patch=1,EE,2035F394,word,00000000 //64420008

--- a/patches/SLES-54622_B3AD1EA4.pnach
+++ b/patches/SLES-54622_B3AD1EA4.pnach
@@ -24,3 +24,9 @@ patch=1,EE,21FB5830,byte,1
 author=Snake356
 description=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
 patch=1,EE,203704F4,word,00000000 //14820019
+
+[No-Interlacing]
+author=Mensa; ported by CRASHARKI
+description=Attempts to disable interlaced offset rendering.
+gsinterlacemode=1
+patch=1,EE,204481E4,word,00000000 //64420008

--- a/patches/SLES-54622_B3AD1EA4.pnach
+++ b/patches/SLES-54622_B3AD1EA4.pnach
@@ -25,8 +25,9 @@ author=Snake356
 description=Patches the game to run at 50 FPS (Might need 180% EE Overclock to be stable).
 patch=1,EE,203704F4,word,00000000 //14820019
 
-[No-Interlacing]
-author=Mensa; ported by CRASHARKI
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-patch=1,EE,204481E4,word,00000000 //64420008
+//The following patch was discarded as it was deemed unnecessary:
+//[No-Interlacing]
+//author=Mensa; ported by CRASHARKI
+//description=Attempts to disable interlaced offset rendering.
+//gsinterlacemode=1
+//patch=1,EE,204481E4,word,00000000 //64420008

--- a/patches/SLUS-21423_7EA439F5.pnach
+++ b/patches/SLUS-21423_7EA439F5.pnach
@@ -66,8 +66,9 @@ author=asasega
 description=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
 patch=1,EE,202D92C4,word,00000000 //14820017
 
-[No-Interlacing]
-author=Mensa
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-patch=1,EE,2035F1B4,word,00000000
+//The following patch was discarded as it was deemed unnecessary:
+//[No-Interlacing]
+//author=Mensa
+//description=Attempts to disable interlaced offset rendering.
+//gsinterlacemode=1
+//patch=1,EE,2035F1B4,word,00000000

--- a/patches/SLUS-21423_7EA439F5.pnach
+++ b/patches/SLUS-21423_7EA439F5.pnach
@@ -58,7 +58,7 @@ patch=1,EE,00291990,word,44810000
 patch=1,EE,00291994,word,0c0820e8
 patch=1,EE,00291998,word,46006302
 
-//Force widescreen from the begginning
+//Force widescreen from the start
 patch=1,EE,203D8B8A,byte,1
 
 [60 FPS]
@@ -66,8 +66,8 @@ author=asasega
 description=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
 patch=1,EE,202D92C4,word,00000000 //14820017
 
-[No Interlacing]
+[No-Interlacing]
 author=Mensa
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-patch=1,EE,2035F1B4,extended,00000001
+patch=1,EE,2035F1B4,word,00000000

--- a/patches/SLUS-21590_4F32A11F.pnach
+++ b/patches/SLUS-21590_4F32A11F.pnach
@@ -25,8 +25,9 @@ author=asasega
 description=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
 patch=1,EE,20370314,word,00000000
 
-[No-Interlacing]
-author=Mensa
-description=Attempts to disable interlaced offset rendering.
-gsinterlacemode=1
-patch=1,EE,20447EDC,word,00000000
+//The following patch was discarded as it was deemed unnecessary:
+//[No-Interlacing]
+//author=Mensa
+//description=Attempts to disable interlaced offset rendering.
+//gsinterlacemode=1
+//patch=1,EE,20447EDC,word,00000000

--- a/patches/SLUS-21590_4F32A11F.pnach
+++ b/patches/SLUS-21590_4F32A11F.pnach
@@ -25,8 +25,8 @@ author=asasega
 description=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
 patch=1,EE,20370314,word,00000000
 
-[No Interlacing]
+[No-Interlacing]
 author=Mensa
 description=Attempts to disable interlaced offset rendering.
 gsinterlacemode=1
-patch=1,EE,20112B24,extended,00000001
+patch=1,EE,20447EDC,word,00000000


### PR DESCRIPTION
The original submission had several issues:
- The [No-Interlacing] tags were wrongly written as [No Interlacing] making them not work with the global enabler.
- The values were changed from 0 to 1.
- GTA Vice City Stories wasn't even using the right patch, it was using GTA Vice City's patch.

So I fixed these issues and also ported the patches to PAL versions.