### PR TITLE
Update SCUS-97128_4167D813.pnach

### DIFF
--- a/patches/SCUS-97128_4167D813.pnach
+++ b/patches/SCUS-97128_4167D813.pnach
@@ -175,3 +175,9 @@ description=Might need EE overclocking to be stable (130%).
 patch=1,EE,001D78F0,extended,28420002
 patch=1,EE,E0010001,extended,004DC8A0
 patch=1,EE,001D78F0,extended,28420004
+
+[HUD White Line Fix]
+author=mrnecromancer247
+description=Removes white pixel lines around the health, arrows and mana HUD elements when using upscaled rendering.
+patch=1,EE,001C2214,word,3C013F7F
+patch=1,EE,001C222C,word,3C013E10

--- a/patches/SCUS-97128_4167D813.pnach
+++ b/patches/SCUS-97128_4167D813.pnach
@@ -177,7 +177,7 @@ patch=1,EE,E0010001,extended,004DC8A0
 patch=1,EE,001D78F0,extended,28420004
 
 [HUD White Line Fix]
-author=mrnecromancer247
+author=pgert, ported by mrnecromancer247
 description=Removes white pixel lines around the health, arrows and mana HUD elements when using upscaled rendering.
 patch=1,EE,001C2214,word,3C013F7F
 patch=1,EE,001C222C,word,3C013E10


### PR DESCRIPTION
Adds a fix for white pixel lines that appear around the health, arrows and mana HUD elements when the internal rendering resolution is increased above native.

Tested:
- Vulkan
- D3D12
- Native, 2x, 4x and 6x internal resolution

Result:
- White HUD artifacts are removed.
- No visible issues observed during gameplay

Before
<img width="1718" height="966" alt="image" src="https://github.com/user-attachments/assets/d3c230ab-66fa-4396-bd85-632498dab0db" />

After
<img width="1718" height="966" alt="image" src="https://github.com/user-attachments/assets/edcc768b-21d4-49f1-ad38-5426238c171c" />
