### PR TITLE
Add and improve patches to Max Payne 2

### DIFF
--- a/patches/SLES-51954_564F352C.pnach
+++ b/patches/SLES-51954_564F352C.pnach
@@ -3,7 +3,7 @@ gametitle=Max Payne 2 - The Fall of Max Payne (PAL-E) SLES-51954 564F352C
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PeterDelta, Arapapa & CRASHARKI
-description=Enable enhanced native widescreen.
+description=Enable enhanced native widescreen. (Original widescreen uses vertical cropping; Enhanced expands the horizontal view.)
 patch=1,EE,005996C8,extended,00000010 //00000004
 patch=1,EE,005996D0,extended,00000009 //00000003
 //Zoom fix (Internal widescreen) by Arapapa & CRASHARKI

--- a/patches/SLES-51954_564F352C.pnach
+++ b/patches/SLES-51954_564F352C.pnach
@@ -2,14 +2,19 @@ gametitle=Max Payne 2 - The Fall of Max Payne (PAL-E) SLES-51954 564F352C
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=PeterDelta
-description=Enable native widescreen
+author=PeterDelta, Arapapa & CRASHARKI
+description=Enable enhanced native widescreen.
 patch=1,EE,005996C8,extended,00000010 //00000004
 patch=1,EE,005996D0,extended,00000009 //00000003
+//Zoom fix (Internal widescreen) by Arapapa & CRASHARKI
+//abaaaa3e 8988083e
+patch=1,EE,2056A0C8,extended,3faccccd //3eaaaaab
+patch=1,EE,D0610AF8,extended,00000000 //Check if it is Graphic Novel
+patch=1,EE,2056A0C8,extended,3eaaaaab
 
 [Remove Blackbars]
 author=PeterDelta
-description=Removes black bars in cutscenes
+description=Removes black bars in cutscenes.
 patch=1,EE,207419F8,extended,3F800000
 
 [50/60 FPS]

--- a/patches/SLES-52256_D13BEF2C.pnach
+++ b/patches/SLES-52256_D13BEF2C.pnach
@@ -3,7 +3,7 @@ gametitle=Max Payne 2 - The Fall of Max Payne (PAL-S) SLES-52256 D13BEF2C
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PeterDelta, Arapapa & CRASHARKI
-description=Enable enhanced native widescreen.
+description=Enable enhanced native widescreen. (Original widescreen uses vertical cropping; Enhanced expands the horizontal view.)
 patch=1,EE,005814C8,extended,00000010 //00000004
 patch=1,EE,005814D0,extended,00000009 //00000003
 //Zoom fix (Internal widescreen) by Arapapa & CRASHARKI

--- a/patches/SLES-52256_D13BEF2C.pnach
+++ b/patches/SLES-52256_D13BEF2C.pnach
@@ -2,14 +2,19 @@ gametitle=Max Payne 2 - The Fall of Max Payne (PAL-S) SLES-52256 D13BEF2C
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=PeterDelta
-description=Enable native widescreen
+author=PeterDelta, Arapapa & CRASHARKI
+description=Enable enhanced native widescreen.
 patch=1,EE,005814C8,extended,00000010 //00000004
 patch=1,EE,005814D0,extended,00000009 //00000003
+//Zoom fix (Internal widescreen) by Arapapa & CRASHARKI
+//abaaaa3e 8988083e
+patch=1,EE,20551EC8,extended,3faccccd //3eaaaaab
+patch=1,EE,D05F8978,extended,00000000 //Check if it is Graphic Novel
+patch=1,EE,20551EC8,extended,3eaaaaab
 
 [Remove Blackbars]
 author=PeterDelta
-description=Removes black bars in cutscenes
+description=Removes black bars in cutscenes.
 patch=1,EE,20729AE8,extended,3F800000
 
 [50/60 FPS]

--- a/patches/SLES-52336_D03BEF2A.pnach
+++ b/patches/SLES-52336_D03BEF2A.pnach
@@ -3,7 +3,7 @@ gametitle=Max Payne 2 - The Fall of Max Payne (PAL-G) SLES-52336 D03BEF2A
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PeterDelta, Arapapa & CRASHARKI
-description=Enable enhanced native widescreen.
+description=Enable enhanced native widescreen. (Original widescreen uses vertical cropping; Enhanced expands the horizontal view.)
 patch=1,EE,005814C8,extended,00000010 //00000004
 patch=1,EE,005814D0,extended,00000009 //00000003
 //Zoom fix (Internal widescreen) by Arapapa & CRASHARKI

--- a/patches/SLES-52336_D03BEF2A.pnach
+++ b/patches/SLES-52336_D03BEF2A.pnach
@@ -1,4 +1,4 @@
-gametitle=Max Payne 2 - The Fall of Max Payne (PAL-I) SLES-52338 D03BE12A
+gametitle=Max Payne 2 - The Fall of Max Payne (PAL-G) SLES-52336 D03BEF2A
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLES-52337_D03BEE2A.pnach
+++ b/patches/SLES-52337_D03BEE2A.pnach
@@ -2,14 +2,19 @@ gametitle=Max Payne 2 - The Fall of Max Payne (PAL-F) SLES-52337 D03BEE2A
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-author=PeterDelta
-description=Enable native widescreen
+author=PeterDelta, Arapapa & CRASHARKI
+description=Enable enhanced native widescreen.
 patch=1,EE,005814C8,extended,00000010 //00000004
 patch=1,EE,005814D0,extended,00000009 //00000003
