### PR TITLE
Add and review patches for the Hitman Trilogy

### DIFF
--- a/patches/SLES-50992_5B9ACF79.pnach
+++ b/patches/SLES-50992_5B9ACF79.pnach
@@ -24,4 +24,4 @@ patch=1,EE,20508090,extended,00000001 //00000002
 [NTSC Mode]
 author=Gabominated
 description=NTSC mode at start. FMVs remain in PAL.
-patch=1,EE,003066B4,word,14A20057 //10A20057
+patch=0,EE,003066B4,word,14A20057 //10A20057

--- a/patches/SLES-50992_5B9ACF79.pnach
+++ b/patches/SLES-50992_5B9ACF79.pnach
@@ -1,9 +1,9 @@
-gametitle=Hitman 2 - Silent Assassin PAL-E SLES-50992 5B9ACF79
+gametitle=Hitman 2 - Silent Assassin (PAL-E 1.01 & 2.00) (SLES-50992)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-description=Widescreen hack
+description=Renders the game in 16:9 aspect ratio.
 patch=1,EE,00313f7c,word,3c013f10 // 3c013f40 ver fov
 patch=1,EE,002bbe18,word,3c1b3f40 // 00000000 zoom
 patch=1,EE,002bc00c,word,3c013f00 // 3c013f80

--- a/patches/SLES-51107_5B9ACF79.pnach
+++ b/patches/SLES-51107_5B9ACF79.pnach
@@ -1,9 +1,9 @@
-gametitle=Hitman 2 - Silent Assassin PAL-I SLES-51107 5B9ACF79
+gametitle=Hitman 2 - Silent Assassin (PAL-I 1.01 & 2.00) (SLES-51107)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-description=Widescreen hack
+description=Renders the game in 16:9 aspect ratio.
 patch=1,EE,00313f7c,word,3c013f10 // 3c013f40 ver fov
 patch=1,EE,002bbe18,word,3c1b3f40 // 00000000 zoom
 patch=1,EE,002bc00c,word,3c013f00 // 3c013f80

--- a/patches/SLES-51107_5B9ACF79.pnach
+++ b/patches/SLES-51107_5B9ACF79.pnach
@@ -24,4 +24,4 @@ patch=1,EE,20508090,extended,00000001 //00000002
 [NTSC Mode]
 author=Gabominated
 description=NTSC mode at start. FMVs remain in PAL.
-patch=1,EE,003066B4,word,14A20057 //10A20057
+patch=0,EE,003066B4,word,14A20057 //10A20057

--- a/patches/SLES-51108_5B9ACF79.pnach
+++ b/patches/SLES-51108_5B9ACF79.pnach
@@ -24,4 +24,4 @@ patch=1,EE,20508090,extended,00000001 //00000002
 [NTSC Mode]
 author=Gabominated
 description=NTSC mode at start. FMVs remain in PAL.
-patch=1,EE,003066B4,word,14A20057 //10A20057
+patch=0,EE,003066B4,word,14A20057 //10A20057

--- a/patches/SLES-51109_5B9ACF79.pnach
+++ b/patches/SLES-51109_5B9ACF79.pnach
@@ -1,9 +1,9 @@
-gametitle=Hitman 2 - Silent Assassin PAL-G SLES-51109 5B9ACF79
+gametitle=Hitman 2 - Silent Assassin (PAL-G 1.01 & 2.00) (SLES-51109)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-description=Widescreen hack
+description=Renders the game in 16:9 aspect ratio.
 patch=1,EE,00313f7c,word,3c013f10 // 3c013f40 ver fov
 patch=1,EE,002bbe18,word,3c1b3f40 // 00000000 zoom
 patch=1,EE,002bc00c,word,3c013f00 // 3c013f80

--- a/patches/SLES-51109_5B9ACF79.pnach
+++ b/patches/SLES-51109_5B9ACF79.pnach
@@ -24,4 +24,4 @@ patch=1,EE,20508090,extended,00000001 //00000002
 [NTSC Mode]
 author=Gabominated
 description=NTSC mode at start. FMVs remain in PAL.
-patch=1,EE,003066B4,word,14A20057 //10A20057
+patch=0,EE,003066B4,word,14A20057 //10A20057

