### PR TITLE
Add Fatal Frame viewfinder stick swap patches

### DIFF
--- a/patches/SLES-50821_22E91837.pnach
+++ b/patches/SLES-50821_22E91837.pnach
@@ -140,3 +140,11 @@ patch=1,EE,0035905C,word,00000000
 // It also wracks up the mirror rendering in the Cutscenes:
 //  https://github.com/PCSX2/pcsx2_patches/pull/588
 // ==========
+
+[Viewfinder Stick Swap]
+author=DAOWAce
+description=Swaps the analog stick functions while using the Camera Obscura viewfinder.
+
+patch=1,EE,2018CE4C,extended,90620193
+patch=1,EE,2018CE60,extended,90620194
+patch=1,EE,2020DD98,extended,24040000

--- a/patches/SLPS-25074_9883194E.pnach
+++ b/patches/SLPS-25074_9883194E.pnach
@@ -49,3 +49,11 @@ gsinterlacemode=1
 author=asasega & synce
 description=Progressive Scan Hack
 patch=1,EE,2022E3CC,extended,00000000
+
+[Viewfinder Stick Swap]
+author=DAOWAce
+description=Swaps the analog stick functions while using the Camera Obscura viewfinder.
+
+patch=1,EE,20189A14,extended,90620193
+patch=1,EE,20189A28,extended,90620194
+patch=1,EE,20208020,extended,24040000

--- a/patches/SLUS-20388_339A0B8C.pnach
+++ b/patches/SLUS-20388_339A0B8C.pnach
@@ -37,3 +37,11 @@ patch=1,EE,2034AC0C,word,00000000
 gsinterlacemode=1
 description=Attempts to disable interlaced offset rendering.
 patch=1,EE,2023188C,word,00000000
+
+[Viewfinder Stick Swap]
+author=DAOWAce
+description=Swaps the analog stick functions while using the Camera Obscura viewfinder.
+
+patch=1,EE,2018B144,extended,90620193
+patch=1,EE,2018B158,extended,90620194
+patch=1,EE,2020B1A8,extended,24040000


### PR DESCRIPTION
First time contributor, sorry if I'm doing anything wrong (let me know).

This adds a viewfinder stick swap patch for the NTSC-U, PAL, and NTSC-J releases. (made for NA, ported to others)

[Long requested feature](https://forums.pcsx2.net/Thread-Fatal-Frame-Tecmo-s-troublesome-analog-stick-layout) that only ever got [addressed for the JP release](https://forums.pcsx2.net/Thread-Update-1-03-PS4-controller-and-Fatal-Frame-1-Project-Zero-analog-stick-solution) in an older version of PCSX2.

I didn't play through the entire game yet, but tested it working (including trying to break it) on every control scheme. Also had one person test the PAL version and [confirm it working](https://www.reddit.com/r/fatalframe/comments/xneful/comment/p2jxbqy/)