### PR TITLE
Dynasty Warriors 4 patches: Fix vertical lines when upscaling

### DIFF
--- a/patches/SLUS-20653_6C89132B.pnach
+++ b/patches/SLUS-20653_6C89132B.pnach
@@ -9,7 +9,7 @@ patch=1,EE,00183dc0,word,3c023f2b
 
 [Fix vertical lines when upscaling]
 description=Fixes missing vertical lines down the screen when upscaling, caused by DW games rendering into ten, vertical slices of equal width; the fix reduces this to a single rectangle.
-author=MichaelMusou
+author=MichaelMusou, ported from DW4:XL by ConorJS
 patch=1,EE,0012cef4,word,2AA20001
 patch=1,EE,0012ce14,word,24090280
 patch=1,EE,0012ce74,word,24090280

--- a/patches/SLUS-20653_6C89132B.pnach
+++ b/patches/SLUS-20653_6C89132B.pnach
@@ -8,7 +8,7 @@ patch=1,EE,00183dc0,word,3c023f2b
 
 
 [Fix vertical lines when upscaling]
-description=Fixes missing vertical lines down the screen when upscaling, caused by DW games rendering at a non-standard, wider-than-usual horizontal resolution.
+description=Fixes missing vertical lines down the screen when upscaling, caused by DW games rendering into ten, vertical slices of equal width; the fix reduces this to a single rectangle.
 author=MichaelMusou
 patch=1,EE,0012cef4,word,2AA20001
 patch=1,EE,0012ce14,word,24090280

--- a/patches/SLUS-20653_6C89132B.pnach
+++ b/patches/SLUS-20653_6C89132B.pnach
@@ -7,3 +7,14 @@ patch=1,EE,00136f30,word,3c0243d6
 patch=1,EE,00183dc0,word,3c023f2b
 
 
+[Fix vertical lines when upscaling]
+description=Fixes missing vertical lines down the screen when upscaling, caused by DW games rendering at a non-standard, wider-than-usual horizontal resolution.
+author=MichaelMusou
+patch=1,EE,0012cef4,word,2AA20001
+patch=1,EE,0012ce14,word,24090280
+patch=1,EE,0012ce74,word,24090280
+patch=1,EE,0012ce50,word,26020940
+patch=1,EE,0012ceb4,word,26020940
+patch=1,EE,0012d0a8,word,2A220001
+patch=1,EE,0012d02c,word,24090280
+patch=1,EE,0012d078,word,26620940

--- a/patches/SLUS-20812_96C20D6F.pnach
+++ b/patches/SLUS-20812_96C20D6F.pnach
@@ -15,3 +15,20 @@ patch=1,EE,2010248c,word,64420000
 patch=1,EE,2012EE28,word,30420000
 
 
+[Fix vertical lines when upscaling]
+description=Fixes missing vertical lines down the screen when upscaling, caused by DW games rendering at a non-standard, wider-than-usual horizontal resolution.
+author=MichaelMusou
+patch=1,EE,0012f8a4,word,2AA20001
+patch=1,EE,0012f7c4,word,24090280
+patch=1,EE,0012f824,word,24090280
+patch=1,EE,0012f800,word,26020940
+patch=1,EE,0012f864,word,26020940
+patch=1,EE,0012fa58,word,2A220001
+patch=1,EE,0012f9dc,word,24090280
+patch=1,EE,0012fa28,word,26620940
+
+
+[Load original (Enables Musou and Free modes)]
+description=DW4XL contains all files required to play Musou/Free modes - this unhides them
+author=SomberTwilight
+patch=1,EE,00363014,word,00000001

--- a/patches/SLUS-20812_96C20D6F.pnach
+++ b/patches/SLUS-20812_96C20D6F.pnach
@@ -16,7 +16,7 @@ patch=1,EE,2012EE28,word,30420000
 
 
 [Fix vertical lines when upscaling]
-description=Fixes missing vertical lines down the screen when upscaling, caused by DW games rendering at a non-standard, wider-than-usual horizontal resolution.
+description=Fixes missing vertical lines down the screen when upscaling, caused by DW games rendering into ten, vertical slices of equal width; the fix reduces this to a single rectangle.
 author=MichaelMusou
 patch=1,EE,0012f8a4,word,2AA20001
 patch=1,EE,0012f7c4,word,24090280