--- a/patches/SLES-51110_5B9ACF79.pnach
+++ b/patches/SLES-51110_5B9ACF79.pnach
@@ -1,9 +1,9 @@
-gametitle=Hitman 2 - Silent Assassin PAL-S SLES-51110 5B9ACF79
+gametitle=Hitman 2 - Silent Assassin (PAL-S 1.01 & 2.00) (SLES-51110)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-description=Widescreen hack
+description=Renders the game in 16:9 aspect ratio.
 patch=1,EE,00313f7c,word,3c013f10 // 3c013f40 ver fov
 patch=1,EE,002bbe18,word,3c1b3f40 // 00000000 zoom
 patch=1,EE,002bc00c,word,3c013f00 // 3c013f80

--- a/patches/SLES-51110_5B9ACF79.pnach
+++ b/patches/SLES-51110_5B9ACF79.pnach
@@ -24,4 +24,4 @@ patch=1,EE,20508090,extended,00000001 //00000002
 [NTSC Mode]
 author=Gabominated
 description=NTSC mode at start. FMVs remain in PAL.
-patch=1,EE,003066B4,word,14A20057 //10A20057
+patch=0,EE,003066B4,word,14A20057 //10A20057

--- a/patches/SLES-52132_3569E863.pnach
+++ b/patches/SLES-52132_3569E863.pnach
@@ -1,4 +1,4 @@
-gametitle=Hitman - Contracts (F) (SLES-52133)
+gametitle=Hitman - Contracts (E) (SLES-52132)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLES-52134_BE198D9E.pnach
+++ b/patches/SLES-52134_BE198D9E.pnach
@@ -1,4 +1,4 @@
-gametitle=Hitman - Contracts (F) (SLES-52133)
+gametitle=Hitman - Contracts (I) (SLES-52134)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLES-52135_3569E863.pnach
+++ b/patches/SLES-52135_3569E863.pnach
@@ -1,4 +1,4 @@
-gametitle=Hitman - Contracts (F) (SLES-52133)
+gametitle=Hitman - Contracts (G) (SLES-52135)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLES-52136_1145D85E.pnach
+++ b/patches/SLES-52136_1145D85E.pnach
@@ -1,6 +1,0 @@
-gametitle=Hitman - Contracts (PAL-S) SLES-52136
-
-[50/60 FPS]
-author=Gabominated
-description=Unlocked at 50/60 FPS. Might need enable EE Overclock to be stable.
-patch=1,EE,2053a70c,extended,00000001 //00000002

--- a/patches/SLES-52136_3569E863.pnach
+++ b/patches/SLES-52136_3569E863.pnach
@@ -1,6 +1,30 @@
-gametitle=Hitman Contracts SLES-52136 3569E863
+gametitle=Hitman - Contracts (S) (SLES-52136)
 
-[50/60fps]
-author=Gabominated
-description=Unlocked at 50/60 FPS. Might need enable EE Overclock to be stable.
+[Widescreen 16:9]
+gsaspectratio=16:9
+author=ElHecht
+description=Renders the game in 16:9 aspect ratio.
+patch=1,EE,002659d8,word,3c013f10 // 3c013f40 ver fov
+patch=1,EE,001c8300,word,3c1b3f40 // 1060006e zoom
+patch=1,EE,001c8304,word,1060006d // ae220044
+patch=1,EE,001c8308,word,ae220044 // c6200038
+patch=1,EE,001c830c,word,c6200038 // 3c013f80
+patch=1,EE,001c8310,word,3c013f80 // 4481a000
+patch=1,EE,001c8314,word,4481a000 // 46140032
+patch=1,EE,001c8318,word,46140032 // 00000000
+patch=1,EE,001c84bc,word,3c013f00 // 3c013f80
+patch=1,EE,001c84c0,word,4481a800 // 4481a000
+patch=1,EE,001c84c4,word,4615ad00 // 3c013f00
+patch=1,EE,001c84c8,word,449bf000 // 4481a800
+patch=1,EE,001c8504,word,461e0002 // 46150002
+patch=1,EE,001c8508,word,46150002 // 4600a583
+patch=1,EE,001c850c,word,4600a583 // e6200054
+patch=1,EE,001c8510,word,e6200054 // 3c01bf00
+patch=1,EE,001c8514,word,4600a807 // 44810000
+
+[50/60 FPS]
+author=Gabominated & CRASHARKI
+description=Unlocked at 50/60 FPS. Might need EE Overclock to be stable.
 patch=1,EE,2053a70c,extended,00000001 //00000002
