### PR TITLE
Ape Escape 3 (SCUS-97501): Disable Monkey LOD Models Patch

### DIFF
--- a/patches/SCUS-97501_7571AAEE.pnach
+++ b/patches/SCUS-97501_7571AAEE.pnach
@@ -13,3 +13,8 @@ gsaspectratio=16:9
 author=CRASHARKI
 description=Run the game at 16:9 Widescreen Aspect Ratio from the start.
 patch=1,EE,20649DC8,byte,1 //0 Widescreen
+
+[Disable Monkey LOD Models]
+description=Disables the lower level-of-detail models for the monkeys.
+author=mthsk
+patch=1,EE,0030EFD8,word,00000000


### PR DESCRIPTION
A simple patch that disables the LOD models for the monkeys in the game. Originally a debug feature, performance hit should be pretty minimal. I figure that some people may want this since it makes the game look nicer at higher resolutions.

**Before:**
<img width="506" height="542" alt="image" src="https://github.com/user-attachments/assets/1d7c2106-92f1-4f5f-af0a-8853bb3f49ed" />

**After:**
<img width="555" height="630" alt="image" src="https://github.com/user-attachments/assets/41a81b73-ec2b-443c-970c-ac9690a65eba" />
