### PR TITLE
Replace C-codes with D-code equivalents

### DIFF
--- a/patches/SLES-53819_98BE10F8.pnach
+++ b/patches/SLES-53819_98BE10F8.pnach
@@ -6,7 +6,7 @@ description=Widescreen Hack
 patch=1,EE,00172570,extended,00000019 // 3C033F4C hor fov gameplay
 patch=1,EE,10172578,extended,0000999A // 3462CCCD hor fov gameplay
 patch=1,EE,001A8760,extended,000000D6 // 3C0243A0 renderfix
-patch=1,EE,C1EC2C88,extended,3C023F80
+patch=1,EE,D1DF6704,extended,01000002
 patch=1,EE,01EC2C88,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]

--- a/patches/SLES-82036_F3A5EC6F.pnach
+++ b/patches/SLES-82036_F3A5EC6F.pnach
@@ -6,7 +6,7 @@ description=Widescreen Hack
 patch=1,EE,001211D0,extended,00000019 // 3C033F4C hor fov gameplay
 patch=1,EE,101211D8,extended,0000999A // 3462CCCD hor fov gameplay
 patch=1,EE,00158880,extended,000000D6 // 3C0243A0 renderfix
-patch=1,EE,C1E16E68,extended,3C023F80
+patch=1,EE,D1D47A04,extended,01000002
 patch=1,EE,01E16E68,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]

--- a/patches/SLES-82037_F3A5EC6F.pnach
+++ b/patches/SLES-82037_F3A5EC6F.pnach
@@ -6,7 +6,7 @@ description=Widescreen Hack
 patch=1,EE,001211D0,extended,00000019 // 3C033F4C hor fov gameplay
 patch=1,EE,101211D8,extended,0000999A // 3462CCCD hor fov gameplay
 patch=1,EE,00158880,extended,000000D6 // 3C0243A0 renderfix
-patch=1,EE,C1E16E68,extended,3C023F80
+patch=1,EE,D1D47A04,extended,01000002
 patch=1,EE,01E16E68,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]

--- a/patches/SLPS-25338_26D1C561.pnach
+++ b/patches/SLPS-25338_26D1C561.pnach
@@ -6,7 +6,7 @@ description=Widescreen Hack
 patch=1,EE,00120F70,extended,00000019 // 3C033F4C hor fov gameplay
 patch=1,EE,10120F78,extended,0000999A // 3462CCCD hor fov gameplay
 patch=1,EE,00158370,extended,000000D6 // 3C0243A0 renderfix
-patch=1,EE,C1E15D18,extended,3C023F80
+patch=1,EE,D1D46A04,extended,01000002
 patch=1,EE,01E15D18,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]

--- a/patches/SLPS-25339_26D1C561.pnach
+++ b/patches/SLPS-25339_26D1C561.pnach
@@ -6,7 +6,7 @@ description=Widescreen Hack
 patch=1,EE,00120F70,extended,00000019 // 3C033F4C hor fov gameplay
 patch=1,EE,10120F78,extended,0000999A // 3462CCCD hor fov gameplay
 patch=1,EE,00158370,extended,000000D6 // 3C0243A0 renderfix
-patch=1,EE,C1E15D18,extended,3C023F80
+patch=1,EE,D1D46A04,extended,01000002
 patch=1,EE,01E15D18,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]

--- a/patches/SLPS-25408_5C4E1AC4.pnach
+++ b/patches/SLPS-25408_5C4E1AC4.pnach
@@ -6,7 +6,7 @@ description=Widescreen Hack
 patch=1,EE,00171790,extended,00000019 // 3C033F4C hor fov gameplay
 patch=1,EE,10171798,extended,0000999A // 3462CCCD hor fov gameplay
 patch=1,EE,001A78C0,extended,000000D6 // 3C0243A0 renderfix
-patch=1,EE,C1EC6DA8,extended,3C023F80
+patch=1,EE,D1DF5F04,extended,01000002
 patch=1,EE,01EC6DA8,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]

--- a/patches/SLPS-25461_3E26EEEB.pnach
+++ b/patches/SLPS-25461_3E26EEEB.pnach
@@ -6,7 +6,7 @@ description=Widescreen Hack
 patch=1,EE,001D84D0,extended,00000019 // 3C033F4C hor fov gameplay
 patch=1,EE,101D84D8,extended,0000999A // 3462CCCD hor fov gameplay
 patch=1,EE,00201E70,extended,000000D6 // 3C0243A0 renderfix
-patch=1,EE,C1D10978,extended,3C023F80
+patch=1,EE,D1C58884,extended,01000002
 patch=1,EE,01D10978,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]

--- a/patches/SLUS-20986_7E5F690C.pnach
+++ b/patches/SLUS-20986_7E5F690C.pnach
@@ -6,7 +6,7 @@ description=Widescreen Hack
 patch=1,EE,001211D0,extended,00000019 // 3C033F4C hor fov gameplay
 patch=1,EE,101211D8,extended,0000999A // 3462CCCD hor fov gameplay
 patch=1,EE,001587C0,extended,000000D6 // 3C0243A0 renderfix
-patch=1,EE,C1E16348,extended,3C023F80
+patch=1,EE,D1D47504,extended,01000002
 patch=1,EE,01E16348,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]

--- a/patches/SLUS-21079_7E5F690C.pnach
+++ b/patches/SLUS-21079_7E5F690C.pnach
@@ -6,7 +6,7 @@ description=Widescreen Hack
 patch=1,EE,001211D0,extended,00000019 // 3C033F4C hor fov gameplay
 patch=1,EE,101211D8,extended,0000999A // 3462CCCD hor fov gameplay
 patch=1,EE,001587C0,extended,000000D6 // 3C0243A0 renderfix
-patch=1,EE,C1E16348,extended,3C023F80
+patch=1,EE,D1D47504,extended,01000002
 patch=1,EE,01E16348,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]

--- a/patches/SLUS-21200_72486978.pnach
+++ b/patches/SLUS-21200_72486978.pnach
@@ -6,7 +6,7 @@ description=Widescreen Hack
 patch=1,EE,00172540,extended,00000019 // 3C033F4C hor fov gameplay
 patch=1,EE,10172548,extended,0000999A // 3462CCCD hor fov gameplay
 patch=1,EE,001A8670,extended,000000D6 // 3C0243A0 renderfix
-patch=1,EE,C1EC2218,extended,3C023F80
+patch=1,EE,D1DF5F04,extended,01000002
 patch=1,EE,01EC2218,extended,00000040 // 3C023F80 hor fov menu
 
 [No-Interlacing]


### PR DESCRIPTION
C-code does not work within pnach so far, so I replaced them with their equivalent of D-code.
- Fixed WS patch of following games:
  - Armored Core Nexus (NTSC-J, NTSC-U, PAL)
  - Armored Core Nine Breaker (NTSC-J, NTSC-U, PAL)
  - Armored Core Formula Front (NTSC-J)