### PR TITLE
Enthusia: Professional Racing - Remove Steering Deadzone

### DIFF
--- a/patches/SLES-53125_5C63B5AC.pnach
+++ b/patches/SLES-53125_5C63B5AC.pnach
@@ -19,3 +19,9 @@ patch=3,EE,20147838,extended,240903DF // li t1, 0xFF -> li t1, 0x3DF
 patch=3,EE,20147844,extended,00842026 // lw a0, 0x2DC(s1) -> xor a0, a0, a0
 patch=3,EE,20147E94,extended,46010043 // nop -> div.s f01, f00, f01
 patch=3,EE,20147E98,extended,46010840 // div.s f01, f00, f01 -> add.s f01, f01, f01
+
+
+[Remove Steering Deadzone]
+author=Azullia / real-xp
+description=Removes the deadzone from steering using the left analog stick.
+patch=3,EE,201477B4,extended,00842026 // lw a0, 0x2D8(s1) -> xor a0, a0, a0

--- a/patches/SLPM-65948_5637E95B.pnach
+++ b/patches/SLPM-65948_5637E95B.pnach
@@ -29,3 +29,9 @@ patch=3,EE,20146208,extended,240903DF // li t1, 0xFF -> li t1, 0x3DF
 patch=3,EE,20146214,extended,00842026 // lw a0, 0x2DC(s1) -> xor a0, a0, a0
 patch=3,EE,20146864,extended,46010043 // nop -> div.s f01, f00, f01
 patch=3,EE,20146868,extended,46010840 // div.s f01, f00, f01 -> add.s f01, f01, f01
+
+
+[Remove Steering Deadzone]
+author=Azullia / real-xp
+description=Removes the deadzone from steering using the left analog stick.
+patch=3,EE,20146184,extended,00842026 // lw a0, 0x2D8(s1) -> xor a0, a0, a0

--- a/patches/SLUS-20967_81D233DC.pnach
+++ b/patches/SLUS-20967_81D233DC.pnach
@@ -26,3 +26,9 @@ patch=3,EE,201461E0,extended,240903DF // addiu t1, zero, 0xFF -> addiu t1, zero,
 patch=3,EE,201461EC,extended,00842026 // lw a0, 0x2DC(s1) -> xor a0, a0, a0
 patch=3,EE,201467C8,extended,46160003 // nop -> div.s f00, f00, f22
 patch=3,EE,201467CC,extended,46000000 // div.s f00, f00, f22 -> add.s f00, f00, f00
+
+
+[Remove Steering Deadzone]
+author=Azullia / real-xp
+description=Removes the deadzone from steering using the left analog stick.
+patch=3,EE,2014615C,extended,00842026 // lw a0, 0x2D8(s1) -> xor a0, a0, a0


### PR DESCRIPTION
Tested on all three versions of the game, no issues found (modifies one variable in the same subroutine as #725). Co-authored with @real-xp.

Removes a ~30% deadzone from left analog stick steering.