+patch=1,EE,E0010001,extended,0053A764 //condition in FMVs
+patch=1,EE,2053a70c,extended,00000002

--- a/patches/SLES-53028_13E1AD6A.pnach
+++ b/patches/SLES-53028_13E1AD6A.pnach
@@ -1,10 +1,10 @@
-gametitle=Hitman - Blood Money (SLES_53028)
+gametitle=Hitman - Blood Money (PAL-E) (SLES-53028)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-description=Widescreen hack
-
-patch=1,EE,00178b58,word,3c013f40 //00000000 hor FOV
+author=ElHecht
+description=Renders the game in 16:9 aspect ratio. (Incompatible with DTV480p)
+patch=1,EE,00178b58,word,3c013f40 //00000000 hor fov
 patch=1,EE,00178b5c,word,4481f000 //00000000
 patch=1,EE,00178b98,word,461e0003 //00000000
 patch=1,EE,00291610,word,461ea502 //00000000

--- a/patches/SLES-53029_72DC82B5.pnach
+++ b/patches/SLES-53029_72DC82B5.pnach
@@ -3,12 +3,16 @@ gametitle=Hitman - Blood Money (PAL-F) (SLES-53029)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-description=Widescreen Hack
-// 16:9
-patch=1,EE,00178c2c,word,3c013f40 // 00000000 hor fov
-patch=1,EE,00178c30,word,4481f000 // 00000000
-patch=1,EE,00178c6c,word,461e0003 // 00000000
-patch=1,EE,002916e0,word,461ea502 // 00000000
-patch=1,EE,002b28c4,word,461ea302 // 4600a306
+description=Renders the game in 16:9 aspect ratio. (Incompatible with DTV480p)
+patch=1,EE,00178c2c,word,3c013f40 //00000000 hor fov
+patch=1,EE,00178c30,word,4481f000 //00000000
+patch=1,EE,00178c6c,word,461e0003 //00000000
+patch=1,EE,002916e0,word,461ea502 //00000000
+patch=1,EE,002b28c4,word,461ea302 //4600a306
 
-
+[50/60 FPS]
+author=PeterDelta & Gabominated
+description=Might need EE Overclock at 180%.
+patch=1,EE,0061C020,word,00000001
+patch=1,EE,E0010000,extended,01FECCF4
+patch=1,EE,0061C020,extended,00000002

--- a/patches/SLES-53030_72DC82B5.pnach
+++ b/patches/SLES-53030_72DC82B5.pnach
@@ -3,12 +3,16 @@ gametitle=Hitman - Blood Money (PAL-G) (SLES-53030)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-description=Widescreen Hack
-// 16:9
-patch=1,EE,00178c2c,word,3c013f40 // 00000000 hor fov
-patch=1,EE,00178c30,word,4481f000 // 00000000
-patch=1,EE,00178c6c,word,461e0003 // 00000000
-patch=1,EE,002916e0,word,461ea502 // 00000000
-patch=1,EE,002b28c4,word,461ea302 // 4600a306
+description=Renders the game in 16:9 aspect ratio. (Incompatible with DTV480p)
+patch=1,EE,00178c2c,word,3c013f40 //00000000 hor fov
+patch=1,EE,00178c30,word,4481f000 //00000000
+patch=1,EE,00178c6c,word,461e0003 //00000000
+patch=1,EE,002916e0,word,461ea502 //00000000
+patch=1,EE,002b28c4,word,461ea302 //4600a306
 
-
+[50/60 FPS]
+author=PeterDelta & Gabominated
+description=Might need EE Overclock at 180%.
+patch=1,EE,0061C020,word,00000001
+patch=1,EE,E0010000,extended,01FECCF4
+patch=1,EE,0061C020,extended,00000002

