### PR TITLE
FMV skip patches for Sonic Unleashed

### DIFF
--- a/patches/SLES-55380_8C913264.pnach
+++ b/patches/SLES-55380_8C913264.pnach
@@ -22,3 +22,8 @@ description=SDTV 480p mode at start.
 patch=1,EE,00671CFC,word,3C050000
 patch=1,EE,00671D04,word,3C060050
 patch=1,EE,00671D0C,word,3C070001
+
+[Skip FMVs]
+author=xan1242
+comment=Allows you to always skip FMVs by pressing Start.
+patch=1,EE,2040E7B4,extended,00000000

--- a/patches/SLES-55380_8C913264.pnach
+++ b/patches/SLES-55380_8C913264.pnach
@@ -25,5 +25,5 @@ patch=1,EE,00671D0C,word,3C070001
 
 [Skip FMVs]
 author=xan1242
-comment=Allows you to always skip FMVs by pressing Start.
+description=Allows you to always skip FMVs by pressing Start.
 patch=1,EE,2040E7B4,extended,00000000

--- a/patches/SLUS-21846_FB236A46.pnach
+++ b/patches/SLUS-21846_FB236A46.pnach
@@ -32,4 +32,7 @@ patch=0,EE,100d91a0,extended,00000000
 //patch=1,EE,20ED1A68,word,43E00000
 //patch=1,EE,20ED1A58,word,00000000
 
-
+[Skip FMVs]
+author=xan1242
+comment=Allows you to always skip FMVs by pressing Start.
+patch=1,EE,2040E767,extended,00000000

--- a/patches/SLUS-21846_FB236A46.pnach
+++ b/patches/SLUS-21846_FB236A46.pnach
@@ -34,5 +34,5 @@ patch=0,EE,100d91a0,extended,00000000
 
 [Skip FMVs]
 author=xan1242
-comment=Allows you to always skip FMVs by pressing Start.
+description=Allows you to always skip FMVs by pressing Start.
 patch=1,EE,2040E767,extended,00000000


### PR DESCRIPTION
These patches allow for skipping fmvs in Sonic Unleashed anytime, the original PAL version of the patch was made by xan1242 and i ported it to the NTSC ver.

https://github.com/user-attachments/assets/8a8434c3-db83-4149-8b94-57551db89da5

Normally you can't skip cutscenes in this game unless it considers them as already watched on that save or during the same session, speedrunners would use completed saves to watch all the movies in the gallery to then make a new save that's capable of skipping cutscenes during the same session, these patches skip that process so you can just skip them anytime