### PR TITLE
The Simpsons Hit & Run patches improvements

### DIFF
--- a/patches/SLES-51897_73E68475.pnach
+++ b/patches/SLES-51897_73E68475.pnach
@@ -2,15 +2,23 @@ gametitle=The Simpsons - Hit & Run (PAL-M4) (SLES-51897) 73E68475
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=ElHecht
+author=ElHecht & PeterDelta
 description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
-// 16:9 ver
+// 16:9 ver- by ElHecht
 patch=1,EE,00138ab8,word,00000000 // 10400005 Interiors and fixed camera angles
 patch=1,EE,0014b3a8,word,00000000 // 10400004 Gameplay Height
 patch=1,EE,0014c3ac,word,00000000 // 10400004 ???
 patch=1,EE,002a1f88,word,00000000 // 10400004 Multiplayer Height
 //patch=1,EE,0031e0b8,word,00000000 // 10400004 3D HUD (it becomes misaligned and goes off the screen)
 patch=1,EE,0031eea4,word,00000000 // 10400004 Main Menu
+// Zoom values by PeterDelta
+patch=0,EE,001EE7C4,word,3C013F00 //3C013E80
+patch=0,EE,0031E21C,word,3C013F00 //3C013E80
+patch=0,EE,0031E1C0,word,3C013F40 //3C013F80
+patch=0,EE,0032CE04,word,3C013F88 //3C013F80
+patch=0,EE,003559F8,word,3C013F92 //3C013F80
+patch=0,EE,0036FB0C,word,3C013F1D //3C013F00
+patch=0,EE,00418790,word,3C01BFC7 //3C01BF80
 
 [480p Mode]
 gsinterlacemode=1

--- a/patches/SLES-51897_73E68475.pnach
+++ b/patches/SLES-51897_73E68475.pnach
@@ -3,19 +3,19 @@ gametitle=The Simpsons - Hit & Run (PAL-M4) (SLES-51897) 73E68475
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-description=Widescreen Hack
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
 // 16:9 ver
-patch=1,EE,00138ab8,word,00000000 // 10400005
-patch=1,EE,0014b3a8,word,00000000 // 10400004
-patch=1,EE,0014c3ac,word,00000000 // 10400004
-patch=1,EE,002a1f88,word,00000000 // 10400004
-patch=1,EE,0031e0b8,word,00000000 // 10400004
-patch=1,EE,0031eea4,word,00000000 // 10400004
+patch=1,EE,00138ab8,word,00000000 // 10400005 Interiors and fixed camera angles
+patch=1,EE,0014b3a8,word,00000000 // 10400004 Gameplay Height
+patch=1,EE,0014c3ac,word,00000000 // 10400004 ???
+patch=1,EE,002a1f88,word,00000000 // 10400004 Multiplayer Height
+//patch=1,EE,0031e0b8,word,00000000 // 10400004 3D HUD (it becomes misaligned and goes off the screen)
+patch=1,EE,0031eea4,word,00000000 // 10400004 Main Menu
 
 [480p Mode]
 gsinterlacemode=1
 author=PeterDelta
 description=SDTV 480p mode at start. Might need EE Overclock (130%)
-patch=1,EE,00406524,word,24110000
-patch=1,EE,00406528,word,24120050
-patch=1,EE,00406534,word,24130001
+patch=1,EE,00406524,word,24110000 // 00058C03
+patch=1,EE,00406528,word,24120050 // 00069403
+patch=1,EE,00406534,word,24130001 // 00079C03

--- a/patches/SLUS-20624_FC99EC8C.pnach
+++ b/patches/SLUS-20624_FC99EC8C.pnach
@@ -2,15 +2,23 @@ gametitle=The Simpsons - Hit & Run (NTSC-U)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=ElHecht
+author=ElHecht & PeterDelta
 description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
-// 16:9 ver
+// 16:9 ver- by ElHecht
 patch=1,EE,00138a88,word,00000000 // 10400005 Interiors and fixed camera angles
 patch=1,EE,0014b360,word,00000000 // 10400004 Gameplay Height
 patch=1,EE,0014b364,word,00000000 // 10400004 ???
 patch=1,EE,002a0b38,word,00000000 // 10400004 Multiplayer Height
 //patch=1,EE,0031c888,word,00000000 // 10400004 3D HUD (it becomes misaligned and goes off the screen)
 patch=1,EE,0031d674,word,00000000 // 10400004 Main Menu
+// Zoom values by PeterDelta
+patch=0,EE,001ED69C,word,3C013F00 //3C013E80
+patch=0,EE,0031C9EC,word,3C013F00 //3C013E80
+patch=0,EE,0031C990,word,3C013F40 //3C013F80
+patch=0,EE,0032B5D4,word,3C013F88 //3C013F80
+patch=0,EE,00354208,word,3C013F92 //3C013F80
+patch=0,EE,0037E9DC,word,3C013F1D //3C013F00
+patch=0,EE,00416D50,word,3C01BFC7 //3C01BF80
 
 [480p Mode]
 gsinterlacemode=1

--- a/patches/SLUS-20624_FC99EC8C.pnach
+++ b/patches/SLUS-20624_FC99EC8C.pnach
@@ -3,13 +3,19 @@ gametitle=The Simpsons - Hit & Run (NTSC-U)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-
+description=Patches the game to run at 16:9 Widescreen Aspect Ratio.
 // 16:9 ver
-patch=1,EE,00138a88,word,00000000 // 10400005
-patch=1,EE,0014b360,word,00000000 // 10400004
-patch=1,EE,0014b364,word,00000000 // 10400004
-patch=1,EE,002a0b38,word,00000000 // 10400004
-patch=1,EE,0031c888,word,00000000 // 10400004
-patch=1,EE,0031d674,word,00000000 // 10400004
+patch=1,EE,00138a88,word,00000000 // 10400005 Interiors and fixed camera angles
+patch=1,EE,0014b360,word,00000000 // 10400004 Gameplay Height
+patch=1,EE,0014b364,word,00000000 // 10400004 ???
+patch=1,EE,002a0b38,word,00000000 // 10400004 Multiplayer Height
+//patch=1,EE,0031c888,word,00000000 // 10400004 3D HUD (it becomes misaligned and goes off the screen)
+patch=1,EE,0031d674,word,00000000 // 10400004 Main Menu
 
-
+[480p Mode]
+gsinterlacemode=1
+author=PeterDelta; ported by CRASHARKI
+description=SDTV 480p mode at start. Might need EE Overclock (130%)
+patch=1,EE,00404ACC,word,24110000 // 00058C03
+patch=1,EE,00404AD0,word,24120050 // 00069403
+patch=1,EE,00404ADC,word,24130001 // 00079C03


### PR DESCRIPTION
Changes:
- Ported the 480p Mode patch from PAL to NTSC-U.
- Added comments to what each line of the widescreen patch does (there's one I couldn't figure out).
- Commented out the line for 3D HUD, as it was misaligning it (see example below; note the coin in the upper right corner).

Before (3D HUD change):
<img width="796" height="448" alt="The Simpsons - Hit   Run_SLUS-20624_20260513110547" src="https://github.com/user-attachments/assets/71e79612-ffb0-4050-a92d-81b08a987ea5" />

After (3D HUD change):
<img width="796" height="448" alt="The Simpsons - Hit   Run_SLUS-20624_20260513110646" src="https://github.com/user-attachments/assets/f963fcaf-0a7e-43b4-8285-7080d52305aa" />

All tested.

Update: Added the zoom values found by PeterDelta so it's Hor+ instead of Ver-. All tested too.