### PR TITLE
ci: update workflows to hopefully get rid of intermittent failures

### DIFF
--- a/.github/workflows/pack_patches.yml
+++ b/.github/workflows/pack_patches.yml
@@ -1,6 +1,6 @@
 name: Pack patches
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   pack:
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Create archives
         run: |
@@ -20,24 +20,3 @@ jobs:
           name: cheats
           path: ./patches.zip
           if-no-files-found: error
-
-  release:
-    needs: [pack]
-    name: Publish release
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Download artifacts
-        uses: actions/download-artifact@v8
-      - name: Create a new release
-        env:
-            GH_TOKEN: ${{ github.token }}
-        run: |
-          git push origin --delete latest || true
-          gh release delete latest --yes || true
-          git tag latest
-          git push origin tag latest
-          gh release create latest --latest --title "Latest Build"
-          gh release upload latest ./patches.zip

--- a/.github/workflows/update_release.yml
+++ b/.github/workflows/update_release.yml
@@ -1,0 +1,62 @@
+name: Release Patches
+
+on:
+  push:
+    branches:
+      - main
+
+# This ensures that only one workflow at a time is going to be attempting to
+# mutate the tag / etc
+#
+# It will also cancel in progress runs (so if two PRs quickly merge, only
+# the most recent will run)
+concurrency:
+  group: release-updating
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Publish release
+    if: github.repository == 'PCSX2/pcsx2_patches'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Create archives
+        run: |
+          7z a -r patches.zip ./patches/*
+
+      - name: Update tag
+        env:
+            GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Pushing latest changes"
+          git push origin --delete latest || true
+          echo "Removing existing tag"
+          gh release delete latest --yes || true
+          echo "Creating tag"
+          git tag latest
+          echo "Pushing tag"
+          git push origin tag latest
+          
+      - name: Create a new release
+        env:
+            GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Creating release"
+          for i in {1..10}; do
+              if gh release create latest \
+                  --latest \
+                  --title "Latest Build"; then
+                  break
+              fi
+
+              echo "Retrying release creation..."
+              sleep 3
+          done
+          echo "Uploading asset"
+          gh release upload latest ./patches.zip

--- a/.github/workflows/validate_patches.yml
+++ b/.github/workflows/validate_patches.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate all patches
         run: |


### PR DESCRIPTION
Does a few things:
- Moves the release step out of the workflow that runs on PRs and instead into a workflow that only runs on pushes to `main`
- Adds some retries on the release creation step incase github's API is still eventually consistent.  Should hopefully resolve errors like this https://github.com/PCSX2/pcsx2_patches/actions/runs/28344568683/job/84135110444
  - Broke up the commands with logs in between so it's easier to tell which command specifically failed in the future.
- However another reason why the above could have failed in the past is because there's a race condition where simultaneous builds are all fighting over the same tag, that is solved via the new `concurrency` addition where only a single build can be active at a time, and it will always be the most recent.

Should work but of course it's a CI change so, kinda have to merge to see 