--- a/patches/SLES-53031_72DC82B5.pnach
+++ b/patches/SLES-53031_72DC82B5.pnach
@@ -3,12 +3,16 @@ gametitle=Hitman - Blood Money (PAL-I) (SLES-53031)
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-description=Widescreen Hack
-// 16:9
-patch=1,EE,00178c2c,word,3c013f40 // 00000000 hor fov
-patch=1,EE,00178c30,word,4481f000 // 00000000
-patch=1,EE,00178c6c,word,461e0003 // 00000000
-patch=1,EE,002916e0,word,461ea502 // 00000000
-patch=1,EE,002b28c4,word,461ea302 // 4600a306
+description=Renders the game in 16:9 aspect ratio. (Incompatible with DTV480p)
+patch=1,EE,00178c2c,word,3c013f40 //00000000 hor fov
+patch=1,EE,00178c30,word,4481f000 //00000000
+patch=1,EE,00178c6c,word,461e0003 //00000000
+patch=1,EE,002916e0,word,461ea502 //00000000
+patch=1,EE,002b28c4,word,461ea302 //4600a306
 
-
+[50/60 FPS]
+author=PeterDelta & Gabominated
+description=Might need EE Overclock at 180%.
+patch=1,EE,0061C020,word,00000001
+patch=1,EE,E0010000,extended,01FECCF4
+patch=1,EE,0061C020,extended,00000002

--- a/patches/SLES-53032_72DC82B5.pnach
+++ b/patches/SLES-53032_72DC82B5.pnach
@@ -1,15 +1,14 @@
-gametitle=Hitman - Blood Money (PAL-S) (SLES-53032) 72DC82B5
+gametitle=Hitman - Blood Money (PAL-S) (SLES-53032)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-description=Renders the game in 16:9 aspect ratio
-// 16:9
-patch=1,EE,00178c2c,word,3c013f40 // 00000000 hor fov
-patch=1,EE,00178c30,word,4481f000 // 00000000
-patch=1,EE,00178c6c,word,461e0003 // 00000000
-patch=1,EE,002916e0,word,461ea502 // 00000000
-patch=1,EE,002b28c4,word,461ea302 // 4600a306
+description=Renders the game in 16:9 aspect ratio. (Incompatible with DTV480p)
+patch=1,EE,00178c2c,word,3c013f40 //00000000 hor fov
+patch=1,EE,00178c30,word,4481f000 //00000000
+patch=1,EE,00178c6c,word,461e0003 //00000000
+patch=1,EE,002916e0,word,461ea502 //00000000
+patch=1,EE,002b28c4,word,461ea302 //4600a306
 
 [50/60 FPS]
 author=PeterDelta & Gabominated
@@ -17,8 +16,3 @@ description=Might need EE Overclock at 180%.
 patch=1,EE,0061C020,word,00000001
 patch=1,EE,E0010000,extended,01FECCF4
 patch=1,EE,0061C020,extended,00000002
-
-[480p Mode]
-author=PeterDelta
-description=Any Hz selection will output in 480p.
-patch=1,EE,0049AF94,word,00000003

--- a/patches/SLUS-20374_0857FCAA.pnach
+++ b/patches/SLUS-20374_0857FCAA.pnach
@@ -1,4 +1,4 @@
-gametitle=Hitman 2 - Silent Assassin (PAL-F 1.01 & 2.00) (SLES-51108)
+gametitle=Hitman 2 - Silent Assassin (NTSC-U 1.01) (SLUS-20374)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -16,12 +16,7 @@ patch=1,EE,002bc05c,word,4600a583 // e6200054
 patch=1,EE,002bc060,word,e6200054 // 3c01bf00
 patch=1,EE,002bc064,word,4600a807 // 44810000
 
-[50/60 FPS]
+[60 FPS]
 author=Gabominated
 description=Might need EE Overclock.
 patch=1,EE,20508090,extended,00000001 //00000002
-
-[NTSC Mode]
-author=Gabominated
-description=NTSC mode at start. FMVs remain in PAL.
-patch=1,EE,003066B4,word,14A20057 //10A20057

