### PR TITLE
Update SCUS-97481_2F123FD8.pnach

### DIFF
--- a/patches/SCUS-97481_2F123FD8.pnach
+++ b/patches/SCUS-97481_2F123FD8.pnach
@@ -1,4 +1,4 @@
-gametitle=God of War 2 (SCUS-97481)
+gametitle=God of War 2 SCUS-97481_2F123FD8
 
 [Widescreen 16:9]
 gsaspectratio=16:9
@@ -10,3 +10,13 @@ patch=1,EE,00234A48,word,46000406
 author=Ezedequias
 comment=With Any Action Button
 patch=1,EE,202D8194,byte,01
+
+
+[High-Res Mode]
+author=memory_fallen
+description=Enables hidden 640x448 mode at startup.
+patch=0,EE,0025A258,word,00000000
+patch=0,EE,0025A260,word,00000000
+patch=0,EE,0025A268,word,00000000
+patch=0,EE,0025A270,word,00000000
+patch=0,EE,0025A278,word,00000000


### PR DESCRIPTION
Adds a patch to force-enable 'High-Res Mode' for _God of War II_ at startup, bypassing the need to input a hidden code.

<img width="1293" height="1025" alt="image" src="https://github.com/user-attachments/assets/e27b6e5e-0483-4d71-bff6-74df291fb948" />
<img width="1294" height="1025" alt="image" src="https://github.com/user-attachments/assets/fb5d4491-ae3d-450b-8961-534187b3c3c1" />