### PR TITLE
Add missing Leisure Suit Larry versions + cleanup

### DIFF
--- a/patches/SLES-52641_A1FD63D6.pnach
+++ b/patches/SLES-52641_A1FD63D6.pnach
@@ -1,8 +1,9 @@
-gametitle=Leisure Suit Larry - Magna Cum Laude - Uncut (PAL-E) (SLES-52641)
+gametitle=Leisure Suit Larry - Magna Cum Laude - Uncut (PAL-E) (SLES-52641) A1FD63D6
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
+description=Renders the game in 16:9 aspect ratio.
 
 // 16:9
 patch=1,EE,002e5fd0,word,080fb7cc // 46020082 jump to code-inject 003edf30
@@ -14,5 +15,3 @@ patch=1,EE,003edf38,word,46020082 // 00000000
 patch=1,EE,003edf3c,word,46020842 // 00000000
 patch=1,EE,003edf40,word,461e0843 // 00000000
 patch=1,EE,003edf44,word,080b97f5 // 00000000 jump back to function 002e5fd4
-
-

--- a/patches/SLES-52642_A1FD63D6.pnach
+++ b/patches/SLES-52642_A1FD63D6.pnach
@@ -1,12 +1,14 @@
-gametitle=Leisure Suit Larry - Magna Cum Laude (PAL-F) (SLES-52642) A1FD63D6
+gametitle=Leisure Suit Larry - Magna Cum Laude - Uncut (PAL-F) (SLES-52642) A1FD63D6
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
-description=Conversion by Bigdemon
+description=Renders the game in 16:9 aspect ratio.
 
+// 16:9
 patch=1,EE,002e5fd0,word,080fb7cc // 46020082 jump to code-inject 003edf30
 patch=1,EE,002e5fd4,word,00000000 // 46020842
+
 patch=1,EE,003edf30,word,3c013f40 // 00000000 hor fov
 patch=1,EE,003edf34,word,4481f000 // 00000000
 patch=1,EE,003edf38,word,46020082 // 00000000

--- a/patches/SLES-52643_A1FD63D6.pnach
+++ b/patches/SLES-52643_A1FD63D6.pnach
@@ -1,4 +1,4 @@
-gametitle=Leisure Suit Larry - Magna Cum Laude - Uncut (PAL-S) (SLES-52644) A1FD63D6
+gametitle=Leisure Suit Larry - Magna Cum Laude - Uncut (PAL-G) (SLES-52643) A1FD63D6
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLES-52645_A1FD63D6.pnach
+++ b/patches/SLES-52645_A1FD63D6.pnach
@@ -1,4 +1,4 @@
-gametitle=Leisure Suit Larry - Magna Cum Laude - Uncut (PAL-S) (SLES-52644) A1FD63D6
+gametitle=Leisure Suit Larry - Magna Cum Laude - Uncut (PAL-I) (SLES-52645) A1FD63D6
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLUS-20956_A1736B07.pnach
+++ b/patches/SLUS-20956_A1736B07.pnach
@@ -1,8 +1,9 @@
-gametitle=Leisure Suit Larry - Magna Cum Laude (NTSC-U) (SLUS-20956)
+gametitle=Leisure Suit Larry - Magna Cum Laude (NTSC-U) (SLUS-20956) A1736B07
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 author=ElHecht
+description=Renders the game in 16:9 aspect ratio.
 
 // 16:9
 patch=1,EE,002e4850,word,080fb09a // 46020082 jump to code-inject 003ec268
@@ -14,5 +15,3 @@ patch=1,EE,003ec270,word,46020082 // 00000000
 patch=1,EE,003ec274,word,46020842 // 00000000
 patch=1,EE,003ec278,word,461e0843 // 00000000
 patch=1,EE,003ec27c,word,080b9215 // 00000000 jump back to 002e4854
-
-


### PR DESCRIPTION
Added the missing German and Italian versions and performed some cleanup across all versions. Although the missing versions shared the same CRC as the other European releases, they were still tested.