--- a/patches/SLUS-20374_5B9ACF79.pnach
+++ b/patches/SLUS-20374_5B9ACF79.pnach
@@ -1,10 +1,9 @@
-gametitle=Hitman 2 - Silent Assassin (NTSC-U) (SLUS-20374) (v2.01)
+gametitle=Hitman 2 - Silent Assassin (NTSC-U 2.01) (SLUS-20374)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-
-// 16:9
+description=Renders the game in 16:9 aspect ratio.
 patch=1,EE,00313f7c,word,3c013f10 // 3c013f40 ver fov
 patch=1,EE,002bbe18,word,3c1b3f40 // 00000000 zoom
 patch=1,EE,002bc00c,word,3c013f00 // 3c013f80
@@ -17,4 +16,7 @@ patch=1,EE,002bc05c,word,4600a583 // e6200054
 patch=1,EE,002bc060,word,e6200054 // 3c01bf00
 patch=1,EE,002bc064,word,4600a807 // 44810000
 
-
+[60 FPS]
+author=Gabominated
+description=Might need EE Overclock.
+patch=1,EE,20508090,extended,00000001 //00000002

--- a/patches/SLUS-20882_3569E863.pnach
+++ b/patches/SLUS-20882_3569E863.pnach
@@ -1,10 +1,9 @@
-gametitle=Hitman - Contracts (SLUS_20882, SLES_52135)
+gametitle=Hitman - Contracts (SLUS-20882)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-
-// 16:9
+description=Renders the game in 16:9 aspect ratio.
 patch=1,EE,002659d8,word,3c013f10 // 3c013f40 ver fov
 patch=1,EE,001c8300,word,3c1b3f40 // 1060006e zoom
 patch=1,EE,001c8304,word,1060006d // ae220044
@@ -23,4 +22,9 @@ patch=1,EE,001c850c,word,4600a583 // e6200054
 patch=1,EE,001c8510,word,e6200054 // 3c01bf00
 patch=1,EE,001c8514,word,4600a807 // 44810000
 
-
+[60 FPS]
+author=Gabominated & CRASHARKI
+description=Unlocked at 60 FPS. Might need EE Overclock to be stable.
+patch=1,EE,2053a70c,extended,00000001 //00000002
+patch=1,EE,E0010001,extended,0053A764 //condition in FMVs
+patch=1,EE,2053a70c,extended,00000002

--- a/patches/SLUS-21108_13E1AD6A.pnach
+++ b/patches/SLUS-21108_13E1AD6A.pnach
@@ -1,13 +1,19 @@
-gametitle=Hitman - Blood Money (SLUS_21108)
+gametitle=Hitman - Blood Money (SLUS-21108)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
-description=Widescreen hack
-
-patch=1,EE,00178b58,word,3c013f40 //00000000 hor FOV
+author=ElHecht
+description=Renders the game in 16:9 aspect ratio. (Incompatible with DTV480p)
+patch=1,EE,00178b58,word,3c013f40 //00000000 hor fov
 patch=1,EE,00178b5c,word,4481f000 //00000000
 patch=1,EE,00178b98,word,461e0003 //00000000
 patch=1,EE,00291610,word,461ea502 //00000000
 patch=1,EE,002b27f4,word,461ea302 //4600a306
 
-
+[60 FPS]
+author=Gabominated
+description=Unlocked at 60 FPS. Might need EE Overclock to be stable.
+patch=1,EE,E0010002,extended,00617820 //condition fps
+patch=1,EE,20617820,extended,00000001 //00000002 fps
+patch=1,EE,E0010001,extended,00617890 //condition in FMVs
+patch=1,EE,20617820,extended,00000002


### PR DESCRIPTION
Hitman 2: Silent Assassin Changes:
- Added missing patches to the NTSC-U versions.
- General cleanup and tidying.

Hitman: Contracts Changes:
- Added missing patches to multiple versions.
- Removed an incorrect PAL-S CRC file.
- Fixed the 50/60 FPS patch to prevent FMV skipping.
- General cleanup and tidying.

Hitman: Blood Money Changes:
- Added missing patches to multiple versions.
- Improved the Widescreen patch description to clarify its incompatibility with DTV480p.
- Removed the 480p mode patch, as the game already boots into an unskippable menu where players must choose between 50 Hz (PAL only), 60 Hz, and DTV480p. Additionally, encouraging 480p usage via a patch is not a good idea, since that mode breaks Widescreen support.
- General cleanup and tidying.

All tested.