### PR TITLE
no interlacing & no blur patches for Shin Megami Tensei: Digital Devil Saga 2

### DIFF
--- a/patches/SLUS-21152_D382C164.pnach
+++ b/patches/SLUS-21152_D382C164.pnach
@@ -1,6 +1,18 @@
+gametitle=Shin Megami Tensei - Digital Devil Saga 2 (U)(SLUS-21152)
+
 [Widescreen 16:9]
 gsaspectratio=16:9
 description=Shin Megami Tensei - Digital Devil Saga 2 NTSC-U-Widescreen Hack (16:9)
 patch=1,EE,2037F5E4,extended,3FC00000
 
+[No Interlacing]
+patch=1,EE,0032A408,word,00000000
+patch=1,EE,0032DF10,word,00000000
 
+[No Motion Blur]
+Author=Sergx12
+patch=1,EE,203899ac,word,00000000
+
+[No Radial Blur]
+Author=Sergx12
+patch=1,EE,203899b0,word,00000000

--- a/patches/SLUS-21152_D382C164.pnach
+++ b/patches/SLUS-21152_D382C164.pnach
@@ -1,18 +1,20 @@
-gametitle=Shin Megami Tensei - Digital Devil Saga 2 (U)(SLUS-21152)
+gametitle=Digital Devil Saga 2 (U)(SLUS-21152)
 
 [Widescreen 16:9]
 gsaspectratio=16:9
 description=Shin Megami Tensei - Digital Devil Saga 2 NTSC-U-Widescreen Hack (16:9)
 patch=1,EE,2037F5E4,extended,3FC00000
 
-[No Interlacing]
-patch=1,EE,0032A408,word,00000000
-patch=1,EE,0032DF10,word,00000000
-
 [No Motion Blur]
-Author=Sergx12
+author=Sergx12
 patch=1,EE,203899ac,word,00000000
 
 [No Radial Blur]
-Author=Sergx12
+author=Sergx12
 patch=1,EE,203899b0,word,00000000
+
+[No Interlacing]
+gsinterlacemode=1
+author=Altimor
+patch=1,EE,0032A408,word,00000000
+patch=1,EE,0032DF10,word,00000000


### PR DESCRIPTION
This PR adds no interlacing and optional blur removal patches for Digital Devil Saga 2, mirroring the existing DDS1 patches.

These patches work perfectly; I completed all content (all zones, rings, bosses, shooter mini-game...) of the game with no issues.

Here are some comparisons from the final dungeon:

INTERLACED
<img width="1920" height="1080" alt="Sun default" src="https://github.com/user-attachments/assets/819c8406-576e-41d7-84d5-59157d02de17" />


PROGRESSIVE
<img width="1920" height="1080" alt="Sun no interlacing" src="https://github.com/user-attachments/assets/e3364d70-21e8-4c58-9505-f1ef59e0c87b" />


PROGRESSIVE+NO MOTION BLUR & NO RADIAL BLUR
<img width="1920" height="1080" alt="Sun no interlacing no blur" src="https://github.com/user-attachments/assets/d5421a2f-7fdb-4072-a137-0647eb79ec97" />