+//Zoom fix (Internal widescreen) by Arapapa & CRASHARKI
+//abaaaa3e 8988083e
+patch=1,EE,20551EC8,extended,3faccccd //3eaaaaab
+patch=1,EE,D05F8978,extended,00000000 //Check if it is Graphic Novel
+patch=1,EE,20551EC8,extended,3eaaaaab
 
 [Remove Blackbars]
 author=PeterDelta
-description=Removes black bars in cutscenes
+description=Removes black bars in cutscenes.
 patch=1,EE,20729AE8,extended,3F800000
 
 [50/60 FPS]

--- a/patches/SLES-52337_D03BEE2A.pnach
+++ b/patches/SLES-52337_D03BEE2A.pnach
@@ -3,7 +3,7 @@ gametitle=Max Payne 2 - The Fall of Max Payne (PAL-F) SLES-52337 D03BEE2A
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PeterDelta, Arapapa & CRASHARKI
-description=Enable enhanced native widescreen.
+description=Enable enhanced native widescreen. (Original widescreen uses vertical cropping; Enhanced expands the horizontal view.)
 patch=1,EE,005814C8,extended,00000010 //00000004
 patch=1,EE,005814D0,extended,00000009 //00000003
 //Zoom fix (Internal widescreen) by Arapapa & CRASHARKI

--- a/patches/SLES-52338_D03BE12A.pnach
+++ b/patches/SLES-52338_D03BE12A.pnach
@@ -3,7 +3,7 @@ gametitle=Max Payne 2 - The Fall of Max Payne (PAL-I) SLES-52338 D03BE12A
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PeterDelta, Arapapa & CRASHARKI
-description=Enable enhanced native widescreen.
+description=Enable enhanced native widescreen. (Original widescreen uses vertical cropping; Enhanced expands the horizontal view.)
 patch=1,EE,005814C8,extended,00000010 //00000004
 patch=1,EE,005814D0,extended,00000009 //00000003
 //Zoom fix (Internal widescreen) by Arapapa & CRASHARKI

--- a/patches/SLUS-20814_CD68E44A.pnach
+++ b/patches/SLUS-20814_CD68E44A.pnach
@@ -1,6 +1,23 @@
-gametitle=Max Payne 2 - Fall of Max Payne (SLUS-20814)
+gametitle=Max Payne 2 - The Fall of Max Payne (NTSC-U) SLUS-20814 CD68E44A
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=PeterDelta, Arapapa & CRASHARKI
+description=Enable enhanced native widescreen.
+patch=1,EE,00599548,extended,00000010 //00000004
+patch=1,EE,00599550,extended,00000009 //00000003
+//Zoom fix (Internal widescreen) by Arapapa & CRASHARKI
+//abaaaa3e 8988083e
+patch=1,EE,20569F48,extended,3faccccd //3eaaaaab
+patch=1,EE,D0610978,extended,00000000 //Check if it is Graphic Novel
+patch=1,EE,20569F48,extended,3eaaaaab
+
+[Remove Blackbars]
+author=PeterDelta; ported by CRASHARKI	
+description=Removes black bars in cutscenes.
+patch=1,EE,20741878,extended,3F800000 //3F400000 (when black bars are present)
 
 [60 FPS]
 author=asasega
-description=Patches the game to run at 60 FPS (Might need 180% EE Overclock to be stable).
-patch=1,EE,005D8DF8,word,00000001
+description=Might need EE Overclock (300%).
+patch=1,EE,005D8DF8,word,00000001 //00000002

--- a/patches/SLUS-20814_CD68E44A.pnach
+++ b/patches/SLUS-20814_CD68E44A.pnach
@@ -13,7 +13,7 @@ patch=1,EE,D0610978,extended,00000000 //Check if it is Graphic Novel
 patch=1,EE,20569F48,extended,3eaaaaab
 
 [Remove Blackbars]
-author=PeterDelta; ported by CRASHARKI	
+author=PeterDelta; ported by CRASHARKI
 description=Removes black bars in cutscenes.
 patch=1,EE,20741878,extended,3F800000 //3F400000 (when black bars are present)
 

--- a/patches/SLUS-20814_CD68E44A.pnach
+++ b/patches/SLUS-20814_CD68E44A.pnach
@@ -3,7 +3,7 @@ gametitle=Max Payne 2 - The Fall of Max Payne (NTSC-U) SLUS-20814 CD68E44A
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=PeterDelta, Arapapa & CRASHARKI
-description=Enable enhanced native widescreen.
+description=Enable enhanced native widescreen. (Original widescreen uses vertical cropping; Enhanced expands the horizontal view.)
 patch=1,EE,00599548,extended,00000010 //00000004
 patch=1,EE,00599550,extended,00000009 //00000003
 //Zoom fix (Internal widescreen) by Arapapa & CRASHARKI


### PR DESCRIPTION
- Added the widescreen patch made by Arapapa that preserves the original FOV, but added a fix to prevent zoom out during the Graphic Novel parts.
- Added the patches to the missing versions.
- All versions were tested. The Spanish version was played from beginning to end.