--- a/patches/SLUS-20812_96C20D6F.pnach
+++ b/patches/SLUS-20812_96C20D6F.pnach
@@ -30,5 +30,5 @@ patch=1,EE,0012fa28,word,26620940
 
 [Load original (Enables Musou and Free modes)]
 description=DW4XL contains all files required to play Musou/Free modes - this unhides them
-author=SomberTwilight
+author=MichaelMusou
 patch=1,EE,00363014,word,00000001

--- a/patches/SLUS-21299_A719D130.pnach
+++ b/patches/SLUS-21299_A719D130.pnach
@@ -17,4 +17,5 @@ patch=1,EE,201427D0,word,30420000
 
 [Load original (Enables Musou and Free modes)]
 description=Dw5xl contains all files required to play Musou/Free modes, This mod unhides Musou/Free mode.
+author=MichaelMusou
 patch=1,EE,001abed4,word,24020001


### PR DESCRIPTION
### Vertical Lines Bug

~~Dynasty Warriors games on PS2 render at a slightly-wider than standard resolution, which causes the hardware renderer (when upscaling) to drop/crush vertical lines at regular intervals~~. **Correction (from MichaelMusou):** Dynasty Warriors games on PS2 render using multiple (10) vertical slices, which doesn't play well with upscaling. MichaelMusou's patch fixes this by changing rendering to target a single rectangle (the size of the screen).

The issue has been raised in the past for DW4(XL): 
- https://github.com/PCSX2/pcsx2/issues/12908
- https://github.com/PCSX2/pcsx2/issues/2614
- https://github.com/PCSX2/pcsx2/issues/3810

The issue exists for other PS2 Dynasty Warriors games: DW3(XL), DW4 Empires, DW5(XL, Empires), but I don't own these, and only asked permission for permission to include the DW4 patch from the original author. PCSX2's policy seems to be that problems with upscaling (which this is) are not "issues" in the strict sense, so shouldn't be raised as such. Nevertheless, this additional enhancement work exists if owner(s) of any of these games are willing to seek permission and carry it out.

The same instructions are applied to both DW4 and DW4:XL at different addresses:

DW4 (ported by me from the original DW4:XL patch)
```ini
[Fix vertical lines when upscaling]
description=Fixes missing vertical lines down the screen when upscaling, caused by DW games rendering at a non-standard, wider-than-usual horizontal resolution.
author=MichaelMusou, ported from DW4:XL by ConorJS
patch=1,EE,0012cef4,word,2AA20001
patch=1,EE,0012ce14,word,24090280
patch=1,EE,0012ce74,word,24090280
patch=1,EE,0012ce50,word,26020940
patch=1,EE,0012ceb4,word,26020940
patch=1,EE,0012d0a8,word,2A220001
patch=1,EE,0012d02c,word,24090280
patch=1,EE,0012d078,word,26620940
```

DW4:XL
```ini
[Fix vertical lines when upscaling]
description=Fixes missing vertical lines down the screen when upscaling, caused by DW games rendering at a non-standard, wider-than-usual horizontal resolution.
author=MichaelMusou
patch=1,EE,0012f8a4,word,2AA20001
patch=1,EE,0012f7c4,word,24090280
patch=1,EE,0012f824,word,24090280
patch=1,EE,0012f800,word,26020940
patch=1,EE,0012f864,word,26020940
patch=1,EE,0012fa58,word,2A220001
patch=1,EE,0012f9dc,word,24090280
patch=1,EE,0012fa28,word,26620940
```

Before:
<img width="3840" height="2160" alt="1b" src="https://github.com/user-attachments/assets/eee5d2a4-ed49-4001-a438-24e1f2a78414" />

After:
<img width="3840" height="2160" alt="1a" src="https://github.com/user-attachments/assets/74b3878c-a650-4a1d-90a0-1c49749b6b44" />

---

### Patch to skip "Load Original"

This step has to be performed every time the console is powered on, when playing the XL version. The same patch (in effect) was already applied to DW5:XL here: https://github.com/PCSX2/pcsx2_patches/pull/346.

```ini
[Load original (Enables Musou and Free modes)]
description=DW4XL contains all files required to play Musou/Free modes - this unhides them
author=MichaelMusou
patch=1,EE,00363014,word,00000001
```